### PR TITLE
JSON parser

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,9 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency "rdf-marmotta", '>= 0.0.2'
   s.add_dependency "blacklight", ">= 5.3.0"
   s.add_dependency "therubyracer"
-
   s.add_dependency "oai"
-
+  s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"
   s.add_dependency "resque", "~>1.0"
 

--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -8,4 +8,5 @@ module Krikri
   autoload :XmlParser,      'krikri/parsers/xml_parser'
   # autoload Krikri::OaiDcParser
   autoload :OaiDcParser,    'krikri/parsers/oai_dc_parser'
+  autoload :JsonParser,     'krikri/parsers/json_parser'
 end

--- a/lib/krikri/parsers/json_parser.rb
+++ b/lib/krikri/parsers/json_parser.rb
@@ -1,0 +1,65 @@
+require 'jsonpath'
+
+module Krikri
+  ##
+  # JsonParser
+  # @see Krikri::Parser
+  class JsonParser < Krikri::Parser
+    ##
+    # @param record [Krikri::OriginalRecord] a record whose properties can
+    # be parsed by the parser instance.
+    # @param root_path [String] JsonPath that identifies the root path for
+    # the desired parse root.
+    # @see http://goessner.net/articles/JsonPath/ JsonPath
+    def initialize(record, root_path = '$')
+      @root = Value.new(JsonPath.on(record.content, root_path).first)
+      super(record)
+    end
+
+    ##
+    # JsonParser::Value
+    # @see Krikri::Parser::Value
+    class Value < Krikri::Parser::Value
+      attr_accessor :node
+
+      def initialize(node)
+        @node = node
+      end
+
+      def attributes
+        raise NotImplementedError, 'Attributes are not supported for JSON'
+      end
+
+      def children
+        @node.is_a?(Hash) ? @node.keys : []
+      end
+
+      def value
+        @node.is_a?(Hash) ? nil : @node
+      end
+
+      def values?
+        !select_values.empty?
+      end
+
+      private
+
+      def get_child_nodes(name)
+        if @node[name].is_a?(Array)
+          @node[name].map { |node| self.class.new(node) }
+        else
+          Array.new([self.class.new(@node[name])])
+        end
+      end
+
+      def attribute(name)
+        msg = "Attributes are not supported for JSON; got attribute `#{name}`"
+        raise NotImplementedError, msg
+      end
+
+      def select_values
+        @node.is_a?(Hash) ? [] : @node
+      end
+    end
+  end
+end

--- a/spec/factories/krikri_original_record.rb
+++ b/spec/factories/krikri_original_record.rb
@@ -6,7 +6,8 @@ FactoryGirl.define do
   end
 
   factory :oai_dc_record, parent: :krikri_original_record do
-    content '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014v-10-27T22:19:17Z</responseDate><request verb="GetRecord" identifier="oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><GetRecord><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+    content <<-EOS
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014v-10-27T22:19:17Z</responseDate><request verb="GetRecord" identifier="oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><GetRecord><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
    <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
    <dc:creator>Bart Besamusca</dc:creator>
    <dc:creator>Tove Jansson</dc:creator>
@@ -16,21 +17,25 @@ FactoryGirl.define do
    <dc:contributor>Bart Besamusca</dc:contributor>
    <dc:type>model</dc:type>
    <dc:language>eng</dc:language>
-</oai_dc:dc></metadata></record></GetRecord></OAI-PMH>'
+</oai_dc:dc></metadata></record></GetRecord></OAI-PMH>
+EOS
   end
 
   factory :json_record, parent: :krikri_original_record do
+    initialize_with { new('456') }
     rec = {
-      'creator' => 'Tove Jansson',
+      'creator' => ['Tove Jansson', 'Moomintroll'],
       'title' => 'Christmas in Moominvalley',
       'subject' => 'Moomin Papa',
       'identifier' => 'https://example.org/moomin/M00000000M1N',
       'date' => '2012-07-13T14:27:31Z',
       'language' => 'eng',
       'contributor' => [{ 'name' => 'Snorkmaiden',
-                          'role' => 'Actor (leading role)'},
+                          'role' => 'Actor (leading role)' },
                         { 'name' => 'Snufkin',
-                          'role' => 'Director'}]
+                          'role' => 'Director' }],
+      'translations' => { 'se' => 'Jul i Mumindalen',
+                          'fi' => 'Muumilaakson joulu' }
     }
 
     content rec.to_json

