### PR TITLE
Enter QA environment with basic search/browse functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Check out this repository and run:
     rake marmotta:fetch
     rake marmotta:install
 
+Copy the solr schema to jetty
+
+    cp solr_conf/schema.xml jetty/solr/blacklight-core/conf/schema.xml 
+    cp solr_conf/solrconfig.xml jetty/solr/blacklight-core/conf/solrconfig.xml
+
 Run the tests with:
 
     rake ci
@@ -28,9 +33,16 @@ Run the tests with:
 Or you can start the dummy application with:
 
     rake engine_cart:generate
+    bundle update
     rake jetty:start
     cd spec/internal
     rails s
+
+To index a sample record into solr:
+    rake krikri:index_sample_data
+
+To delete the sample record:
+    rake krikri:delete_sample_data
 
 Copyright & License
 --------------------

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.1.6"
-  s.add_dependency "dpla-map", "~>4.0.0.0-pre"
+  s.add_dependency "dpla-map", "~>4.0.0.0.pre.4"
   s.add_dependency "blacklight", ">= 5.3.0"
   s.add_dependency "therubyracer"
 

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -5,8 +5,36 @@ module Krikri
 
   class Install < Rails::Generators::Base
 
+    source_root File.expand_path("../templates", __FILE__)
+
+    ##
+    # Add factory girl dependency for development
+    # Factory girl is used to generate sample data
+    # This must execute before run_required_generators
+    def insert_factory_girl_dependency
+      append_to_file "Gemfile" do 
+        "\n\n#KriKri uses Factory Girl to generate sample data
+        gem 'factory_girl_rails', '~>4.4.0', group: :development"
+      end
+    end
+
     def run_required_generators
       generate "blacklight:install --devise"
+    end
+
+    ##
+    # Copy files from KriKri
+    #
+    # :force => true prevents user from having to manually accept 
+    # overwrite for files that are generated elsewhere
+
+    def catalog_controller
+      copy_file "catalog_controller.rb", 
+        "app/controllers/catalog_controller.rb", :force => true
+    end
+
+    def catalog_view_home
+      copy_file "_home.html.erb", "app/views/catalog/_home.html.erb"
     end
 
   end

--- a/lib/generators/krikri/templates/_home.html.erb
+++ b/lib/generators/krikri/templates/_home.html.erb
@@ -1,0 +1,1 @@
+<%= render :partial=>'search_results' %>

--- a/lib/generators/krikri/templates/catalog_controller.rb
+++ b/lib/generators/krikri/templates/catalog_controller.rb
@@ -1,0 +1,87 @@
+# -*- encoding : utf-8 -*-
+#
+require 'blacklight/catalog'
+
+##
+# Implements catalog controller to be deployed when the engine is included in
+# a Rails/Blacklight application.
+class CatalogController < ApplicationController
+  include Blacklight::Catalog
+
+  configure_blacklight do |config|
+    ##
+    # Default parameters to send to solr for all search-like requests.
+    # See also SolrHelper#solr_search_params.
+    config.default_solr_params = {
+      :qt => 'search',
+      :rows => 10
+    }
+
+    # solr field configuration for search results/index views
+    config.index.title_field = 'sourceResource_title'
+
+    # solr fields that will be treated as facets by the blacklight application
+    #   The ordering of the field names is the order of the display
+    #
+    # Setting a limit will trigger Blacklight's 'more' facet values link.
+    # * If left unset, then all facet values returned by solr will be displayed.
+    # * If set to an integer, then "f.somefield.facet.limit" will be added to
+    # solr request, with actual solr request being +1 your configured limit --
+    # you configure the number of items you actually want _displayed_ in a page.
+    # * If set to 'true', then no additional parameters will be sent to solr,
+    # but any 'sniffed' request limit parameters will be used for paging, with
+    # paging at requested limit -1. Can sniff from facet.limit or
+    # f.specific_field.facet.limit solr request params. This 'true' config
+    # can be used if you set limits in :default_solr_params, or as defaults
+    # on the solr side in the request handler itself. Request handler defaults
+    # sniffing requires solr requests to be made with "echoParams=all", for
+    # app code to actually have it echo'd back to see it.
+    #
+    # :show may be set to false if you don't want the facet to be drawn in the
+    # facet bar
+
+    config.add_facet_field 'sourceResource_type_id', :label => 'Type'
+    config.add_facet_field 'sourceResource_format', :label => 'Format'
+    config.add_facet_field 'sourceResource_spatial_name', :label => 'Place'
+    config.add_facet_field 'sourceResource_subject_name', :label => 'Subject'
+    config.add_facet_field('sourceResource_collection_title',
+                           :label => 'Collection')
+    config.add_facet_field 'dataProvider_name', :label => 'Data Provider'
+    config.add_facet_field 'sourceResource_creator_name', :label => 'Creator'
+
+    # Have BL send all facet field names to Solr, which has been the default
+    # previously. Simply remove these lines if you'd rather use Solr request
+    # handler defaults, or have no facets.
+    config.add_facet_fields_to_solr_request!
+
+    # solr fields to be displayed in the index (search results) view
+    #   The ordering of the field names is the order of the display
+    config.add_index_field 'id', :label => 'ID'
+    config.add_index_field 'sourceResource_description', :label => 'Description'
+    config.add_index_field 'sourceResource_date_providedLabel', :label => 'Date'
+    config.add_index_field 'sourceResource_type_id', :label => 'Type'
+    config.add_index_field 'sourceResource_format', :label => 'Format'
+    config.add_index_field 'sourceResource_rights', :label => 'Rights'
+    config.add_index_field 'dataProvider_name', :label => 'Data Provider'
+
+    config.index.thumbnail_field = :preview_id
+
+    # TODO: Decide whether we want the show (single result) view metadata
+    # to come from the search index or from marmotta
+    #
+    # solr fields to be displayed in the show (single result) view
+    #   The ordering of the field names is the order of the display
+    config.add_show_field 'sourceResource_title', :label => 'Title'
+    config.add_show_field 'sourceResource_description', :label => 'Description'
+    config.add_show_field 'sourceResource_date_providedLabel', :label => 'Date'
+    config.add_show_field 'sourceResource_type_id', :label => 'Type'
+    config.add_show_field 'sourceResource_format', :label => 'Format'
+    config.add_show_field 'sourceResource_rights', :label => 'Rights'
+    config.add_show_field 'dataProvider_name', :label => 'Data Provider'
+    config.add_show_field 'sourceResource_creator_name', :label => 'Creator'
+    config.add_show_field 'sourceResource_spatial_name', :label => 'Place'
+    config.add_show_field 'sourceResource_subject_name', :label => 'Subject'
+    config.add_show_field('sourceResource_collection_title',
+                          :label => 'Collection')
+  end
+end

