### PR TITLE
Update Marmotta to the 3.3.0 release candidate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ require 'jettywrapper'
 
 import 'lib/tasks/jetty.rake'
 
-ZIP_URL = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-SNAPSHOT-da254a79.zip"
+Jettywrapper.url = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-release-candidate.zip"
 
 desc "Run all specs in spec directory (excluding plugin specs) in an engine_cart-generated app"
 task :ci => ['jetty:clean', 'engine_cart:generate'] do


### PR DESCRIPTION
- Update Marmotta to the 3.3.0 release candidate
- Use new style jettywrapper configuration (as suggested by Justin Coyne)
