### PR TITLE
Add vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.vagrant/
 log/*.log
 pkg/
 spec/dummy/db/*.sqlite3

--- a/README.md
+++ b/README.md
@@ -74,6 +74,49 @@ To delete the sample institution and harvest source:
 
     rake krikri:delete_sample_institution
 
+
+Using Vagrant for development (experimental)
+--------------------------------------------
+
+Prerequisites:
+
+* [VirtualBox](https://www.virtualbox.org/) (Version 4.3)
+* [Vagrant](http://www.vagrantup.com/) (Version 1.6)
+* [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest/) (`vagrant plugin install vagrant-vbguest`)
+* [Ansible](http://www.ansible.com/) (Version 1.7 or greater; [installation instructions](http://docs.ansible.com/intro_installation.html))
+
+
+For installation:
+
+    vagrant up
+    vagrant reload  # Because of o/s packages having been upgraded
+    vagrant ssh
+    cd /vagrant
+    bundle exec rake jetty:start
+    cd spec/internal
+    bundle exec rake krikri:index_sample_data
+    bundle exec rails s
+
+Then access the wrapper application at http://localhost:3000/
+
+From then on, to start things up, do:
+
+    vagrant up
+    vagrant ssh
+    cd /vagrant
+    bundle exec rake jetty:start
+    cd /vagrant/spec/internal
+    bundle exec rails s
+
+You may re-run the provisioning with `vagrant provision`.  This will
+clean and re-create the Jetty installation.  (So don't do it if you want to
+preserve your Marmotta or Solr.)  A future update will include more
+specific configuration and update tasks.
+
+
+Using Guard for tests
+---------------------
+
 Guard is configured with RSpec; you can run `guard` to enable specs to run as
 configured in the `Guardfile`.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+
+Vagrant.configure(2) do |config|
+  config.vm.define 'krikri' do |krikri|
+    krikri.vm.box = 'hashicorp/precise64'
+    krikri.vm.hostname = 'krikri'
+    krikri.vm.network :private_network, ip: '192.168.50.20'
+    krikri.vm.network "forwarded_port", guest: 8983, host: 8983
+    krikri.vm.network "forwarded_port", guest: 3000, host: 3000
+    krikri.vm.provider 'virtualbox' do |vb|
+      vb.memory = 1024
+    end
+    krikri.vm.provision 'ansible' do |ansible|
+      ansible.playbook = 'provisioning/provision.yml'
+    end
+  end
+end

--- a/provisioning/files/install_krikri.sh
+++ b/provisioning/files/install_krikri.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+USE_RUBY_VERSION=$1
+export PATH=$HOME/.rbenv/bin:$PATH
+
+eval "`rbenv init -`"
+cd /vagrant || exit 1
+rbenv global $USE_VERSION
+
+bundle install || exit 1
+rbenv rehash
+
+bundle exec rake jetty:stop 2>/dev/null
+bundle exec rake jetty:clean || bundle exec rake jetty:unzip
+if [ $? -ne 0 ]; then
+    >&2 echo "Could not clean or unzip Jetty"
+    exit 1
+fi
+bundle exec rake jetty:config
+if [ $? -ne 0 ]; then
+    >&2 echo "Could not configure Jetty"
+    exit 1
+fi
+bundle exec rake jetty:start || exit 1
+
+bundle exec rake engine_cart:clean && bundle exec rake engine_cart:generate
+if [ $? -ne 0 ]; then
+    >&2 echo "Could not generate wrapper application"
+    exit 1
+fi

--- a/provisioning/files/install_ruby_tools.sh
+++ b/provisioning/files/install_ruby_tools.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+USE_VERSION=$1
+
+cd $HOME
+
+if [ ! -d $HOME/.rbenv ]; then
+    git clone https://github.com/sstephenson/rbenv.git ~/.rbenv && \
+        echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc && \
+        echo 'eval "$(rbenv init -)"' >> ~/.bashrc && \
+        git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+fi
+export PATH=$HOME/.rbenv/bin:$PATH
+eval "$(rbenv init -)"
+
+if [ -d $HOME/.rbenv/versions/$USE_VERSION ]; then
+    export RBENV_VERSION=$USE_VERSION
+else
+    rbenv install $USE_VERSION
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+    export RBENV_VERSION=$USE_VERSION
+fi
+
+bundler=`gem list bundler | grep bundler`
+if [ -z "$bundler"]; then
+    gem install bundler
+else
+    gem update bundler
+fi
+rbenv rehash
+

--- a/provisioning/provision.yml
+++ b/provisioning/provision.yml
@@ -1,0 +1,28 @@
+---
+
+- hosts: all
+  sudo: yes
+  tasks:
+    - name: Upgrade o/s packages
+      apt: upgrade=safe update_cache=yes
+    - name: Ensure that necessary packages are installed
+      apt: >-
+        pkg="{{ item }}" state=present
+      with_items:
+        - curl
+        - unzip
+        - redis-server
+        - git
+        - g++
+        - sqlite3
+        - libsqlite3-dev
+        - openjdk-7-jdk
+
+- hosts: all
+  # do as "vagrant" user
+  sudo: no
+  tasks:
+    - name: Ensure that Ruby packages and tools are installed
+      script: files/install_ruby_tools.sh 2.1.3
+    - name: Install Krikri and friends
+      script: files/install_krikri.sh 2.1.3


### PR DESCRIPTION
Add a Vagrant configuration and provisioning via Ansible.

Spools up a VM with a generated wrapper application, Marmotta, and Solr.

Includes Redis.

The instructions in the README describe what to do.
