### PR TITLE
Change default MIME Type for Original Records

### DIFF
--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -14,7 +14,7 @@ module Krikri
     class << self
       def load(identifier)
         record = new(identifier)
-        raise 'No #{self} found with id: identifier' unless record.exists?
+        raise "No #{self} found with id: identifier" unless record.exists?
         record.rdf_subject = nr_uri_from_headers(record.http_head)
         record.reload
       end

--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -61,7 +61,7 @@ module Krikri
     end
 
     def content_type
-      @content_type || 'application/octet-stream'
+      @content_type || 'text/xml'
     end
 
     ##

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -147,9 +147,10 @@ describe Krikri::OriginalRecord do
 
     it 'reloads content_type' do
       subject.save
+      ctype = subject.content_type
       subject.content_type = 'application/xml'
       subject.reload
-      expect(subject.content_type).to eq 'application/octet-stream'
+      expect(subject.content_type).to eq ctype
     end
   end
 


### PR DESCRIPTION
Marmotta assigns file extensions based on content type. The octet stream MIME Type causes OriginalRecords to have the `.bin` extension. This changes the default MIME to `text/xml` so the default extension will be `.xml`.

Note that Marmotta infers that `application/xml`, `text/plain`, and some other types are RDF Sources.

An unrelated minor fix I spotted while working on this is included as a separate commit.  I can rebase this into another branch/PR if desired.
