### PR TITLE
Add legacy MD5 Minter

### DIFF
--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -10,9 +10,4 @@ module Krikri
   autoload :OaiDcParser,    'krikri/parsers/oai_dc_parser'
   autoload :JsonParser,     'krikri/parsers/json_parser'
   autoload :ModsParser,     'krikri/parsers/mods_parser'
-
-  # Enrichments
-  autoload :Enrichment,       'krikri/enrichment'
-  autoload :FieldEnrichment,  'krikri/field_enrichment'
-  autoload :Enrichments,      'krikri/enrichments'
 end

--- a/lib/krikri/md5_minter.rb
+++ b/lib/krikri/md5_minter.rb
@@ -1,0 +1,14 @@
+module Krikri
+  module Md5Minter
+    def self.create(id, prefix = nil)
+      id = add_prefix(prefix.to_s, id) unless prefix.nil?
+      Digest::MD5.hexdigest(id)
+    end
+
+    private
+
+    def self.add_prefix(source, id)
+      "#{source}--#{id.strip.gsub(' ', '__')}"
+    end
+  end
+end

--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -5,7 +5,7 @@ describe Krikri::Harvester do
   # Our subject is an instance of a dummy class that mixes in
   # Krikri::Harvester.
   let(:klass) { Class.new }
-  subject { klass.include(Krikri::Harvester).new }
+  subject { klass.include(Krikri::Harvester).new(:uri => 'urn:fake_uri') }
 
   context 'with record_ids implemented' do
     before do

--- a/spec/lib/krikri/md5_minter_spec.rb
+++ b/spec/lib/krikri/md5_minter_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Krikri::Md5Minter do
+  describe '#create' do
+    let(:ids) do
+      [{ source: 'nypl',
+         id: '5e66b3e8-fb4b-d471-e040-e00a180654d7',
+         result: 'a87d1e31a525df9d3bde91e8320e908d' },
+       { source: 'getty',
+         id: 'GETTY_ROSETTAIE167555',
+         result: 'ad9543cb337d32c7e24675fee6cb9b7a' }
+      ]
+    end
+
+    it 'matches legacy identifier' do
+      ids.each do |item_id|
+        expect(described_class.create(item_id[:id], item_id[:source]))
+          .to eq item_id[:result]
+      end
+    end
+
+    it 'mints without prefix' do
+      expect(described_class.create(ids.first[:id]))
+        .to eq '5485b7d867192c9a0acd49f73e5f3282'
+    end
+
+    it 'mints with symbol prefix' do
+      expect(described_class.create(ids.first[:id], ids.first[:source].to_sym))
+        .to eq ids.first[:result]
+    end
+  end
+end


### PR DESCRIPTION
Submitting this for discussion.

Interested in ideas about more robust testing of edge cases for existing ID's. This needs to be able to replicate https://github.com/dpla/ingestion/blob/develop/lib/akamod/select-id.py#L55