### PR TITLE
Feature/harvester

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,17 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
-
 
 # use engine_cart instead of generic dummy app
 gem 'engine_cart'
 
-file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
-if File.exists?(file)
+gem 'rubocop', require: false
+
+file = File.expand_path('Gemfile',
+                        ENV['ENGINE_CART_DESTINATION'] ||
+                        ENV['RAILS_ROOT'] ||
+                        File.expand_path('../spec/internal', __FILE__))
+if File.exist?(file)
   puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
   instance_eval File.read(file)
 end

--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -1,0 +1,40 @@
+module Krikri
+  ##
+  # Activity wraps code execution with metadata about when it ran, which
+  # agents were responsible.
+  #
+  # The following example will run the block given, and return an
+  # Activity instance with the start and end times for the execution,
+  # and knowledge that `my_software_agent` was the responsible agent.
+  #
+  #     activity = Activity.new(my_software_agent) do
+  #       # code to run
+  #     end
+  #
+  # TODO: Support persistence
+  # TODO: should Activities be aware of which records (OriginalRecord,
+  #       DPLA::MAP::Aggregations) they operate on?
+  class Activity
+    attr_reader :start_time, :end_time, :agent
+
+    def initialize(agent)
+      @agent = agent
+      if block_given?
+        set_start_time
+        yield
+        set_end_time
+      end
+    end
+
+    def set_start_time
+      @start_time = DateTime.now.utc
+    end
+
+    def set_end_time
+      now = DateTime.now
+      fail 'Start time must exist and be before now to set an end time' unless
+        start_time && (start_time <= now)
+      @end_time = now.utc
+    end
+  end
+end

--- a/app/models/krikri/harvester.rb
+++ b/app/models/krikri/harvester.rb
@@ -1,0 +1,78 @@
+module Krikri
+  ##
+  # Harvester is the abstract interface for aggregating records from a
+  # source. Harvesters need to be able to:
+  #
+  #   - Enumerate record ids (#record_ids)
+  #   - Enumerate records (#records)
+  #   - Retrieve individual records (#get_record)
+  #
+  # Implementations of Enumerators in subclasses should be lazy,
+  # avoiding loading large numbers of records into memory or sending
+  # unnecessary requests to providers. The following example should be
+  # safe:
+  #
+  #    my_harvester.record_ids.take(100)
+  #
+  # This parent class implements a few generic methods based on the
+  # services outlined above:
+  #
+  #    - #count. This assumes that lazy counting is implemented on the
+  #      Enumerable returned by #record_ids. If not, it is strongly
+  #      recommended to override this method in your subclass with
+  #      an efficient implementation.
+  #    - #run. Wraps persistence of each record returned by #records
+  #      in an Activity to run a full harvest.
+  class Harvester
+    extend SoftwareAgent
+
+    ##
+    # This is an interface intended to be overridden in subclasses. It
+    # should provide a low-memory, lazy enumerable for record ids. The
+    # following usage should be safe:
+    #
+    #     record_ids.each do |id|
+    #        some_operation(id)
+    #     end
+    #
+    # @return [Enumerable<String>] The identifiers included in the harvest.
+    def record_ids
+      raise NotImplementedError
+    end
+
+    ##
+    # @return [Integer] A count of the records expected in the harvest.
+    # @note override if #record_ids does not implement a lazy
+    #   Enumerable#count.
+    def count
+      record_ids.count
+    end
+
+    ##
+    # This is an interface intended to be overridden in subclasses.
+    # @return [Enumerable<Krikri::OriginalRecord>] The harvested records.
+    def records
+      raise NotImplementedError
+    end
+
+    ##
+    # This is an interface intended to be overridden in subclasses.
+    # @param identifier [#to_s] the identifier for the record to be
+    #   retrieved
+    # @return [Krikri::OriginalRecord]
+    def get_record(identifier)
+      raise NotImplementedError
+    end
+
+    ##
+    # Creates a harvest activity and runs harvest.
+    # This should be idempotent so it can be safely retried on errors.
+    #
+    # @return [Boolean]
+    def run
+      Krikri::Activity.new(self) do
+        records.each(&:save)
+      end
+    end
+  end
+end

