### PR TITLE
Add discovery of Harvester options

### DIFF
--- a/db/migrate/20150106164218_add_opts_to_krikri_harvest_sources.rb
+++ b/db/migrate/20150106164218_add_opts_to_krikri_harvest_sources.rb
@@ -1,0 +1,5 @@
+class AddOptsToKrikriHarvestSources < ActiveRecord::Migration
+  def change
+    add_column :krikri_harvest_sources, :opts, :text
+  end
+end

--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -88,5 +88,42 @@ module Krikri
     # An application-wide registry of defined Harvesters.
     Registry = Class.new(Krikri::Registry)
 
+    ##
+    # @abstract Return initialization options for the harvester.
+    #   The harvester will expect to receive these upon instantiation (in the
+    #   opts argument to #initialize), in the form:
+    #   {
+    #      key: <symbol for this harvester>,
+    #      opts: {
+    #        option_name: {type: :type, required: <boolean>,
+    #                      multiple_ok: <boolean, default false>}
+    #      }
+    #   }
+    #   ... where type could be :uri, :string, :int, etc.
+    #   ... and multiple_ok means whether it's allowed to be an array
+    #   ... for example, for OAI this might be:
+    #   {key: :oai,
+    #    set: {type: :string, required: false, multiple_ok: true},
+    #    metadata_prefix: {type: string, required: true}}
+    #
+    # @todo The actual type token values and how they'll be used is to be
+    #   determined, but something should exist for providing validation
+    #   guidelines to a client so it doesn't have to have inside knowledge of
+    #   the harvester's code.
+    #
+    # @note The options are going to vary between harvesters.  Some options
+    #   are going to be constant for the whole harvest, and some are going to
+    #   be lists that get iterated over.  For example, a set or collection.
+    #   There will be an ingestion event where we want multiple jobs enqueued,
+    #   one per set or collection.  The one option (a list) that would vary
+    #   from harvest job to harvest job might be 'set' (in the case of OAI).
+    #   This method doesn't solve how that's going to happen, but simply
+    #   provides, as a convenience, the options that the harvester wants to
+    #   see.
+    #
+    def self.expected_opts
+      raise NotImplementedError
+    end
+
   end
 end

--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -10,10 +10,15 @@ module Krikri::Harvesters
     #   Allowable options are specified in OAI::Const::Verbs. Currently :from,
     #   :until, :set, and :metadata_prefix.
     # @see OAI::Client
+    # @see #expected_opts
     def initialize(opts = {})
-      endpoint = opts.delete(:endpoint)
-      @opts = opts
-      @client = OAI::Client.new(endpoint)
+      uri = opts.delete(:uri)
+      if opts.include?(:oai)
+        @opts = opts[:oai]
+      else
+        @opts = {}
+      end
+      @client = OAI::Client.new(uri)
     end
 
     ##
@@ -59,5 +64,18 @@ module Krikri::Harvesters
         .build(identifier,
                client.get_record(opts).doc.to_s)
     end
+
+    ##
+    # @see Krikri::Harvester::expected_opts
+    def self.expected_opts
+      {
+        key: :oai,
+        opts: {
+          set: {type: :string, required: false, multiple_ok: true},
+          metadata_prefix: {type: :string, required: true}
+        }
+      }
+    end
+
   end
 end

--- a/lib/krikri/software_agent.rb
+++ b/lib/krikri/software_agent.rb
@@ -58,8 +58,8 @@ module Krikri
       #   Krikri::Harvesters::OAIHarvester.enqueue(
       #     Krikri::HarvestJob,
       #     opts = {
-      #       endpoint: 'http://vcoai.lib.harvard.edu/vcoai/vc',
-      #       set: 'dag'
+      #       uri: 'http://vcoai.lib.harvard.edu/vcoai/vc',
+      #       oai: { set: 'dag', metadata_prefix: 'mods' }
       #     }
       #   )
       #
@@ -74,6 +74,7 @@ module Krikri
       # @see https://github.com/resque/resque/tree/1-x-stable
       # @see Krikri::HarvestJob
       # @see Krikri::SoftwareAgent#agent_name
+      # @see Krikri::Harvester::expected_opts
       # @return [Boolean]
       def enqueue(job_class, opts = {})
         fail "#{job_class} has no #perform method" unless

--- a/spec/factories/krikri_activities.rb
+++ b/spec/factories/krikri_activities.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
 
   factory :krikri_activity, class: Krikri::Activity do
     agent 'Krikri::Harvesters::OAIHarvester'
-    opts '{"endpoint": "http://example.org/endpoint", ' \
-         ' "metadata_prefix": "mods"}'
+    opts '{"uri": "http://example.org/endpoint", ' \
+         '"oai": {"metadata_prefix": "mods", "set": "set1"}}'
   end
 
 end

