### PR TITLE
Use the new DPLA marmotta-jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Check out this repository and run:
     bundle install
     rake jetty:unzip
     rake jetty:config
-    rake marmotta:fetch
-    rake marmotta:install
 
 Run the tests with:
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,24 +21,18 @@ require 'rspec/core/rake_task'
 
 require 'engine_cart/rake_task'
 require 'jettywrapper'
-require 'marmottawrapper'
 
 import 'lib/tasks/jetty.rake'
 
-ZIP_URL = "https://github.com/projectblacklight/blacklight-jetty/archive/v4.9.0.zip"
+ZIP_URL = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-SNAPSHOT-20141115.zip"
 
 desc "Run all specs in spec directory (excluding plugin specs) in an engine_cart-generated app"
 task :ci => ['jetty:clean', 'engine_cart:generate'] do
   Rake::Task['jetty:config'].invoke
-  Rake::Task["marmotta:fetch"].invoke
-  Rake::Task["marmotta:install"].invoke
-  Rake::Task["marmotta:start"].invoke
 
   Jettywrapper.wrap(quiet: true, jetty_port: 8983, :startup_wait => 30) do
     Rake::Task["spec"].invoke
   end
-
-  Rake::Task["marmotta:stop"].invoke
 end
 
 desc "Run all specs in spec directory (excluding plugin specs)"

--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,0 +1,6 @@
+default:
+  startup_wait: 90
+  jetty_port: 8983
+  java_opts:
+    - "-XX:MaxPermSize=128m"
+    - "-Xmx256m"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 ---
 marmotta:
-  base: 'http://localhost:8080/marmotta/'
-  ldp: 'http://localhost:8080/marmotta/ldp'
+  base: 'http://localhost:8983/marmotta/'
+  ldp: 'http://localhost:8983/marmotta/ldp'

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency "oai"
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "marmottawrapper", '>=0.0.5'
   s.add_development_dependency "jettywrapper"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency 'webmock'

--- a/lib/tasks/jetty.rake
+++ b/lib/tasks/jetty.rake
@@ -4,9 +4,8 @@ namespace :jetty do
 
   desc 'Configure solr schema'
   task :config do
-    cp('solr_conf/schema.xml', 'jetty/solr/blacklight-core/conf/schema.xml')
+    cp('solr_conf/schema.xml', 'jetty/solr/development-core/conf/schema.xml')
     cp('solr_conf/solrconfig.xml',
-       'jetty/solr/blacklight-core/conf/solrconfig.xml')
+       'jetty/solr/development-core/conf/solrconfig.xml')
   end
-
 end


### PR DESCRIPTION
This unifies us on a single servlet container for Solr and Marmotta. It also pins us to a snapshot of Marmotta 3.3.0, which current LDP work depends on. We're expecting an official 3.3.0 release imminently.

When building for the first time with this update, you may need to remove any lingering Marmotta files by doing `rm -rf /tmp/marmotta`.