--- a/app/models/krikri/harvesters/oai_harvester.rb
+++ b/app/models/krikri/harvesters/oai_harvester.rb
@@ -1,0 +1,51 @@
+module Krikri::Harvesters
+  ##
+  # A harvester implementation for OAI-PMH
+  class OAIHarvester < Krikri::Harvester
+    attr_accessor :client
+
+    def initialize(opts = {})
+      endpoint = opts.delete(:endpoint)
+      @client = OAI::Client.new(endpoint)
+    end
+
+    ##
+    # Sends ListIdentifier requests lazily.
+    #
+    # The following will only send requests to the endpoint until it
+    # has 1000 record ids:
+    #
+    #     record_ids.take(1000)
+    #
+    def record_ids
+      client.list_identifiers.full.lazy.flat_map(&:identifier)
+    end
+
+    # Count on record_ids will request all ids and load them into memory
+    # TODO: an efficient implementation of count for OAI
+    def count
+      raise NotImplementedError
+    end
+
+    ##
+    # Sends ListRecords requests lazily.
+    #
+    # The following will only send requests to the endpoint until it
+    # has 1000 records:
+    #
+    #     records.take(1000)
+    #
+    def records
+      client.list_records.full.lazy.flat_map do |rec|
+        Krikri::OriginalRecord.new(rec.metadata.to_s)
+      end
+    end
+
+    # TODO: normalize records; there will be differences in XML
+    # for different requests
+    def get_record(identifier)
+      Krikri::OriginalRecord
+        .new(client.get_record(:identifier => identifier).doc.to_s)
+    end
+  end
+end

--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -1,0 +1,22 @@
+module Krikri
+  ##
+  # Handles records as harvested, prior to mapping
+  class OriginalRecord
+    def initialize(str_or_file)
+      raise(ArgumentError,
+            '`str_or_file` must be a readable IO object or String.'\
+            "Got a #{str_or_file.class}") unless
+        str_or_file.is_a?(String) || str_or_file.respond_to?(:read)
+      @content = str_or_file
+    end
+
+    def to_s
+      @content
+    end
+
+    def save
+      # TODO: implement persistence/retrieval
+      true
+    end
+  end
+end

--- a/app/models/krikri/software_agent.rb
+++ b/app/models/krikri/software_agent.rb
@@ -1,0 +1,12 @@
+module Krikri
+  ##
+  # SoftwareAgent is a mixin for logic common to code that generates a
+  # Krikri::Activity.
+  #
+  # TODO: Figure out what, if anything, agents need to know about
+  #   themselves. They will likely have names or versions or some such.
+  #   If not, remove this module.
+  module SoftwareAgent
+    extend ActiveSupport::Concern
+  end
+end

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -22,10 +22,13 @@ Gem::Specification.new do |s|
   s.add_dependency "blacklight", ">= 5.3.0"
   s.add_dependency "therubyracer"
 
+  s.add_dependency "oai"
+
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "marmottawrapper", '>=0.0.5'
   s.add_development_dependency "jettywrapper"
   s.add_development_dependency "rspec-rails"
+  s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'
 end

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'oai/client'
+
 module Krikri
   class Engine < ::Rails::Engine
     isolate_namespace Krikri

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Krikri::Activity do
+
+  subject { described_class.new(agent_class.new) }
+  let(:agent_class) { Class.new { extend Krikri::SoftwareAgent } }
+
+  describe '#agent' do
+    it 'has an agent' do
+      expect(subject.agent).to be_a agent_class
+    end
+  end
+
+  describe '#start_time' do
+    before do
+      subject.set_start_time
+    end
+
+    it 'marks start time' do
+      expect(subject.start_time).to be_a DateTime
+    end
+  end
+
+  describe 'end_time' do
+    it 'raises an error if not started' do
+      expect { subject.set_end_time }.to raise_error
+    end
+
+    context 'with start time' do
+      before do
+        subject.set_start_time
+        subject.set_end_time
+      end
+
+      it 'marks end time' do
+        subject.set_start_time
+        expect(subject.end_time).to be_a DateTime
+      end
+    end
+  end
+
+  describe 'running activities' do
+    subject do
+      described_class.new(agent_class) {}
+    end
+
+    it 'runs block passed in' do
+      expect { |b| described_class.new(agent_class, &b) }.to yield_control
+    end
+
+    it 'sets start time' do
+      expect(subject.start_time).to be_within(1.second).of(DateTime.now)
+    end
+
+    it 'sets end time' do
+      expect(subject.end_time).to be_within(1.second).of(DateTime.now)
+    end
+  end
+
+end