--- a/spec/factories/krikri_harvest_sources.rb
+++ b/spec/factories/krikri_harvest_sources.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     source_type 'OAI'
     metadata_schema 'MARC'
     uri 'http://www.example.com'
+    opts '{"set": "set1"}'
     notes 'These are notes about the Krikri Sample Source.'
     association :institution, factory: :krikri_institution
   end

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe Krikri::Harvesters::OAIHarvester do
 
-  let(:args) { { endpoint: 'http://example.org/endpoint' } }
+  let(:args) { { uri: 'http://example.org/endpoint' } }
   subject { described_class.new(args) }
 
   it 'has a client' do
@@ -136,7 +136,7 @@ describe Krikri::Harvesters::OAIHarvester do
     describe 'options' do
       let(:result) { double }
       let(:args) do
-        {endpoint: 'http://example.org/endpoint', metadata_prefix: 'mods'}
+        {uri: 'http://example.org/endpoint', oai: {metadata_prefix: 'mods'}}
       end
       let(:request_opts) { {set: 'moomin'} }
 
@@ -149,13 +149,13 @@ describe Krikri::Harvesters::OAIHarvester do
       shared_examples 'send options' do
         it 'sends request with option' do
           expect(subject.client).to receive(request_type)
-            .with(:metadata_prefix => args[:metadata_prefix])
+            .with(:metadata_prefix => args[:oai][:metadata_prefix])
             .and_return(result)
           subject.send(method)
         end
         it 'adds options passed into request' do
           expect(subject.client).to receive(request_type)
-            .with(:metadata_prefix => args[:metadata_prefix],
+            .with(:metadata_prefix => args[:oai][:metadata_prefix],
                   :set => request_opts[:set])
             .and_return(result)
           subject.send(method, request_opts)
@@ -189,7 +189,7 @@ describe Krikri::Harvesters::OAIHarvester do
         it 'sends request with option' do
           expect(subject.client).to receive(request_type)
             .with(:identifier => identifier,
-                  :metadata_prefix => args[:metadata_prefix])
+                  :metadata_prefix => args[:oai][:metadata_prefix])
             .and_return(result)
           subject.get_record(identifier)
         end
@@ -197,7 +197,7 @@ describe Krikri::Harvesters::OAIHarvester do
         it 'adds options passed into request' do
           expect(subject.client).to receive(request_type)
             .with(:identifier => identifier,
-                  :metadata_prefix => args[:metadata_prefix],
+                  :metadata_prefix => args[:oai][:metadata_prefix],
                   :set => request_opts[:set])
             .and_return(result)
           subject.get_record(identifier, request_opts)
@@ -207,7 +207,7 @@ describe Krikri::Harvesters::OAIHarvester do
 
     describe '#enqueue' do
       let(:args) do
-        {endpoint: 'http://example.org/endpoint', metadata_prefix: 'mods'}
+        {uri: 'http://example.org/endpoint', oai: {metadata_prefix: 'mods'}}
       end
       before do
         Resque.remove_queue('harvest')  # Not strictly necessary. Future?

--- a/spec/lib/krikri/software_agent_spec.rb
+++ b/spec/lib/krikri/software_agent_spec.rb
@@ -10,13 +10,16 @@ describe Krikri::SoftwareAgent do
   end
 
   it 'represents its agent name as the correct string, as an instance' do
-    h = Krikri::Harvesters::OAIHarvester.new({endpoint: 'http://example.org/'})
+    h = Krikri::Harvesters::OAIHarvester.new({uri: 'http://example.org/'})
     expect(h.agent_name).to eq('Krikri::Harvesters::OAIHarvester')
   end
 
   describe '#enqueue' do
     let(:args) do
-      { endpoint: 'http://example.org/endpoint', metadata_prefix: 'mods' }
+      {
+        uri: 'http://example.org/endpoint',
+        oai: {metadata_prefix: 'mods', set: 'set1'}
+      }
     end
     # Use these classes as representatives for the tests
     let(:agent_class) { Krikri::Harvesters::OAIHarvester }


### PR DESCRIPTION
This adds an `opts` field to `HarvestSource` for storing serialized options that get passed to the harvester.  For example, a list of sets for an OAI harvester.

`Krikri::Harvester.expected_opts` has been added to help client code know what options to get from the user to store in `HarvestSource`.  See the comment below for that method.

OAIHarvester has also been changed to take 'uri' as an option instead of 'endpoint', to bring it inline with the HarvestSource model, which has a 'uri' field, not an 'endoint' field.

The next step, assuming this goes over well, is to make an Event that can read the `opts` in a HarvestSource and determine the right strategy for enqueueing jobs for the relevant harvester, e.g. do one harvest job for the whole harvest, or iterate over sets, using the same URI each time, etc.
