### PR TITLE
add instructions to update/restart dummy app and jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ To index a sample record into solr:
 To delete the sample record:
     rake krikri:delete_sample_data
 
+To update/restart dummy application, from the root KriKri directory:
+    git pull
+    bundle update
+    rake engine_cart:clean
+    rake engine_cart:generate
+    cd spec/internal
+    rails s
+
+To update/restart jetty, from the root KriKri directory:
+    git pull
+    bundle update
+    rake jetty:stop
+    rake jetty:config
+    rake jetty:start
+
 Contribution Guidelines
 -----------------------
 Please observe the following guidelines:


### PR DESCRIPTION
This adds instructions to README to update and restart both the dummy app and jetty.
