### PR TITLE
Pessimistically constrain sass-rails to match Rails 4.1 generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,11 @@ if File.exist?(file)
 else
   gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
-  # explicitly include sass-rails to get compatible sprocket dependencies
+  # explicitly include sass-rails to get compatible dependencies
   if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'] =~ /^4.2/
-    gem 'sass-rails', '>= 5.0.0.beta1'
+    gem 'sass-rails', '~> 5.0.0'
     gem 'responders', '~> 2.0'
   else
-    gem 'sass-rails'
+    gem 'sass-rails', '~> 4.0.3'
   end
 end

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -24,7 +24,7 @@ module Krikri
     # This must execute before run_required_generators
     def insert_jettywrapper_dependency
       append_to_file "Gemfile" do
-        "\n\n#KriKri uses Factory Girl to generate sample data
+        "\n\n# jettywrapper provides a Jetty container for Marmotta and Solr
         gem 'jettywrapper', '~>1.8.3', group: :development"
       end
     end


### PR DESCRIPTION
Since sass-rails 5.0.0 was released, Krikri's Bundler installation was using it by
default, despite the Rails 4.1 generator using ~> 4.0.3 as a pessimistic constraint.
This caused a conflict when generating a new app, such as the one created using
engine_cart to run tests in CI.

Also addresses a minor change in a comment added to the Gemfile created by the
generator.