--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -3,4 +3,6 @@ require "krikri/engine"
 require 'blacklight'
 
 module Krikri
+  # autoload libraries
+  autoload :IndexService,   'krikri/index_service'
 end

--- a/lib/krikri/index_service.rb
+++ b/lib/krikri/index_service.rb
@@ -1,0 +1,89 @@
+require 'rubygems'
+require 'rsolr'
+
+module Krikri
+  ##
+  # Generates flattened Solr documents and manages indexing of DPLA MAP models.
+  class IndexService
+    @solr = RSolr.connect
+
+    # TODO: Assure that the following metacharacters are escaped:
+    # + - && || ! ( ) { } [ ] ^ " ~ * ? : \
+
+    ##
+    # Adds a single JSON document to Solr
+    # @param JSON
+    def self.add(doc)
+      @solr.add solr_doc(doc)
+    end
+
+    ##
+    # Deletes an item from Solr
+    # @param String or Array
+    def self.delete_by_id(id)
+      @solr.delete_by_id id
+    end
+
+    ##
+    # Deletes items from Solr that match query
+    # @param String or Array
+    def self.delete_by_query(query)
+      @solr.delete_by_query query
+    end
+
+    ##
+    # Commits changes to Solr, making them visible to new requests
+    # Should be run after self.add and self.delete
+    # Okay to add or delete multiple docs and commit them all with
+    # a single self.commit
+    def self.commit
+      @solr.commit
+    end
+
+    ##
+    # Converts JSON document into a Hash that complies with Solr
+    # schema
+    def self.solr_doc(doc)
+      flat_hash(JSON.parse(doc))
+    end
+
+    ##
+    # Flattens a nested hash
+    # Joins keys with "_" and removes "@" symbols
+    # Example:
+    #   flat_hash( {"a"=>"1", "b"=>{"c"=>"2", "d"=>"3"} )
+    #   => {"a"=>"1", "b_c"=>"2", "b_d"=>"3"}
+    def self.flat_hash(hash, keys = [])
+      new_hash = {}
+
+      hash.each do |key, val|
+
+        if val.is_a? Hash
+          new_hash.merge!(flat_hash(val, keys + [key]))
+        else
+          new_hash[format_key(keys + [key])] = val
+        end
+      end
+
+      new_hash
+    end
+
+    ##
+    # Formats a key to match a field name in the Solr schema
+    #
+    # Removes unnecessary special character strings that would
+    # require special treatment in Solr
+    #
+    # @param Array
+    #
+    # TODO: Revisit this to make it more generalizable
+    def self.format_key(keys)
+      keys.join('_')
+        .gsub('@', '')
+        .gsub('http://www.geonames.org/ontology#', '')
+        .gsub('http://www.w3.org/2003/01/geo/wgs84_pos#', '')
+    end
+
+    private_class_method(:solr_doc, :flat_hash, :format_key)
+  end
+end

