### PR TITLE
Setup Guard & guard-rpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ gem 'rubocop', require: false
 
 gem 'database_cleaner', '~> 1.3.0', require: false
 
+group :development do
+  gem 'guard'
+  gem 'guard-rspec', require: false
+end
+
 file = File.expand_path('Gemfile',
                         ENV['ENGINE_CART_DESTINATION'] ||
                         ENV['RAILS_ROOT'] ||

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,15 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard 'rspec', :version => 2 do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/krikri.rb$})     { |m| "spec/krikri_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+  watch('config/routes.rb')                           { "spec/routing" }
+  watch('app/controllers/krikri/application_controller.rb')  { "spec/controllers" }
+end

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ To delete the sample institution and harvest source:
 
     rake krikri:delete_sample_institution
 
+Guard is configured with RSpec; you can run `guard` to enable specs to run as
+configured in the `Guardfile`.
+
 Known Issues
 ------------
 

--- a/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
@@ -1,0 +1,21 @@
+describe Krikri::MappingDSL::ChildDeclaration do
+  include_context 'mapping dsl'
+  it_behaves_like 'a named property'
+  subject { described_class.new(:my_property, klass) {} }
+  let(:klass) { double }
+
+  describe '#to_proc' do
+    let(:mapping) { double }
+    let(:target) { double }
+
+    before do
+      allow(::Krikri::Mapping).to receive(:new).and_return(mapping)
+      allow(mapping).to receive(:process_record).with('').and_return(:value)
+    end
+
+    it 'returns a proc' do
+      expect(target).to receive(:my_property=).with(:value)
+      subject.to_proc.call(target, '')
+    end
+  end
+end

--- a/spec/lib/krikri/mapping_dsl/property_declaration_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/property_declaration_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe Krikri::MappingDSL::PropertyDeclaration do
+  include_context 'mapping dsl'
+  it_behaves_like 'a named property'
+  it_behaves_like 'a valued property'
+
+  subject { described_class.new(:my_property, value) }
+
+  describe '#to_proc' do
+    shared_context 'mapped property' do
+      before do
+        expect(mapped).to receive(:my_property=).with(value)
+      end
+      let(:mapped) { double }
+    end
+
+    shared_context 'property block' do
+      subject do
+        described_class.new(:my_property, start_value) do |v|
+          v.upcase
+        end
+      end
+      let(:start_value) do
+        return value.map(&:downcase) if value.is_a? Enumerable
+        value.downcase
+      end
+    end
+
+    shared_examples 'a property value' do
+      it 'gives a proc that sets value' do
+        subject.to_proc.call(mapped, '')
+      end
+    end
+
+    context 'static' do
+      include_context 'mapped property'
+      it_behaves_like 'a property value'
+    end
+
+    context 'with multiple values' do
+      include_context 'mapped property'
+      it_behaves_like 'a property value'
+
+      let(:value) { %w('value_1', 'value_2') }
+
+      context 'with block of arity 1' do
+        include_context 'property block'
+        it_behaves_like 'a property value'
+
+        let(:value) { %w('value_1', 'value_2').map(&:upcase) }
+      end
+    end
+
+    context 'with block of arity 1' do
+      include_context 'mapped property'
+      include_context 'property block'
+      it_behaves_like 'a property value'
+
+      let(:value) { 'value'.upcase }
+    end
+
+    context 'with callable value' do
+      include_context 'mapped property'
+      it_behaves_like 'a property value'
+
+      before do
+        expect(proc_value).to receive(:call).and_return(value)
+      end
+
+      subject { described_class.new(:my_property, proc_value) }
+
+      let(:proc_value) { ->(_) {} }
+    end
+
+    context 'with block of wrong arity' do
+      subject do
+        described_class.new(:my_property, value) { |v, what| v + what }
+      end
+
+      it 'raises error' do
+        expect { subject.to_proc.call(nil, nil) }
+          .to raise_error('Block must have arity of 1 to be applied to '\
+                          'property')
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/mapping_dsl_spec.rb
+++ b/spec/lib/krikri/mapping_dsl_spec.rb
@@ -1,19 +1,7 @@
 require 'spec_helper'
 
 describe Krikri::MappingDSL do
-  before do
-    # dummy class
-    class DummyMappingImplementation
-      include Krikri::MappingDSL
-    end
-  end
-
-  after do
-    Object.send(:remove_const, 'DummyMappingImplementation')
-  end
-
-  let(:mapping) { DummyMappingImplementation.new }
-  let(:value) { 'value' }
+  include_context 'mapping dsl'
 
   it 'knows it responds to missing methods' do
     expect(mapping.respond_to?(:blah)).to be true
@@ -75,125 +63,6 @@ describe Krikri::MappingDSL do
       mapping.properties.first.to_proc.call(mapped, '')
       expect(mapped.aggregatedCHO.first.creator.first.label)
         .to contain_exactly('Tove Jansson')
-    end
-  end
-
-  shared_examples 'a named property' do
-    it 'has name' do
-      expect(subject.name).to eq :my_property
-    end
-  end
-
-  shared_examples 'a valued property' do
-    it 'has value' do
-      expect(subject.value).to eq value
-    end
-  end
-
-  describe Krikri::MappingDSL::PropertyDeclaration do
-    it_behaves_like 'a named property'
-    it_behaves_like 'a valued property'
-
-    subject { described_class.new(:my_property, value) }
-
-    describe '#to_proc' do
-      shared_context 'mapped property' do
-        before do
-          expect(mapped).to receive(:my_property=).with(value)
-        end
-        let(:mapped) { double }
-      end
-
-      shared_context 'property block' do
-        subject do
-          described_class.new(:my_property, start_value) do |v|
-            v.upcase
-          end
-        end
-        let(:start_value) do
-          return value.map(&:downcase) if value.is_a? Enumerable
-          value.downcase
-        end
-      end
-
-      shared_examples 'a property value' do
-        it 'gives a proc that sets value' do
-          subject.to_proc.call(mapped, '')
-        end
-      end
-
-      context 'static' do
-        include_context 'mapped property'
-        it_behaves_like 'a property value'
-      end
-
-      context 'with multiple values' do
-        include_context 'mapped property'
-        it_behaves_like 'a property value'
-
-        let(:value) { %w('value_1', 'value_2') }
-
-        context 'with block of arity 1' do
-          include_context 'property block'
-          it_behaves_like 'a property value'
-
-          let(:value) { %w('value_1', 'value_2').map(&:upcase) }
-        end
-      end
-
-      context 'with block of arity 1' do
-        include_context 'mapped property'
-        include_context 'property block'
-        it_behaves_like 'a property value'
-
-        let(:value) { 'value'.upcase }
-      end
-
-      context 'with callable value' do
-        include_context 'mapped property'
-        it_behaves_like 'a property value'
-
-        before do
-          expect(proc_value).to receive(:call).and_return(value)
-        end
-
-        subject { described_class.new(:my_property, proc_value) }
-
-        let(:proc_value) { ->(_) {} }
-      end
-
-      context 'with block of wrong arity' do
-        subject do
-          described_class.new(:my_property, value) { |v, what| v + what }
-        end
-
-        it 'raises error' do
-          expect { subject.to_proc.call(nil, nil) }
-            .to raise_error('Block must have arity of 1 to be applied to '\
-                            'property')
-        end
-      end
-    end
-  end
-
-  describe Krikri::MappingDSL::ChildDeclaration do
-    it_behaves_like 'a named property'
-    subject { described_class.new(:my_property, klass) {} }
-    let(:klass) { double }
-
-    describe '#to_proc' do
-      let(:mapping) { double }
-      let(:target) { double }
-
-      before do
-        allow(::Krikri::Mapping).to receive(:new).and_return(mapping)
-        allow(mapping).to receive(:process_record).with('').and_return(:value)
-      end
-
-      it 'returns a proc' do
-        expect(target).to receive(:my_property=).with(:value)
-        subject.to_proc.call(target, '')
-      end
     end
   end
 end

--- a/spec/support/shared_contexts/mapping_dsl.rb
+++ b/spec/support/shared_contexts/mapping_dsl.rb
@@ -1,0 +1,16 @@
+shared_context 'mapping dsl' do
+  before do
+    # dummy class
+    class DummyMappingImplementation
+      include Krikri::MappingDSL
+    end
+  end
+
+  after do
+    Object.send(:remove_const, 'DummyMappingImplementation')
+  end
+
+  let(:mapping_class) { DummyMappingImplementation }
+  let(:mapping) { mapping_class.new }
+  let(:value) { 'value' }
+end

--- a/spec/support/shared_examples/mapping_dsl.rb
+++ b/spec/support/shared_examples/mapping_dsl.rb
@@ -1,0 +1,11 @@
+shared_examples 'a named property' do
+  it 'has name' do
+    expect(subject.name).to eq :my_property
+  end
+end
+
+shared_examples 'a valued property' do
+  it 'has value' do
+    expect(subject.value).to eq value
+  end
+end


### PR DESCRIPTION
Introduces Guard and slightly reorganizes specs for better consistency.

You can start Guard by running `bundle exec guard`. This should run all the Krikri specs and start file monitoring. Changing a given file will trigger a run of the relevant specs.