--- a/spec/models/harvester_spec.rb
+++ b/spec/models/harvester_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Krikri::Harvester do
+  it 'is a havester' do
+    expect(subject).to be_a Krikri::Harvester
+  end
+
+  context 'with record_ids implemented' do
+    before do
+      described_class.send(:define_method, :record_ids) do
+        [1, 2, 3, 4, 5]
+      end
+    end
+
+    it 'knows its record count' do
+      expect(subject.count).to eq 5
+    end
+  end
+end

--- a/spec/models/harvesters/oai_harvester_spec.rb
+++ b/spec/models/harvesters/oai_harvester_spec.rb
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+describe Krikri::Harvesters::OAIHarvester do
+
+  let(:args) { { endpoint: 'http://example.org/endpoint' } }
+  subject { described_class.new(args) }
+
+  it 'has a client' do
+    expect(subject.client).to be_a OAI::Client
+  end
+
+  context 'with connection' do
+    before do
+      # TODO: webmock ListIdentifiers, test lazy resumption
+      records = (1..100).map do |id|
+        element = REXML::Element.new
+        element.add_element REXML::Element.new('identifier').add_text(id.to_s)
+        OAI::Header.new(element)
+      end
+
+      subject.client.stub_chain(:list_identifiers, :full).and_return(records)
+
+      # TODO: better way of maintaining example OAI record results?
+      # GetRecord -- Single record OAI Request
+      stub_request(:get,
+                   'http://example.org/endpoint?identifier=1&metadataPrefix='\
+                   'oai_dc&verb=GetRecord')
+        .with(:headers => {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.9.0'
+              })
+        .to_return(:status => 200,
+                   :body => '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T22:19:17Z</responseDate><request verb="GetRecord" identifier="oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><GetRecord><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000010</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record></GetRecord></OAI-PMH>',
+                   :headers => {})
+
+      # ListRecords -- Multiple record OAI Request (w/ resumption)
+      stub_request(:get,
+                   'http://example.org/endpoint?metadataPrefix=oai_dc&verb='\
+                   'ListRecords')
+        .with(:headers => {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.9.0'
+              })
+        .to_return(:status => 200,
+                   :body => '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T23:05:33Z</responseDate><request verb="ListRecords" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><ListRecords><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000010</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000011</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction</setSpec><setSpec>arthurianfiction:manuscript</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 5018-D</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000011</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000012</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction</setSpec><setSpec>arthurianfiction:manuscript</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 445-D</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000012</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000013</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 5667 E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000013</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><resumptionToken cursor="1">MToxMHwyOnwzOnw0Onw1Om9haV9kYw==</resumptionToken></ListRecords></OAI-PMH>',
+                   :headers => {})
+
+      # ListRecords -- Multiple record OAI Request (resumed)
+      stub_request(:get,
+                   'http://example.org/endpoint?resumptionToken='\
+                   'MToxMHwyOnwzOnw0Onw1Om9haV9kYw==&verb=ListRecords')
+        .with(:headers => {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.9.0'
+              })
+        .to_return(:status => 200,
+                   :body => '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T23:05:33Z</responseDate><request verb="ListRecords" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><ListRecords><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000010</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000011</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction</setSpec><setSpec>arthurianfiction:manuscript</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 5018-D</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000011</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record></ListRecords></OAI-PMH>',
+                   :headers => {})
+    end
+
+    describe 'resumption' do
+
+      let(:resumed_uri) do
+        'http://example.org/endpoint?resumptionToken='\
+        'MToxMHwyOnwzOnw0Onw1Om9haV9kYw==&verb=ListRecords'
+      end
+      it 'follows resumption token' do
+        subject.records.each { |r| r }
+        WebMock.should have_requested(:get, resumed_uri).once
+      end
+
+      it 'only follows resumption token as far as requested' do
+        subject.records.take(4).each { |r| r }
+        WebMock.should_not have_requested(:get, resumed_uri)
+      end
+    end
+
+    it_behaves_like 'a harvester'
+  end
+end

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Krikri::OriginalRecord do
+
+  shared_context 'serializations' do
+    it 'has a string format' do
+      expect(subject.to_s).to be_a String
+    end
+
+    it 'string format matches input' do
+      expect(subject.to_s).to eq record.to_s
+    end
+  end
+
+  subject { described_class.new(record) }
+
+  it 'raises an error if not passed a file or string' do
+    expect { described_class.new([1, 2, 3]) }.to raise_error ArgumentError
+  end
+
+  context 'with string input' do
+    let(:record) { '<record><title>Comet in Moominland</title></record>' }
+
+    include_context 'serializations'
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ EngineCart.load_application!
 
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'webmock/rspec'
 require 'factory_girl_rails'
 
 require 'dpla/map/factories'
