### PR TITLE
Remove some deprecated syntax in specs

### DIFF
--- a/spec/krikri_spec.rb
+++ b/spec/krikri_spec.rb
@@ -5,10 +5,10 @@ describe Krikri::Engine do
     before do
       settings_path =
         Krikri::Engine.root.join('config', 'settings.local.yml').to_s
-      File.stub(:exists?).and_call_original
-      File.stub(:exists?).with(settings_path).and_return(true)
-      IO.stub(:read).and_call_original
-      IO.stub(:read).with(settings_path)
+      allow(File).to receive(:exists?).and_call_original
+      allow(File).to receive(:exists?).with(settings_path).and_return(true)
+      allow(IO).to receive(:read).and_call_original
+      allow(IO).to receive(:read).with(settings_path)
         .and_return("---\n\nqa_test: 'test!'")
 
       Krikri::Settings.reload!
@@ -20,8 +20,8 @@ describe Krikri::Engine do
 
     it 'allows app to override configuration' do
       app_settings_path = Rails.root.join('config', 'settings.local.yml').to_s
-      File.stub(:exists?).with(app_settings_path).and_return(true)
-      IO.stub(:read).with(app_settings_path)
+      allow(File).to receive(:exists?).with(app_settings_path).and_return(true)
+      allow(IO).to receive(:read).with(app_settings_path)
         .and_return("---\n\napi_test: 'app!'")
       Krikri::Settings.reload!
 

--- a/spec/models/harvesters/oai_harvester_spec.rb
+++ b/spec/models/harvesters/oai_harvester_spec.rb
@@ -19,7 +19,8 @@ describe Krikri::Harvesters::OAIHarvester do
         OAI::Header.new(element)
       end
 
-      subject.client.stub_chain(:list_identifiers, :full).and_return(records)
+      allow(subject.client).to receive_message_chain(:list_identifiers, :full)
+        .and_return(records)
 
       # TODO: better way of maintaining example OAI record results?
       # GetRecord -- Single record OAI Request
@@ -126,12 +127,12 @@ describe Krikri::Harvesters::OAIHarvester do
       end
       it 'follows resumption token' do
         subject.records.each { |r| r }
-        WebMock.should have_requested(:get, resumed_uri).once
+        expect(WebMock).to have_requested(:get, resumed_uri).once
       end
 
       it 'only follows resumption token as far as requested' do
         subject.records.take(4).each { |r| r }
-        WebMock.should_not have_requested(:get, resumed_uri)
+        expect(WebMock).not_to have_requested(:get, resumed_uri)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'engine_cart'
 EngineCart.load_application!
 
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'webmock/rspec'
 require 'factory_girl_rails'
 

--- a/spec/support/shared_examples/harvester.rb
+++ b/spec/support/shared_examples/harvester.rb
@@ -44,7 +44,7 @@ shared_examples 'a harvester' do
     it 'saves the OriginalRecords' do
       # TODO: Is this fragile? Should it change when original records have
       #   persistence?
-      harvester.stub(:records)
+      allow(harvester).to receive(:records)
         .and_return [double('Original Record 1'), double('Record 2')]
 
       harvester.records.each do |r|


### PR DESCRIPTION
Some of the specs on OAIHarvester used 'should' syntax, causing deprecation warnings. This replaces them with the proper syntax.
