### PR TITLE
Fix external requests on LDP::Resource

### DIFF
--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -49,10 +49,10 @@ module Krikri
 
     def ==(other)
       return false unless other.is_a? OriginalRecord
-      return false unless etag == other.etag
-      return false unless content == other.content
       return false unless local_name == other.local_name
+      return false unless content == other.content
       return false unless content_type == other.content_type
+      return false unless etag == other.etag
       true
     end
 

--- a/spec/ldp/resource_spec.rb
+++ b/spec/ldp/resource_spec.rb
@@ -99,6 +99,26 @@ describe Krikri::LDP::Resource do
     end
 
     describe '#delete!' do
+      context 'before saved' do
+        it 'raises an error' do
+          expect { subject.delete! }
+            .to raise_error('Cannot delete ' \
+                            "#{subject.rdf_subject}, does not exist.")
+        end
+      end
+
+      context 'with saved object' do
+        before { subject.save }
+
+        it 'deletes object from LDP endpoint' do
+          expect(subject.delete!.env.status).to eq 204
+        end
+
+        it 'no longer exists' do
+          subject.delete!
+          expect(subject).not_to exist
+        end
+      end
     end
 
     describe '#exist?' do
@@ -109,6 +129,22 @@ describe Krikri::LDP::Resource do
       it 'knows when it does exist' do
         subject.save
         expect(subject).to exist
+      end
+    end
+
+    describe '#etag' do
+      context 'before saved' do
+        it 'returns nil' do
+          expect(subject.etag).to be_nil
+        end
+      end
+
+      context 'with etag' do
+        before { subject.save }
+
+        it 'returns an etag' do
+          expect(subject.etag).to be_a String
+        end
       end
     end
   end

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -60,6 +60,45 @@ describe Krikri::OriginalRecord do
     end
   end
 
+  describe '#==' do
+    let(:other) { subject.clone }
+
+    it 'gives equality for equivalent objects' do
+      expect(subject == other).to be true
+    end
+
+    shared_examples 'is false' do
+      it 'compares false' do
+        expect(subject == other).to be false
+      end
+    end
+
+    context 'when comparing wrong type' do
+      let(:other) { Object.new }
+      include_examples 'is false'
+    end
+
+    context 'when one object is saved' do
+      before { other.save }
+      include_examples 'is false'
+    end
+
+    context'when local name is different' do
+      before { other.local_name = 'new_mummi' }
+      include_examples 'is false'
+    end
+
+    context 'content is different' do
+      before { other.content = 'new_mummi_content' }
+      include_examples 'is false'
+    end
+
+    context 'content_type is different' do
+      before { other.content_type = 'application/xml+moomin' }
+      include_examples 'is false'
+    end
+  end
+
   context 'with string input' do
     let(:record) { '<record><title>Comet in Moominland</title></record>' }
 


### PR DESCRIPTION
Avoid LDP requests for etags, etc... on non-existing resources. Fix Resource#delete (which was not fully implemented.

Test `OriginalRecord#==`.
