### PR TITLE
Update to marmotta-jetty built on apache/marmotta@da254a79

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ require 'jettywrapper'
 
 import 'lib/tasks/jetty.rake'
 
-ZIP_URL = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-SNAPSHOT-20141115.zip"
+ZIP_URL = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-SNAPSHOT-da254a79.zip"
 
 desc "Run all specs in spec directory (excluding plugin specs) in an engine_cart-generated app"
 task :ci => ['jetty:clean', 'engine_cart:generate'] do


### PR DESCRIPTION
This brings Marmotta up to date against the current `HEAD` on their develop branch, inching us closer to the 3.3.0 release. 
