### PR TITLE
Add initial queueing mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ script: "bundle exec rake ci"
 rvm:
   - 2.1.3
 sudo: false
+services:
+  - redis-server

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Installation
    will have been added, and `bundle exec rails s` to check that the new
    resources are served.
 
+6. See [the Resque documentation](https://github.com/resque/resque/tree/1-x-stable)
+   on how to run queue workers.  There will be a console for the Resque job
+   queue available as '/resque' under the Krikri base path in your web
+   application.
+
 
 Development
 -----------

--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -1,24 +1,33 @@
 module Krikri
   ##
   # Activity wraps code execution with metadata about when it ran, which
-  # agents were responsible.
+  # agents were responsible.  It is designed to run a variety of different
+  # jobs, and its #run method is passed a block that performs the actual work.
+  # It records the start and end time of the job run, and provides the name of
+  # the agent to whomever needs it, but it does not care what kind of activity
+  # it is -- harvest, enrichment, etc.
   #
-  # The following example will run the block given, and return an
-  # Activity instance with the start and end times for the execution,
-  # and knowledge that `my_software_agent` was the responsible agent.
-  #
-  #     activity = Activity.new(my_software_agent) do
-  #       # code to run
-  #     end
-  #
-  # TODO: Support persistence
-  # TODO: should Activities be aware of which records (OriginalRecord,
-  #       DPLA::MAP::Aggregations) they operate on?
-  class Activity
-    attr_reader :start_time, :end_time, :agent
+  class Activity < ActiveRecord::Base
 
-    def initialize(agent)
-      @agent = agent
+    validate :agent_must_be_a_software_agent
+
+    def agent_must_be_a_software_agent
+      errors.add(:agent, 'does not represent a SoftwareAgent') unless
+        agent.constantize < Krikri::SoftwareAgent
+    end
+
+    def set_start_time
+      update_attribute(:start_time, DateTime.now.utc)
+    end
+
+    def set_end_time
+      now = DateTime.now.utc
+      fail 'Start time must exist and be before now to set an end time' unless
+        self[:start_time] && (self[:start_time] <= now)
+      update_attribute(:end_time, now)
+    end
+
+    def run
       if block_given?
         set_start_time
         yield
@@ -26,15 +35,5 @@ module Krikri
       end
     end
 
-    def set_start_time
-      @start_time = DateTime.now.utc
-    end
-
-    def set_end_time
-      now = DateTime.now
-      fail 'Start time must exist and be before now to set an end time' unless
-        start_time && (start_time <= now)
-      @end_time = now.utc
-    end
   end
 end

--- a/app/models/krikri/harvest_job.rb
+++ b/app/models/krikri/harvest_job.rb
@@ -1,0 +1,25 @@
+module Krikri
+  ##
+  # HarvestJob: perform enqueued Krikri::Harvesters jobs
+  #
+  # A HarvestJob is instantiated by the queue system and #perform is invoked
+  # to run the job.  The HarvestJob looks up an Activity that was created when
+  # the job was enqueued, and instantiates the particular Harvester that it
+  # specifies as its agent, and has the Activity run it.  This is necessary
+  # because the Activity is designed not to care about what kind of job it's
+  # running.
+  #
+  # @see Krikri::Activity
+  # @see https://github.com/resque/resque/tree/1-x-stable
+  #
+  class HarvestJob < Krikri::Job
+    @queue = :harvest
+    def self.perform(activity_id)
+      activity = Krikri::Activity.find(activity_id)
+      classname = activity['agent']
+      opts = JSON.parse(activity['opts'], symbolize_names: true)
+      harvester = classname.constantize.new(opts)
+      activity.run { harvester.run }
+    end
+  end
+end

--- a/app/models/krikri/harvester.rb
+++ b/app/models/krikri/harvester.rb
@@ -21,10 +21,11 @@ module Krikri
   #      Enumerable returned by #record_ids. If not, it is strongly
   #      recommended to override this method in your subclass with
   #      an efficient implementation.
-  #    - #run. Wraps persistence of each record returned by #records
-  #      in an Activity to run a full harvest.
+  #    - #run. Wraps persistence of each record returned by #records.
+  #      Runs a full harvest, inserting Original Records into the database,
+  #      given the options passed to #initialize.
   class Harvester
-    extend SoftwareAgent
+    include SoftwareAgent
 
     ##
     # @abstract Provide a low-memory, lazy enumerable for record ids.
@@ -65,14 +66,17 @@ module Krikri
     end
 
     ##
-    # Creates a harvest activity and runs harvest.
+    # Run the harvest.
     # This should be idempotent so it can be safely retried on errors.
     #
     # @return [Boolean]
     def run
-      Krikri::Activity.new(self) do
-        records.each(&:save)
-      end
+      mname = self.class.to_s + '#' + __method__.to_s
+      Rails.logger.debug(mname + ' is running')
+      records.each(&:save)
+      Rails.logger.debug(mname + ' is done')
+      true
     end
+
   end
 end

--- a/app/models/krikri/job.rb
+++ b/app/models/krikri/job.rb
@@ -1,0 +1,13 @@
+module Krikri
+  ##
+  # Generic Job class the gets extended by specific types of Jobs;
+  # Harvest, Enrichment, etc.
+  class Job
+    @queue = nil
+    ##
+    # @abstract Perform the job; called by the queue system
+    def self.perform(*)
+      fail NotImplementedError
+    end
+  end
+end

--- a/app/models/krikri/software_agent.rb
+++ b/app/models/krikri/software_agent.rb
@@ -3,10 +3,71 @@ module Krikri
   # SoftwareAgent is a mixin for logic common to code that generates a
   # Krikri::Activity.
   #
-  # TODO: Figure out what, if anything, agents need to know about
-  #   themselves. They will likely have names or versions or some such.
-  #   If not, remove this module.
   module SoftwareAgent
     extend ActiveSupport::Concern
+
+    ##
+    # Return an agent name suitable for saving in an Activity.
+    # This is the name of the most-derived class upon which this is invoked.
+    # @see Krikri::Activity
+    def agent_name
+      self.class.to_s
+    end
+
+    ##
+    # @abstract Perform this agent's work
+    # @return [Boolean]
+    def run
+      fail NotImplementedError
+    end
+
+    ##
+    # Class methods for extension by ActiveSupport::Concern
+    module ClassMethods
+
+      ##
+      # @see SoftwareAgent#agent_name
+      def agent_name
+        to_s
+      end
+
+      ##
+      # Enqueue a job.
+      #
+      # Example:
+      #
+      #   Krikri::Harvesters::OAIHarvester.enqueue(
+      #     Krikri::HarvestJob,
+      #     opts = {
+      #       endpoint: 'http://vcoai.lib.harvard.edu/vcoai/vc',
+      #       set: 'dag'
+      #     }
+      #   )
+      #
+      # A worker process must be started to process jobs in the "harvest"
+      # queue, either before or after they are enqueued:
+      #
+      #  shell$ QUEUE=harvest bundle exec rake environment resque:work
+      #
+      # This depends on Redis and Marmotta being available and properly
+      # configured (if necessary) in the Rails app.
+      #
+      # @see https://github.com/resque/resque/tree/1-x-stable
+      # @see Krikri::HarvestJob
+      # @see Krikri::SoftwareAgent#agent_name
+      # @return [Boolean]
+      def enqueue(job_class, opts = {})
+        fail 'the given class has no #perform method' \
+          unless job_class.respond_to?(:perform)
+        fail 'opts is not a hash' unless opts.is_a?(Hash)
+        activity = Krikri::Activity.create do |a|
+          a.agent = agent_name
+          a.opts = JSON.generate(opts)
+        end
+        Resque.enqueue(job_class, activity.id)
+      end
+
+    end
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+require 'resque/server'
 
 Krikri::Engine.routes.draw do
   # TODO: remove unnecessary :harvest_sources and :institutions routes once we
@@ -5,4 +6,5 @@ Krikri::Engine.routes.draw do
   resources :institutions do
     resources :harvest_sources, shallow: true
   end
+  mount Resque::Server.new, at: '/resque'
 end

--- a/db/migrate/20141212220924_create_krikri_activities.rb
+++ b/db/migrate/20141212220924_create_krikri_activities.rb
@@ -1,0 +1,11 @@
+class CreateKrikriActivities < ActiveRecord::Migration
+  def change
+    create_table :krikri_activities do |t|
+      t.datetime :start_time
+      t.datetime :end_time
+      t.string :agent
+      t.string :opts
+      t.timestamps
+    end
+  end
+end

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "oai"
 
   s.add_dependency "devise", "~>3.4.1"
+  s.add_dependency "resque", "~>1.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper"
@@ -34,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'
+  s.add_development_dependency 'timecop'
 end

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -6,6 +6,8 @@ require 'dpla/map'
 require 'rdf/marmotta'
 require 'oai/client'
 
+require 'resque'
+
 module Krikri
   ##
   # Krikri provides metadata aggregation and enhancement services.

--- a/lib/tasks/krikri.rake
+++ b/lib/tasks/krikri.rake
@@ -2,6 +2,7 @@ require 'factory_girl_rails'
 include FactoryGirl::Syntax::Methods
 require 'dpla/map/factories'
 require 'open-uri'
+require 'resque/tasks'
 
 namespace :krikri do
 

--- a/spec/factories/krikri_activities.rb
+++ b/spec/factories/krikri_activities.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+
+  factory :krikri_activity, class: Krikri::Activity do
+    agent 'Krikri::Harvesters::OAIHarvester'
+    opts '{"endpoint": "http://example.org/endpoint", ' \
+         ' "metadata_prefix": "mods"}'
+  end
+
+end

--- a/spec/models/harvest_job_spec.rb
+++ b/spec/models/harvest_job_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Krikri::HarvestJob do
+  let(:activity) { create(:krikri_activity) }
+  describe '#perform' do
+    before do
+      expect_any_instance_of(Krikri::Harvester)
+        .to receive(:run)
+        .and_return(true)
+    end
+    it 'runs a harvest' do
+      expect { Krikri::HarvestJob.perform(activity.id) }.not_to raise_error
+    end
+    it 'causes activity timestamps to be correctly modified' do
+      Krikri::HarvestJob.perform(activity.id)
+      activity.reload
+      expect(activity.end_time).to be_within(1.second).of(DateTime.now)
+    end
+  end
+end

--- a/spec/models/harvesters/oai_harvester_spec.rb
+++ b/spec/models/harvesters/oai_harvester_spec.rb
@@ -208,6 +208,24 @@ describe Krikri::Harvesters::OAIHarvester do
       end
     end
 
+    describe '#enqueue' do
+      let(:args) do
+        {endpoint: 'http://example.org/endpoint', metadata_prefix: 'mods'}
+      end
+      before do
+        Resque.remove_queue('harvest')  # Not strictly necessary. Future?
+        Krikri::Activity.delete_all
+      end
+      it 'saves harvest options correctly when creating an activity' do
+        # Ascertain that options particular to this harvester type are
+        # serialized and deserialized properly.
+        described_class.enqueue(Krikri::HarvestJob, opts = args)
+        activity = Krikri::Activity.first
+        opts = JSON.parse(activity.opts, symbolize_names: true)
+        expect(opts).to eq(args)
+      end
+    end
+
     it_behaves_like 'a harvester'
   end
 end

--- a/spec/models/software_agent_spec.rb
+++ b/spec/models/software_agent_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Krikri::SoftwareAgent do
+
+  it 'represents its agent name as the correct string, as a class' do
+    expect(Krikri::Harvester.agent_name).to eq('Krikri::Harvester')
+  end
+
+  it 'represents its agent name as the correct string, as an instance' do
+    h = Krikri::Harvester.new
+    expect(h.agent_name).to eq('Krikri::Harvester')
+  end
+
+  describe '#enqueue' do
+    let(:args) do
+      { endpoint: 'http://example.org/endpoint', metadata_prefix: 'mods' }
+    end
+    # Use these classes as representatives for the tests
+    let(:agent_class) { Krikri::Harvester }
+    let(:job_class) { Krikri::HarvestJob }
+    let(:queue_name) { job_class.instance_variable_get('@queue') }
+    before do
+      Resque.remove_queue(queue_name)
+      Krikri::Activity.delete_all
+    end
+    it 'enqueues a job' do
+      agent_class.enqueue(job_class, args)
+      expect(Resque.size(queue_name)).to eq(1)
+    end
+    it 'creates a new activity when it enqueues a job' do
+      agent_class.enqueue(job_class, args)
+      expect(Krikri::Activity.count).to eq(1)
+    end
+  end
+
+end

--- a/spec/support/shared_examples/harvester.rb
+++ b/spec/support/shared_examples/harvester.rb
@@ -57,12 +57,6 @@ shared_examples 'a harvester' do
   end
 
   describe '#run' do
-    it 'runs as an Activity' do
-      allow_any_instance_of(Krikri::OriginalRecord).to receive(:save)
-        .and_return(true)
-      expect(harvester.run).to be_a Krikri::Activity
-    end
-
     it 'saves the OriginalRecords' do
       # TODO: Is this fragile? Should it change when original records have
       #   persistence?


### PR DESCRIPTION
Here's a checkpoint pull request.  This is a work in progress but it will
be good to get these changes in before too much piles up on this branch.

This changeset adds a general queueing mechanism and a specific implementation of harvest queueing, using Resque.

A Resque control panel has been routed on top of the Krikri application's base path.

The tests in spec/models and the comment in Krikri::SoftwareAgent describe how harvest jobs are put onto the queue and run.

STILL TO DO:
- Have the Activity that persists and records the timeframe of the harvest job
  get updated if the job fails.  The only way to manage the failure queue is
  currently with the Resque web console (e.g. "/krikri/resque") or with the 
  Rails console.  The Krikri application is going to have to do this, too.
- Model the higher-level event that encompasses the harvest job.
  For a provider that has multiple sets or collections, a harvest job will
  probably be run for each set.  How does the greater "harvest event" know when
  all of the collections are complete?  How does the greater ingestion process
  know when all of the harvests are done, and it's time to move on to
  enrichment?
- Provide http resources (HTML u.i. and JSON API) to allow interaction with
  Krikri to create and manage harvests.