--- a/lib/tasks/krikri.rake
+++ b/lib/tasks/krikri.rake
@@ -1,0 +1,29 @@
+require 'factory_girl_rails'
+include FactoryGirl::Syntax::Methods
+require 'dpla/map/factories'
+require 'open-uri'
+
+namespace :krikri do
+
+  # Tasks will execute in spec/internal unless directory is changed
+  desc 'Index sample data in solr'
+  task :index_sample_data do
+    agg = build(:aggregation)
+
+    graph = agg.to_jsonld['@graph'][0]
+
+    # prepend "krikri_sample" to @id so that sample data can be identified for
+    # deletion
+    # TODO: add ids with prefixes (or similar identification) to factories
+    graph['@id'] = 'krikri_sample' + graph['@id']
+
+    Krikri::IndexService.add graph.to_json
+    Krikri::IndexService.commit
+  end
+
+  desc 'Delete sample data from solr'
+  task :delete_sample_data do
+    Krikri::IndexService.delete_by_query 'id:krikri_sample*'
+    Krikri::IndexService.commit
+  end
+end

--- a/lib/tasks/krikri_tasks.rake
+++ b/lib/tasks/krikri_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :krikri do
-#   # Task goes here
-# end

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ This is the Solr schema file. This file should be named "schema.xml" and
+ should be in the conf directory under the solr home
+ (i.e. ./solr/conf/schema.xml by default)
+ or located where the classloader for the Solr webapp can find it.
+
+ This example schema is the recommended starting point for users.
+ It should be kept correct and concise, usable out-of-the-box.
+
+ For more information, on how to customize this file, please see
+ http://wiki.apache.org/solr/SchemaXml
+
+ PERFORMANCE NOTE: this schema includes many optional features and should not
+ be used for benchmarking.  To improve performance one could
+  - set stored="false" for all fields possible (esp large fields) when you
+    only need to search on the field but don't need to return the original
+    value.
+  - set indexed="false" if you don't need to search on the field, but only
+    return the field as a result of searching on other indexed fields.
+  - remove all unneeded copyField statements
+  - for best index size and searching performance, set "index" to false
+    for all general text fields, use copyField to copy them to the
+    catchall "text" field, and use that for searching.
+  - For maximum indexing performance, use the StreamingUpdateSolrServer
+    java client.
+  - Remember to run the JVM in server mode, and use a higher logging level
+    that avoids logging every request
+-->
+
+<schema name="DPLA MAPV4.0" version="1.5">
+  <!-- attribute "name" is the name of this schema and is only used for display purposes.
+       Applications should change this to reflect the nature of the search collection.
+       version="1.5" is Solr's version number for the schema syntax and semantics.  It should
+       not normally be changed by applications.
+       1.0: multiValued attribute did not exist, all fields are multiValued by nature
+       1.1: multiValued attribute introduced, false by default
+       1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
+       1.3: removed optional field compress feature
+       1.4: default auto-phrase (QueryParser feature) to off
+     -->
+
+  <types>
+    <!-- field type definitions. The "name" attribute is
+       just a label to be used by field definitions.  The "class"
+       attribute and any other attributes determine the real
+       behavior of the fieldType.
+         Class names starting with "solr" refer to java classes in the
+       org.apache.solr.analysis package.
+    -->
+
+    <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+
+    <!-- boolean type: "true" or "false" -->
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
+    <fieldtype name="binary" class="solr.BinaryField"/>
+
+    <!-- The optional sortMissingLast and sortMissingFirst attributes are
+v         currently supported on types that are sorted internally as strings
+         and on numeric types.
+	       This includes "string","boolean", and, as of 3.5 (and 4.x),
+	       int, float, long, date, double, including the "Trie" variants.
+       - If sortMissingLast="true", then a sort on this field will cause documents
+         without the field to come after documents with the field,
+         regardless of the requested sort order (asc or desc).
+       - If sortMissingFirst="true", then a sort on this field will cause documents
+         without the field to come before documents with the field,
+         regardless of the requested sort order.
+       - If sortMissingLast="false" and sortMissingFirst="false" (the default),
+         then default lucene sorting will be used which places docs without the
+         field first in an ascending sort and last in a descending sort.
+    -->
+
+    <!--
+      Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
+    -->
+    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+
+    <!--
+     Numeric field types that index each value at various levels of precision
+     to accelerate range queries when the number of values between the range
+     endpoints is large. See the javadoc for NumericRangeQuery for internal
+     implementation details.
+
+     Smaller precisionStep values (specified in bits) will lead to more tokens
+     indexed per value, slightly larger index size, and faster range queries.
+     A precisionStep of 0 disables indexing at different precision levels.
+    -->
+    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
+         is a more restricted form of the canonical representation of dateTime
+         http://www.w3.org/TR/xmlschema-2/#dateTime
+         The trailing "Z" designates UTC time and is mandatory.
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
+         All other components are mandatory.
+
+         Expressions can also be used to denote calculations that should be
+         performed relative to "NOW" to determine the value, ie...
+
+               NOW/HOUR
+                  ... Round to the start of the current hour
+               NOW-1DAY
+                  ... Exactly 1 day prior to now
+               NOW/DAY+6MONTHS+3DAYS
+                  ... 6 months and 3 days in the future from the start of
+                      the current day
+
+         Consult the DateField javadocs for more information.
+
+         Note: For faster range queries, consider the tdate type
+      -->
+    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+
+    <!-- A Trie based date field for faster date range queries and date faceting. -->
+    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+
+
+    <!--
+      Note:
+      These should only be used for compatibility with existing indexes (created with older Solr versions)
+      or if "sortMissingFirst" or "sortMissingLast" functionality is needed. Use Trie based fields instead.
+
+      Plain numeric field types that store and index the text
+      value verbatim (and hence don't support range queries, since the
+      lexicographic ordering isn't equal to the numeric ordering)
+    -->
+    <fieldType name="pint" class="solr.IntField" omitNorms="true"/>
+    <fieldType name="plong" class="solr.LongField" omitNorms="true"/>
+    <fieldType name="pfloat" class="solr.FloatField" omitNorms="true"/>
+    <fieldType name="pdouble" class="solr.DoubleField" omitNorms="true"/>
+    <fieldType name="pdate" class="solr.DateField" sortMissingLast="true" omitNorms="true"/>
+
+    <!-- The "RandomSortField" is not used to store or search any
+         data.  You can declare fields of this type it in your schema
+         to generate pseudo-random orderings of your docs for sorting
+         purposes.  The ordering is generated based on the field name
+         and the version of the index, As long as the index version
+         remains unchanged, and the same field name is reused,
+         the ordering of the docs will be consistent.
+         If you want different psuedo-random orderings of documents,
+         for the same version of the index, use a dynamicField and
+         change the name
+     -->
+    <fieldType name="random" class="solr.RandomSortField" indexed="true" />
+
+    <!-- solr.TextField allows the specification of custom text analyzers
+         specified as a tokenizer and a list of token filters. Different
+         analyzers may be specified for indexing and querying.
+
+         The optional positionIncrementGap puts space between multiple fields of
+         this type on the same document, with the purpose of preventing false phrase
+         matching across fields.
+
+         For more info on customizing your analyzer chain, please see
+         http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
+     -->
+     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+       <analyzer>
+         <tokenizer class="solr.StandardTokenizerFactory"/>
+         <filter class="solr.ICUFoldingFilterFactory" />
+         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+         <filter class="solr.SnowballPorterFilterFactory" language="English" />
+       </analyzer>
+     </fieldType>
+
+    <!-- One can also specify an existing Analyzer class that has a
+         default constructor via the class attribute on the analyzer element
+    <fieldType name="text_greek" class="solr.TextField">
+      <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
+    </fieldType>
+    -->
+
+    <!-- A text field that only splits on whitespace for exact matching of words -->
+    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A general text field that has reasonable, generic
+         cross-language defaults: it tokenizes with StandardTokenizer,
+	 removes stop words from case-insensitive "stopwords.txt"
+	 (empty by default), and down cases.  At query time only, it
+	 also applies synonyms. -->
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        -->
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field with defaults appropriate for English: it
+         tokenizes with StandardTokenizer, removes English stop words
+         (stopwords_en.txt), down cases, protects words from protwords.txt, and
+         finally applies Porter's stemming.  The query time analyzer
+         also applies synonyms from synonyms.txt. -->
+    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        -->
+        <!-- Case insensitive stop word removal.
+          add enablePositionIncrements=true in both the index and query
+          analyzers to leave a 'gap' for more accurate phrase queries.
+        -->
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords_en.txt"
+                enablePositionIncrements="true"
+                />
+        <filter class="solr.LowerCaseFilterFactory"/>
+	<filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+	<!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+	-->
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords_en.txt"
+                enablePositionIncrements="true"
+                />
+        <filter class="solr.LowerCaseFilterFactory"/>
+	<filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+	<!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+	-->
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field with defaults appropriate for English, plus
+	 aggressive word-splitting and autophrase features enabled.
+	 This field is just like text_en, except it adds
+	 WordDelimiterFilter to enable splitting and matching of
+	 words on case-change, alpha numeric boundaries, and
+	 non-alphanumeric chars.  This means certain compound word
+	 cases will work, for example query "wi fi" will match
+	 document "WiFi" or "wi-fi".  However, other cases will still
+	 not match, for example if the query is "wifi" and the
+	 document is "wi fi" or if the query is "wi-fi" and the
+	 document is "wifi".
+        -->
+    <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        -->
+        <!-- Case insensitive stop word removal.
+          add enablePositionIncrements=true in both the index and query
+          analyzers to leave a 'gap' for more accurate phrase queries.
+        -->
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords_en.txt"
+                enablePositionIncrements="true"
+                />
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords_en.txt"
+                enablePositionIncrements="true"
+                />
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
+         but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
+    <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+             possible with WordDelimiterFilter in conjuncton with stemming. -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- Just like text_general except it reverses the characters of
+	 each token, to enable more efficient leading wildcard queries. -->
+    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
+           maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
+        <filter class="solr.StandardFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- charFilter + WhitespaceTokenizer  -->
+    <!--
+    <fieldType name="text_char_norm" class="solr.TextField" positionIncrementGap="100" >
+      <analyzer>
+        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+    -->
+
+    <!-- This is an example of using the KeywordTokenizer along
+         With various TokenFilterFactories to produce a sortable field
+         that does not include some properties of the source text
+      -->
+    <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <!-- KeywordTokenizer does no actual tokenizing, so the entire
+             input string is preserved as a single token
+          -->
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <!-- The LowerCase TokenFilter does what you expect, which can be
+             when you want your sorting to be case insensitive
+          -->
+        <filter class="solr.LowerCaseFilterFactory" />
+        <!-- The TrimFilter removes any leading or trailing whitespace -->
+        <filter class="solr.TrimFilterFactory" />
+        <!-- The PatternReplaceFilter gives you the flexibility to use
+             Java Regular expression to replace any sequence of characters
+             matching a pattern with an arbitrary replacement string,
+             which may include back references to portions of the original
+             string matched by the pattern.
+
+             See the Java Regular Expression documentation for more
+             information on pattern and replacement string syntax.
+
+             http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
+          -->
+        <filter class="solr.PatternReplaceFilterFactory"
+                pattern="([^a-z])" replacement="" replace="all"
+        />
+      </analyzer>
+    </fieldType>
+
+    <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
+      </analyzer>
+    </fieldtype>
+
+    <fieldtype name="payloads" stored="false" indexed="true" class="solr.TextField" >
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <!--
+        The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
+        a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
+        Attributes of the DelimitedPayloadTokenFilterFactory :
+         "delimiter" - a one character delimiter. Default is | (pipe)
+	 "encoder" - how to encode the following value into a playload
+	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
+	    integer -> o.a.l.a.p.IntegerEncoder
+	    identity -> o.a.l.a.p.IdentityEncoder
+            Fully Qualified class name implementing PayloadEncoder, Encoder must have a no arg constructor.
+         -->
+        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
+      </analyzer>
+    </fieldtype>
+
+    <!-- lowercases the entire field value, keeping it as a single token.  -->
+    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <fieldType name="text_path" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.PathHierarchyTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- since fields of this type are by default not stored or indexed,
+         any data added to them will be ignored outright.  -->
+    <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
+
+    <!-- This point type indexes the coordinates as separate fields (subFields)
+      If subFieldType is defined, it references a type, and a dynamic field
+      definition is created matching *___<typename>.  Alternately, if
+      subFieldSuffix is defined, that is used to create the subFields.
+      Example: if subFieldType="double", then the coordinates would be
+        indexed in fields myloc_0___double,myloc_1___double.
+      Example: if subFieldSuffix="_d" then the coordinates would be indexed
+        in fields myloc_0_d,myloc_1_d
+      The subFields are an implementation detail of the fieldType, and end
+      users normally should not need to know about them.
+     -->
+    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+
+    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
+    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+
+   <!--
+    A Geohash is a compact representation of a latitude longitude pair in a single field.
+    See http://wiki.apache.org/solr/SpatialSearch
+   -->
+    <fieldtype name="geohash" class="solr.GeoHashField"/>
+ </types>
+
+
+ <fields>
+   <!-- Valid attributes for fields:
+     name: mandatory - the name for the field
+     type: mandatory - the name of a previously defined type from the
+       <types> section
+     indexed: true if this field should be indexed (searchable or sortable)
+     stored: true if this field should be retrievable
+     multiValued: true if this field may contain multiple values per document
+     omitNorms: (expert) set to true to omit the norms associated with
+       this field (this disables length normalization and index-time
+       boosting for the field, and saves some memory).  Only full-text
+       fields or fields that need an index-time boost need norms.
+     termVectors: [false] set to true to store the term vector for a
+       given field.
+       When using MoreLikeThis, fields used for similarity should be
+       stored for best performance.
+     termPositions: Store position information with the term vector.
+       This will increase storage costs.
+     termOffsets: Store offset information with the term vector. This
+       will increase storage costs.
+     default: a value that should be used if no value is specified
+       when adding a document.
+   -->
+
+   <field name="id" type="string" indexed="true" stored="true" required="true" />
+   <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false" />
+
+   <!-- default, catch all search field -->
+   <!-- set multiValued to true in order to copyfield -->
+   <field name="text" type="text" indexed="true" stored="false" multiValued="true" />
+
+   <field name="type" type="string" indexed="false" stored="false" />
+
+   <field name="dataProvider_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="dataProvider_type" type="string" indexed="false" stored="false" />
+   <field name="dataProvider_name" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="dataProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="hasView_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="hasView_type" type="string" indexed="false" stored="false" />
+   <field name="hasView_format" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="hasView_rights" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="hasView_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="intermediateProvider_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="intermediateProvider_type" type="string" indexed="false" stored="false" />
+   <field name="intermediateProvider_name" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="intermediateProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="isShownAt_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="isShownAt_type" type="string" indexed="false" stored="false" />
+   <field name="isShownAt_format" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="isShownAt_rights" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="isShownAt_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="object_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="object_type" type="string" indexed="false" stored="false" />
+   <field name="object_format" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="object_rights" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="object_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="originalRecord" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="preview_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="preview_type" type="string" indexed="false" stored="false" />
+   <field name="preview_format" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="preview_rights" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="preview_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="provider_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="provider_type" type="string" indexed="false" stored="false" />
+   <field name="provider_name" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="provider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+
+   <field name="sourceResource_id" type="string" indexed="true" stored="true" multiValued="false"/>
+   <field name="sourceResource_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_alternative" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_collection_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_collection_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_collection_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_collection_title" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_collection_description" type="text" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_contributor_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_contributor_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_contributor_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_contributor_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_creator_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_creator_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_creator_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_creator_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <!-- TODO: Change date_begin and date_end type to "date" assuming they have been correctly formatted -->
+   <field name="sourceResource_date_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_date_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_date_begin" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_date_end" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_date_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_description" type="text" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_extent" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_format" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_identifier" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_language_id" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_genre" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_genre_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_genre_type" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_publisher_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_publisher_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_publisher_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_publisher_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_relation" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_isReplacedBy" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_replaces" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_rights" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_spatial_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_spatial_exactMatch" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_countryCode" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_parentFeature_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_alt" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_lat" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_long" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_spatial_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_specType_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_specType_type" type="string" indexed="false" stored="false" />
+
+   <field name="sourceResource_subject_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_subject_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_subject_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_subject_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_temporal" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_title" type="string" indexed="true" stored="true" multiValued="true" />
+
+   <field name="sourceResource_type_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_type_type" type="string" indexed="false" stored="false" />
+
+   <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
+        will be used if the name matches any of the patterns.
+        RESTRICTION: the glob-like pattern in the name attribute must have
+        a "*" only at the start or the end.
+        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
+        Longer patterns will be matched first.  if equal size patterns
+        both match, the first appearing in the schema will be used.  -->
+   <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
+   <dynamicField name="*_s"  type="string"  indexed="true"  stored="true"/>
+   <dynamicField name="*_l"  type="long"   indexed="true"  stored="true"/>
+   <dynamicField name="*_t"  type="text"    indexed="true"  stored="true" multiValued="true"/>
+   <dynamicField name="*_txt" type="text_general"    indexed="true"  stored="true" multiValued="true"/>
+   <dynamicField name="*_b"  type="boolean" indexed="true"  stored="true"/>
+   <dynamicField name="*_f"  type="float"  indexed="true"  stored="true"/>
+   <dynamicField name="*_d"  type="double" indexed="true"  stored="true"/>
+
+   <!-- Type used to index the lat and lon components for the "location" FieldType -->
+   <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false"/>
+
+   <dynamicField name="*_dt" type="date"    indexed="true"  stored="true"/>
+   <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
+
+   <!-- some trie-coded dynamic fields for faster range queries -->
+   <dynamicField name="*_ti" type="tint"    indexed="true"  stored="true"/>
+   <dynamicField name="*_tl" type="tlong"   indexed="true"  stored="true"/>
+   <dynamicField name="*_tf" type="tfloat"  indexed="true"  stored="true"/>
+   <dynamicField name="*_td" type="tdouble" indexed="true"  stored="true"/>
+   <dynamicField name="*_tdt" type="tdate"  indexed="true"  stored="true"/>
+
+   <dynamicField name="*_pi"  type="pint"    indexed="true"  stored="true"/>
+
+   <dynamicField name="ignored_*" type="ignored" multiValued="true"/>
+   <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
+
+   <dynamicField name="random_*" type="random" />
+
+   <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
+   <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
+   <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
+
+   <!-- uncomment the following to ignore any fields that don't already match an existing
+        field name or dynamic field, rather than reporting them as an error.
+        alternately, change the type="ignored" to some other type e.g. "text" if you want
+        unknown fields indexed and/or stored by default -->
+   <!--dynamicField name="*" type="ignored" multiValued="true" /-->
+
+ </fields>
+
+ <!-- Field to use to determine and enforce document uniqueness.
+      Unless this field is marked with required="false", it will be a required field
+   -->
+ <uniqueKey>id</uniqueKey>
+
+ <!-- field for the QueryParser to use when an explicit fieldname is absent -->
+ <defaultSearchField>text</defaultSearchField>
+
+ <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
+ <solrQueryParser defaultOperator="AND" />
+
+  <!-- copyField commands copy one field to another at the time a document
+        is added to the index.  It's used either to index the same field differently,
+        or to add multiple fields to the same field for easier/faster searching.  -->
+   <!-- Copy Fields -->
+   <!-- The source fields are copied into the text field to allow tokenization -->
+  <copyField source="dataProvider_name" dest="text" />
+  <copyField source="dataProvider_providedLabel" dest="text" />
+  <copyField source="hasView_format" dest="text" />
+  <copyField source="hasView_rights" dest="text" />
+  <copyField source="intermediateProvider_name" dest="text" />
+  <copyField source="intermediateProvider_providedLabel" dest="text" />
+  <copyField source="isShownAt_format" dest="text" />
+  <copyField source="isShownAt_rights" dest="text" />
+  <copyField source="object_format" dest="text" />
+  <copyField source="object_rights" dest="text" />
+  <copyField source="preview_format" dest="text" />
+  <copyField source="preview_rights" dest="text" />
+  <copyField source="provider_name" dest="text" />
+  <copyField source="provider_providedLabel" dest="text" />
+  <copyField source="sourceResource_alternative" dest="text" />
+  <copyField source="sourceResource_collection_providedLabel" dest="text" />
+  <copyField source="sourceResource_collection_title" dest="text" />
+  <copyField source="sourceResource_contributor_name" dest="text" />
+  <copyField source="sourceResource_contributor_providedLabel" dest="text" />
+  <copyField source="sourceResource_creator_name" dest="text" />
+  <copyField source="sourceResource_creator_providedLabel" dest="text" />
+  <copyField source="sourceResource_date_providedLabel" dest="text" />
+  <copyField source="sourceResource_extent" dest="text" />
+  <copyField source="sourceResource_format" dest="text" />
+  <copyField source="sourceResource_genre" dest="text" />
+  <copyField source="sourceResource_publisher_name" dest="text" />
+  <copyField source="sourceResource_publisher_providedLabel" dest="text" />
+  <copyField source="sourceResource_relation" dest="text" />
+  <copyField source="sourceResource_isReplacedBy" dest="text" />
+  <copyField source="sourceResource_replaces" dest="text" />
+  <copyField source="sourceResource_rights" dest="text" />
+  <copyField source="sourceResource_spatial_name" dest="text" />
+  <copyField source="sourceResource_spatial_providedLabel" dest="text" />
+  <copyField source="sourceResource_subject_name" dest="text" />
+  <copyField source="sourceResource_subject_providedLabel" dest="text" />
+  <copyField source="sourceResource_temporal" dest="text" />
+  <copyField source="sourceResource_title" dest="text" />
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+	  Another way to map multiple source fields to the same
+	  destination field is to use the dynamic field syntax.
+	  copyField also supports a maxChars to copy setting.  -->
+
+   <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
+
+   <!-- copy name to alphaNameSort, a field designed for sorting by name -->
+   <!-- <copyField source="name" dest="alphaNameSort"/> -->
+
+
+ <!-- Similarity is the scoring routine for each document vs. a query.
+      A custom similarity may be specified here, but the default is fine
+      for most applications.  -->
+ <!-- <similarity class="org.apache.lucene.search.DefaultSimilarity"/> -->
+ <!-- ... OR ...
+      Specify a SimilarityFactory class name implementation
+      allowing parameters to be used.
+ -->
+ <!--
+ <similarity class="com.example.solr.CustomSimilarityFactory">
+   <str name="paramkey">param value</str>
+ </similarity>
+ -->
+
+
+</schema>

--- a/solr_conf/solrconfig.xml
+++ b/solr_conf/solrconfig.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ This is a stripped down config file used for a simple example...  
+ It is *not* a good example to work from. 
+-->
+<config>
+  <luceneMatchVersion>LUCENE_40</luceneMatchVersion>
+  <!--  The DirectoryFactory to use for indexes.
+        solr.StandardDirectoryFactory, the default, is filesystem based.
+        solr.RAMDirectoryFactory is memory based, not persistent, and doesn't work with replication. -->
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
+
+  <lib dir="../lib/contrib/analysis-extras/lib" />
+  <lib dir="../lib/contrib/analysis-extras/lucene-libs" />
+
+  <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
+  
+  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" /> 
+
+  <requestDispatcher handleSelect="true" >
+    <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048" />
+  </requestDispatcher>
+  
+  <requestHandler name="standard" class="solr.StandardRequestHandler" />
+  <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
+  <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
+     
+  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+    <lst name="invariants">
+      <str name="q">solrpingquery</str>
+    </lst>
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+    </lst>
+  </requestHandler>
+   
+  <!-- config for the admin interface --> 
+  <admin>
+    <defaultQuery>solr</defaultQuery>
+  </admin>
+
+  <!-- SearchHandler
+
+       http://wiki.apache.org/solr/SearchHandler
+
+       For processing Search Queries, the primary Request Handler
+       provided with Solr is "SearchHandler" It delegates to a sequent
+       of SearchComponents (see below) and supports distributed
+       queries across multiple shards
+    -->
+  <requestHandler name="search" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+     <lst name="defaults">
+       <str name="defType">dismax</str>
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+
+       <str name="q.alt">*:*</str>
+       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+
+       <!-- TODO: Configure qf and pf for better search results -->
+
+       <!-- this qf and pf are used by default, if not otherwise specified by
+            client. The default blacklight_config will use these for the
+            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            below, which the default blacklight_config will specify for
+            those searches. You may also be interested in:
+            http://wiki.apache.org/solr/LocalParams
+       -->
+
+       <str name="qf">
+         dataProvider_name 
+         sourceResource_collection_title
+         sourceResource_creator_name
+         sourceResource_date_providedLabel
+         sourceResource_description
+         sourceResource_format
+         sourceResource_rights
+         sourceResource_spatial_name
+         sourceResource_subject_name
+         sourceResource_title
+         sourceResource_type_id
+         text
+       </str>
+
+       <str name="pf">
+         dataProvider_name 
+         sourceResource_collection_title
+         sourceResource_creator_name
+         sourceResource_date_providedLabel
+         sourceResource_description
+         sourceResource_format
+         sourceResource_rights
+         sourceResource_spatial_name
+         sourceResource_subject_name
+         sourceResource_title
+         sourceResource_type_id
+         text
+       </str>
+       
+       <int name="ps">3</int>
+       <float name="tie">0.01</float>
+
+       <str name="fl">
+         id,
+         dataProvider_name, 
+         preview_id,
+         sourceResource_collection_title,
+         sourceResource_creator_name,
+         sourceResource_date_providedLabel,
+         sourceResource_description,
+         sourceResource_format,
+         sourceResource_rights,
+         sourceResource_spatial_name,
+         sourceResource_subject_name,
+         sourceResource_title,
+         sourceResource_type_id
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.limit">10</str>
+       <str name="facet.field">dataProvider_name</str>
+
+     </lst>
+      
+  </requestHandler>
+
+  <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
+  <requestHandler name="document" class="solr.SearchHandler" >
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+      <str name="fl">*</str>
+      <str name="rows">1</str>
+      <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
+    </lst>
+  </requestHandler>
+
+</config>
+

--- a/spec/lib/krikri/index_service_spec.rb
+++ b/spec/lib/krikri/index_service_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Krikri::IndexService do
+
+  subject { Krikri::IndexService }
+  let(:solr) { RSolr.connect }
+
+  describe '#solr_doc' do
+    it 'converts JSON into Solr-compatible hash' do
+      json = { 'a' => '1', 'b' => { 'c' => '2', 'd' => '3' } }.to_json
+      flat_hash = { 'a' => '1', 'b_c' => '2', 'b_d' => '3' }
+      result = subject.class_eval { solr_doc(json) }
+      expect(result).to eq flat_hash
+    end
+
+    it 'removes special character strings from keys' do
+      json = {
+        'http://www.geonames.org/ontology#a' => '1',
+        'http://www.w3.org/2003/01/geo/wgs84_pos#b' => '2',
+        '@c' => '3'
+      }.to_json
+      flat_hash = { 'a' => '1', 'b' => '2', 'c' => '3' }
+      result = subject.class_eval { solr_doc(json) }
+      expect(result).to eq flat_hash
+    end
+
+    context 'with models' do
+      let(:aggregation) { build(:aggregation) }
+
+      before do
+        aggregation.set_subject!('http://api.dp.la/item/123')
+        Krikri::IndexService.add aggregation.to_jsonld['@graph'][0].to_json
+        Krikri::IndexService.commit
+      end
+
+      after do
+        q = 'id:*'
+        Krikri::IndexService.delete_by_query(q)
+        Krikri::IndexService.commit
+      end
+
+      it 'posts DPLA MAP JSON to solr' do
+        response = solr.get('select', :params => { :q => '' })['response']
+        expect(response['numFound']).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
Configure Solr
Add IndexService library
Index and delete sample data with rake task
Generate catalog controller to customize blacklight
Show search results in catalog home view
Basic keyword search
Refine search with facets
Show basic metadata for single record

To test in your browser:  Follow the new README instructions to configure and start the dummy application, and index sample data to Solr.  You may need to visit [http://127.0.0.1:8983/solr/#/~cores/blacklight-core](http://127.0.0.1:8983/solr/#/~cores/blacklight-core) and click `Reload` for the sample data to index. Go to [http://localhost:3000/catalog](http://localhost:3000/catalog) (you will see the same page if you go to http://localhost:3000 because of the current route configuration).  You should see your sample record.  You should be able to search and refine your search with facets.  You should also be able to view some basic metadata for a single record if you click on the record id.  

There are also two unit test you can run with `bundle exec rake ci`.

Because we are likely moving away from Solr, I focused on getting Solr working without necessarily employing the most elegant solutions.  

In `schema.xml`, everything above line 476 `<fields>` is standard.  Everything below is ours, with the exception of `dynamic field definitions`, which is also standard.
