### PR TITLE
Update spec_helper to use engine_cart properly

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "marmottawrapper", '>=0.0.5'
   s.add_development_dependency "jettywrapper"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+
+require 'engine_cart'
+EngineCart.load_application!
 
 require 'rspec/rails'
 require 'rspec/autorun'
@@ -11,9 +13,6 @@ Rails.backtrace_cleaner.remove_silencers!
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
-
-require 'engine_cart'
-EngineCart.load_application!
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
The old dummy application was still hanging around is spec_helper. Also, this pins a `factory_girl` to 4.4.0. The recent 4.5.0 update to breaks the linter for ActiveTriples by assuming there is a database involved in the models. I'll submit an issue to the `factory_girl` folks.
