### PR TITLE
institutions and harvest feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'engine_cart'
 
 gem 'rubocop', require: false
 
+gem 'database_cleaner', '~> 1.3.0', require: false
+
 file = File.expand_path('Gemfile',
                         ENV['ENGINE_CART_DESTINATION'] ||
                         ENV['RAILS_ROOT'] ||

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A Rails engine for metadata aggregation, enhancement, and quality control.
 Installation
 -------------
 
-Add `krikri` to your Gemfile, and mount it by editing your application's `config/routes.rb`
-to include:
+Add `krikri` to your Gemfile.  Kri-Kri will mount automatically by editing your 
+application's `config/routes.rb` to include:
 
-    mount Krikri::Engine, at: "/"
+    mount Krikri::Engine => '/krikri'
 
 Development
 -----------
@@ -32,7 +32,7 @@ Or you can start the dummy application with:
     cd spec/internal
     rails s
 
-To index a sample record into solr:
+To index a sample record into solr, from `/krikri/spec/internal`:
     rake krikri:index_sample_data
 
 To delete the sample record:
@@ -52,6 +52,12 @@ To update/restart jetty, from the root KriKri directory:
     rake jetty:stop
     rake jetty:config
     rake jetty:start
+
+To create a sample institution and harvest source, from `/krikri/spec/internal`:
+    rake krikri:create_sample_institution
+
+To delete the sample institution and harvest source:
+    rake krikri:delete_sample_institution
 
 Contribution Guidelines
 -----------------------

--- a/app/controllers/krikri/harvest_sources_controller.rb
+++ b/app/controllers/krikri/harvest_sources_controller.rb
@@ -1,0 +1,10 @@
+module Krikri
+  # Marshalls HarvestSources for views
+  class HarvestSourcesController < ApplicationController
+
+    def show
+      @harvest_source = HarvestSource.find(params[:id])
+    end
+
+  end
+end

--- a/app/controllers/krikri/institutions_controller.rb
+++ b/app/controllers/krikri/institutions_controller.rb
@@ -1,0 +1,15 @@
+module Krikri
+  # Marshalls Institutions for views
+  class InstitutionsController < ApplicationController
+
+    def index
+      @institutions = Institution.all
+    end
+
+    def show
+      @institution = Institution.find(params[:id])
+      @harvest_sources = @institution.harvest_sources
+    end
+
+  end
+end

--- a/app/models/krikri/harvest_source.rb
+++ b/app/models/krikri/harvest_source.rb
@@ -1,0 +1,8 @@
+module Krikri
+  # HarvestSource models user-submitted information about a harvest source
+  # Some data may be used to create a Harvester
+  class HarvestSource < ActiveRecord::Base
+    belongs_to :institution
+    validates :institution, :name, presence: true
+  end
+end

--- a/app/models/krikri/institution.rb
+++ b/app/models/krikri/institution.rb
@@ -1,0 +1,7 @@
+module Krikri
+  # Institution models user-submitted information about an institution
+  class Institution < ActiveRecord::Base
+    has_many :harvest_sources, dependent: :destroy
+    validates :name, presence: true
+  end
+end

--- a/app/views/krikri/harvest_sources/show.html.erb
+++ b/app/views/krikri/harvest_sources/show.html.erb
@@ -1,0 +1,7 @@
+<% # krikri/harvest_sources/show %>
+<h1>Harvest Source</h1>
+<p>Name: <%= @harvest_source.name %></p>
+<p>Source type: <%= @harvest_source.source_type %></p>
+<p>Metadata schema: <%= @harvest_source.metadata_schema %></p>
+<p>URI: <%= @harvest_source.uri %></p>
+<p>Notes: <%= @harvest_source.notes %></p>

--- a/app/views/krikri/institutions/index.html.erb
+++ b/app/views/krikri/institutions/index.html.erb
@@ -1,0 +1,13 @@
+<% # krikri/institutions/index %>
+<h1>Institutions</h1>
+<ul>
+<% @institutions.each do |institution| %>
+  <li>
+    <%= link_to institution.name,
+      controller: "institutions", 
+      action: "show",
+      id: institution.id
+    %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/krikri/institutions/show.html.erb
+++ b/app/views/krikri/institutions/show.html.erb
@@ -1,0 +1,16 @@
+<% # krikri/institutions/show %>
+<h1>Institution Profile</h1>
+<p>Name: <%= @institution.name %></p>
+<p>Harvest Sources:</p>
+<ul>
+<% @harvest_sources.each do |harvest_source| %>
+  <li>
+    <%= link_to harvest_source.name,
+      controller: "harvest_sources",
+      action: "show",
+      id: harvest_source.id
+    %>
+  </li>
+</ul>
+<p>Notes: <%= @institution.notes %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,6 @@
 Krikri::Engine.routes.draw do
+  # TODO: remove unnecessary :harvest_sources and :institutions routes once we
+  # have established what we do and don't need
+  resources :harvest_sources
+  resources :institutions
 end

--- a/db/migrate/20141113200614_create_krikri_institutions.rb
+++ b/db/migrate/20141113200614_create_krikri_institutions.rb
@@ -1,0 +1,10 @@
+class CreateKrikriInstitutions < ActiveRecord::Migration
+  def change
+    create_table :krikri_institutions do |t|
+      t.string :name
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20141113200643_create_krikri_harvest_sources.rb
+++ b/db/migrate/20141113200643_create_krikri_harvest_sources.rb
@@ -1,0 +1,14 @@
+class CreateKrikriHarvestSources < ActiveRecord::Migration
+  def change
+    create_table :krikri_harvest_sources do |t|
+      t.integer :institution_id
+      t.string :name
+      t.string :source_type
+      t.string :metadata_schema
+      t.string :uri
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -22,6 +22,19 @@ module Krikri
       generate "blacklight:install --devise"
     end
 
+    def copy_migrations
+      rake "krikri:install:migrations"
+    end
+
+    ##
+    # Add the krikri routes
+    # This will add routes at with the krikri namespace in the name
+    # For example:
+    #   /krikri/institutions
+    def inject_krikri_routes
+      route "mount Krikri::Engine => '/krikri'"
+    end
+
     ##
     # Copy files from KriKri
     #

--- a/lib/tasks/krikri.rake
+++ b/lib/tasks/krikri.rake
@@ -26,4 +26,36 @@ namespace :krikri do
     Krikri::IndexService.delete_by_query 'id:krikri_sample*'
     Krikri::IndexService.commit
   end
+
+  desc 'Create sample institution and harvest source'
+  # the '=> :environment' dependency gives task access to ActiveRecord models
+  task :create_sample_institution => :environment do
+
+    unless Krikri::Institution.find_by(name: 'Krikri Sample Institution')
+
+      institution = Krikri::Institution.create(
+        name: 'Krikri Sample Institution',
+        notes: 'These are notes about the Krikri Sample Institution.'
+      )
+
+      Krikri::HarvestSource.create(
+        institution_id: institution.id,
+        name: 'OAI feed',
+        source_type: 'OAI',
+        metadata_schema: 'MARC',
+        uri: 'http://www.example.com',
+        notes: 'These are notes about the Krikri Sample Source.'
+      )
+
+    end
+  end
+
+  desc 'Delete sample institution and harvest source'
+  task :delete_sample_institution => :environment do
+    # any harvest sources associated with sample institution will be
+    # destroyed through dependent_destroy
+    institution = Krikri::Institution.find_by(name: 'Krikri Sample Institution')
+    institution.destroy if institution
+  end
+
 end

--- a/spec/controllers/harvest_sources_controller_spec.rb
+++ b/spec/controllers/harvest_sources_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Krikri::HarvestSourcesController, :type => :controller do
+
+  routes { Krikri::Engine.routes }
+
+  before(:all) do
+    @harvest_sources_factory = create(:krikri_harvest_sources)
+  end
+
+  describe '#show' do
+    it 'assigns the requested harvest source to @harvest_source' do
+      get :show, id: @harvest_sources_factory.id
+      expect(assigns(:harvest_source)).to eq(@harvest_sources_factory)
+    end
+
+    it 'renders the :show view' do
+      get :show, id: @harvest_sources_factory.id
+      expect(response).to render_template('krikri/harvest_sources/show')
+    end
+  end
+
+end

--- a/spec/controllers/institutions_controller_spec.rb
+++ b/spec/controllers/institutions_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'database_cleaner'
+
+describe Krikri::InstitutionsController, :type => :controller do
+
+  routes { Krikri::Engine.routes }
+
+  before(:all) do
+    # This clean statement is a safety precaution
+    # Occasionally there is an extra institution written to the test db
+    # for a reason I am yet to ascertain
+    DatabaseCleaner.clean_with(:truncation)
+    @harvest_sources_factory = create(:krikri_harvest_sources)
+    @institutions_factory = @harvest_sources_factory.institution
+  end
+
+  describe 'GET #index' do
+
+    it 'assigns all institutions to @institutions' do
+      get :index
+      expect(assigns(:institutions)).to eq([@institutions_factory])
+    end
+
+    it 'renders the :index view' do
+      get :index
+      expect(response).to render_template('krikri/institutions/index')
+    end
+
+  end
+
+  describe 'GET #show' do
+
+    it 'assigns the requested institution to @institution' do
+      get :show, id: @institutions_factory.id
+      expect(assigns(:institution)).to eq(@institutions_factory)
+    end
+
+    it 'assigns associated harvest sources to @harvest_sources' do
+      get :show, id: @institutions_factory.id
+      expect(assigns(:harvest_sources)).to eq([@harvest_sources_factory])
+    end
+
+    it 'renders the :show view' do
+      get :show, id: @institutions_factory.id
+      expect(response).to render_template('krikri/institutions/show')
+    end
+  end
+
+end

--- a/spec/factories/krikri_harvest_sources.rb
+++ b/spec/factories/krikri_harvest_sources.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+
+  factory :krikri_harvest_sources, class: Krikri::HarvestSource do
+    name 'OAI feed'
+    source_type 'OAI'
+    metadata_schema 'MARC'
+    uri 'http://www.example.com'
+    notes 'These are notes about the Krikri Sample Source.'
+    association :institution, factory: :krikri_institutions
+  end
+
+end

--- a/spec/factories/krikri_institutions.rb
+++ b/spec/factories/krikri_institutions.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory :krikri_institutions, class: Krikri::Institution do
+    name 'Krikri Sample Institution'
+    notes 'These are notes about the Krikri Sample Institution.'
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
 
-  config.use_transactional_fixtures = true
+  # use_transactional_fixtures is false to comply with database cleaner configs
+  config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'
 
@@ -40,4 +41,5 @@ RSpec.configure do |config|
   config.after(:suite) do
     clear_repository
   end
+  
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,23 @@
+require 'database_cleaner'
+
+RSpec.configure do |config|
+
+  # clear database completely before test suite runs
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  # set default database cleaning strategy to be transactions
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+end


### PR DESCRIPTION
Institutions and harvest feeds (user-entered data meant primarily for human consumption)
- basic models, controllers, views, routes, and migrations
- rake tasks to save and delete sample institution and harvest feed

For reference, the ER diagram is here: https://docs.google.com/a/dp.la/drawings/d/1Wmtq6x_VBjJGgwAMhT2qUHvkuQAygMLooXd0K2eOAPo/edit

You can test in your browser by following the README instructions to generate and start a dummy application, and then creating a sample institution.  Go to `http://localhost:3000/krikri/institutions`.  You should see one institution listed.  A link from that page should take you to a view with data for that institution.  From there, another link should take you to a view with data for one sample harvest feed.

Once @mb has customized the user model, we can integrate it with the institution model and possibly rethink the routes to fit with admin and general user dashboards.
