### PR TITLE
Adding .rubocop.yml with some minor customizations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,33 @@
+AllCops:
+  Exclude: 
+    # not maintained manually
+    - 'bin/rails'
+    - 'spec/internal/**/*'
+    # excluded
+    - 'spec/models/harvesters/oai_harvester_spec.rb' # has some longlines
+    # grandfathered; cleanup over time
+    - 'Rakefile'
+    - 'krikri.gemspec'
+    - 'lib/krikri.rb'
+    - 'lib/krikri/engine.rb'
+    - 'lib/krikri/version.rb'
+    - 'lib/generators/krikri/install_generator.rb'
+    - 'spec/spec_helper.rb'
+    - 'spec/test_app_templates/lib/generators/test_app_generator.rb'
+    - 'app/helpers/krikri/application_helper.rb'
+
+# We like Ruby 1.8 hash syntax for dynamic key support
+HashSyntax:
+  Enabled: false
+
+# While we like guard clauses, nested conditionals are okay sometimes
+GuardClause:
+  Enabled: false
+
+# `raise` and `fail` are both fine 
+SignalException:
+  Enabled: false
+
+# Compact class/module nesting is fine
+ClassAndModuleChildren:
+  Enabled: false


### PR DESCRIPTION
Excludes files that already have some cleanup to do, or aren't actually maintained by us.

Also customizes the style guide to allow some things that are good (hash rockets, compact class/module nesting), okay in some circumstances (nested conditionals), or just don't matter one way or the other (`raise` vs. `fail`).