--- a/spec/lib/krikri/parsers/json_parser_spec.rb
+++ b/spec/lib/krikri/parsers/json_parser_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Krikri::JsonParser do
+  subject { Krikri::JsonParser.new(record) }
+  let(:record) { build(:json_record) }
+
+  it_behaves_like 'a parser'
+
+  context 'with a root path that specifies an array' do
+    subject { Krikri::JsonParser.new(record, '$.contributor') }
+    it_behaves_like 'a parser'
+  end
+
+  context 'with a root path with that specifies a key in an array' do
+    subject { Krikri::JsonParser.new(record, '$.contributor[0]') }
+    it_behaves_like 'a parser'
+  end
+
+  context 'with a root path that specifies an object' do
+    subject { Krikri::JsonParser.new(record, '$.translations') }
+    it_behaves_like 'a parser'
+  end
+end
+
+describe Krikri::JsonParser::Value do
+  subject { Krikri::JsonParser.new(record).root }
+  let(:record) { build(:json_record) }
+
+  it_behaves_like 'a parser value'
+end

--- a/spec/lib/krikri/parsers/xml_parser_spec.rb
+++ b/spec/lib/krikri/parsers/xml_parser_spec.rb
@@ -18,4 +18,5 @@ describe Krikri::XmlParser::Value do
   let(:record) { build(:oai_dc_record) }
 
   it_behaves_like 'a parser value'
+  it_behaves_like 'a parser value that has attributes'
 end

--- a/spec/support/shared_examples/parser.rb
+++ b/spec/support/shared_examples/parser.rb
@@ -15,6 +15,46 @@ shared_examples_for 'a parser value' do
   let(:child) { value.children.first }
   let(:attr) { value.attributes.first }
 
+  describe '#children' do
+    it 'has children' do
+      expect(value.children).to all(be_a(String))
+    end
+  end
+
+  describe '#[]' do
+    it 'retrieves a child node' do
+      expect(value[child]).to include(an_instance_of(described_class))
+    end
+  end
+
+  describe '#child?' do
+    it 'knows its children' do
+      expect(value.child?(child)).to be true
+    end
+
+    it 'knows its non-children' do
+      expect(value.child?(:fake)).to be false
+    end
+  end
+
+  describe '#value' do
+    it 'gives a datatype representation' do
+      expect(value[child].first.value).to respond_to :to_s
+    end
+  end
+
+  describe '#values?' do
+    it 'has typed values' do
+      expect(value[child].first.values?).to be true
+    end
+  end
+end
+
+shared_examples_for 'a parser value that has attributes' do
+  let(:value) { subject || described_class.new }
+  let(:child) { value.children.first }
+  let(:attr) { value.attributes.first }
+
   describe '#attributes' do
     it 'has an attribute list as symbols' do
       expect(value.attributes).to all(be_a(Symbol))
@@ -38,34 +78,6 @@ shared_examples_for 'a parser value' do
 
     it 'raises not found if attribute does not exist' do
       expect { value.send(:fake) }.to raise_error NoMethodError
-    end
-  end
-
-  describe '#children' do
-    it 'has children' do
-      expect(value.children).to all(be_a(String))
-    end
-  end
-
-  describe '#[]' do
-    it 'retrieves a child node' do
-      expect(value[child]).to contain_exactly(an_instance_of(described_class))
-    end
-  end
-
-  describe '#child?' do
-    it 'knows its children' do
-      expect(value.child?(child)).to be true
-    end
-
-    it 'knows its non-children' do
-      expect(value.child?(:fake)).to be false
-    end
-  end
-
-  describe '#value' do
-    it 'gives a datatype representation' do
-      expect(value[child].first.value).to respond_to :to_s
     end
   end
 end


### PR DESCRIPTION
Here's a first attempt at a JSON parser. Notes:
- It probably needs documentation.
- This quickly proved to be a bit fiddly when I first tried to use [jsonpath](https://github.com/joshbuddy/jsonpath). I abandoned that strategy, but jsonpath might still be useful when we get to needing to map JSON data in the DSL.
- I'm not sure if the behavior in `Krikri::JsonParser#get_child_nodes` is exactly desirable - it was an attempt to "sanely" handle the fact that JSON natively has an array datatype, unlike XML. 
- I rearranged the parser specs; there maybe a more idiomatic way to do this in rspec land, so feedback there is welcome too.