@@ -13,6 +14,8 @@ Rails.backtrace_cleaner.remove_silencers!
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
+WebMock.disable_net_connect!(:allow_localhost => true)
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/shared_examples/harvester.rb
+++ b/spec/support/shared_examples/harvester.rb
@@ -1,0 +1,60 @@
+
+shared_examples 'a harvester' do
+
+  let(:harvester) { subject || described_class.new }
+
+  it 'is a harvester' do
+    expect(harvester).to be_a Krikri::Harvester
+  end
+
+  xit 'has a record count' do
+    expect(harvester.count).to be_a Integer
+  end
+
+  describe '#record_ids' do
+    it 'can get its record ids' do
+      expect(harvester.record_ids).to be_a Enumerator
+    end
+
+    it 'gives ids as strings' do
+      harvester.record_ids.each { |i| expect(i).to be_a String }
+    end
+  end
+
+  describe '#records' do
+    it 'returns a record enumerator' do
+      expect(subject.records).to be_a Enumerator
+    end
+
+    it 'returns OriginalRecords' do
+      subject.records.each { |r| expect(r).to be_a Krikri::OriginalRecord }
+    end
+  end
+
+  it 'can get an individual record' do
+    expect(harvester.get_record(harvester.record_ids.first))
+      .to be_a Krikri::OriginalRecord
+  end
+
+  describe '#run' do
+    it 'runs as an Activity' do
+      expect(harvester.run).to be_a Krikri::Activity
+    end
+
+    it 'saves the OriginalRecords' do
+      # TODO: Is this fragile? Should it change when original records have
+      #   persistence?
+      harvester.stub(:records)
+        .and_return [double('Original Record 1'), double('Record 2')]
+
+      harvester.records.each do |r|
+        expect(r).to receive(:save).and_return(true)
+      end
+
+      harvester.run
+    end
+  end
+
+  it_behaves_like 'a software agent'
+
+end

--- a/spec/support/shared_examples/software_agent.rb
+++ b/spec/support/shared_examples/software_agent.rb
@@ -1,0 +1,5 @@
+
+shared_examples 'a software agent' do
+  let(:agent) { subject || described_class.new }
+
+end


### PR DESCRIPTION
Implements an abstract harvester with [lazy enumerators](http://ruby-doc.org/core-2.0/Enumerator/Lazy.html) for `records` and `record_ids`.  

Starts work on several other classes that will play a role in the ingest/enrichment pipeline. 
- `SoftwareAgent` is a (currently empty) concern that will contain any info common to `Harvesters`, mappings, and enrichments.
- `Activity` accepts an `SoftwareAgent` as its owner and a block to run, then tracks its start/stop times.
- 'OriginalRecord' is a model for records as harvested from the partner.

An `OAIHarvester` is also implemented, with appropriately lazy enumerators. 
