### PR TITLE
Add login

### DIFF
--- a/app/controllers/krikri/application_controller.rb
+++ b/app/controllers/krikri/application_controller.rb
@@ -1,4 +1,5 @@
 module Krikri
   class ApplicationController < ActionController::Base
+    before_action :authenticate_user!
   end
 end

--- a/app/models/krikri/user.rb
+++ b/app/models/krikri/user.rb
@@ -1,0 +1,9 @@
+
+module Krikri
+  # The KriKri engine's User model, which extends the wrapper application's
+  # user model so that it can eventually relate to some kind of
+  # access-control model.
+  class User < ::User
+    # TODO
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+
 Krikri::Engine.routes.draw do
   # TODO: remove unnecessary :harvest_sources and :institutions routes once we
   # have established what we do and don't need

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "oai"
 
+  s.add_dependency "devise", "~>3.4.1"
+
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper"
   s.add_development_dependency "rspec-rails"

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -18,12 +18,26 @@ module Krikri
       end
     end
 
-    def run_required_generators
-      generate "blacklight:install --devise"
+    ##
+    # Devise is a dependency, and is specified in krikri.gemspec,
+    # but it requires some setup if it's generated into
+    # a development environment.
+    def install_devise_dependency
+      append_to_file "Gemfile" do
+        <<-EOT.strip_heredoc
+
+        # Devise is used for authentication by KriKri and Blacklight.
+        gem 'devise', '~>3.4.1'
+
+        EOT
+      end
+      generate "devise:install"
+      generate "devise User"
+      rake("db:migrate")
     end
 
-    def copy_migrations
-      rake "krikri:install:migrations"
+    def run_required_generators
+      generate "blacklight:install"
     end
 
     ##

--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -1,4 +1,5 @@
 require 'rails'
+require 'devise'
 require "krikri/engine"
 require 'blacklight'
 

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -35,5 +35,14 @@ module Krikri
       RailsConfig.load_and_set_settings(source_paths)
       Krikri::Settings = Kernel.const_get(RailsConfig.const_name)
     end
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s == root.to_s
+        config.paths['db/migrate'].expanded.each do |exp_path|
+          app.config.paths['db/migrate'] << exp_path
+        end
+      end
+    end
+
   end
 end

--- a/spec/controllers/harvest_sources_controller_spec.rb
+++ b/spec/controllers/harvest_sources_controller_spec.rb
@@ -9,6 +9,8 @@ describe Krikri::HarvestSourcesController, :type => :controller do
   end
 
   describe '#show' do
+    login_user
+
     it 'assigns the requested harvest source to @harvest_source' do
       get :show, id: @harvest_sources_factory.id
       expect(assigns(:harvest_source)).to eq(@harvest_sources_factory)

--- a/spec/controllers/institutions_controller_spec.rb
+++ b/spec/controllers/institutions_controller_spec.rb
@@ -15,6 +15,7 @@ describe Krikri::InstitutionsController, :type => :controller do
   end
 
   describe 'GET #index' do
+    login_user
 
     it 'assigns all institutions to @institutions' do
       get :index
@@ -29,6 +30,7 @@ describe Krikri::InstitutionsController, :type => :controller do
   end
 
   describe 'GET #show' do
+    login_user
 
     it 'assigns the requested institution to @institution' do
       get :show, id: @institutions_factory.id

--- a/spec/factories/krikri_users.rb
+++ b/spec/factories/krikri_users.rb
@@ -1,0 +1,7 @@
+
+FactoryGirl.define do
+  factory :krikri_user, class: Krikri::User do
+    email 'test@example.tld'
+    password 'abcabcabc'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'factory_girl_rails'
 require 'dpla/map/factories'
 require 'rdf/marmotta'
 
+require 'devise'
+
 Rails.backtrace_cleaner.remove_silencers!
 
 # Load support files
@@ -23,6 +25,10 @@ RSpec.configure do |config|
   config.mock_with :rspec
 
   config.include FactoryGirl::Syntax::Methods
+
+  # These are for ensuring that controller tests are authenticated:
+  config.include Devise::TestHelpers, type: :controller
+  config.extend ControllerMacros, type: :controller
 
   # use_transactional_fixtures is false to comply with database cleaner configs
   config.use_transactional_fixtures = false

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,10 @@
+
+module ControllerMacros
+  def login_user
+    before(:each) do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      user = FactoryGirl.create(:krikri_user)
+      sign_in user
+    end
+  end
+end


### PR DESCRIPTION
This changeset adds user-authentication awareness by way of the Devise gem.

See https://www.pivotaltracker.com/n/projects/1172184/stories/80648080

See https://github.com/dpla/heidrun/pull/3.  This mounts KriKri inside of Heiðrún and shows off its simple signup, login, and account-management pages.

I'm assuming that certain things, like token-based authentication and fleshing out the ACLs, are best implemented in other stories.  Right now, the basic request for logins is being satisfied.  The application controller's before_filter requires all KriKri requests to be authenticated.

The AclController is deliberately left incomplete, since another story will be created to deal with access control, probably after we've thought about our needs some more.
