### PR TITLE
Ldp connection refused

### DIFF
--- a/lib/krikri/ldp/resource.rb
+++ b/lib/krikri/ldp/resource.rb
@@ -69,7 +69,7 @@ module Krikri::LDP
     rescue Faraday::ResourceNotFound
       false
     rescue Faraday::ClientError => e
-      return false if e.response[:status] == 410
+      return false if !e.response.nil? && e.response[:status] == 410
       raise e
     end
     alias_method :exist?, :exists?

--- a/spec/ldp/resource_spec.rb
+++ b/spec/ldp/resource_spec.rb
@@ -31,6 +31,21 @@ describe Krikri::LDP::Resource do
       RDF::Marmotta.new(Krikri::Settings['marmotta']['base']).clear!
     end
 
+    context 'without marmotta connection' do
+      before do
+        @real_connection = Krikri::Settings['marmotta']['ldp']
+        Krikri::Settings['marmotta']['ldp'] = 'http://localhost:0/marmotta/'
+      end
+
+      after do
+        Krikri::Settings['marmotta']['ldp'] = @real_connection
+      end
+
+      it 'raises an appropriate error' do
+        expect { subject.exists? }.to raise_error Faraday::ConnectionFailed
+      end
+    end
+
     describe '#save' do
       let(:response) { subject.save }
 


### PR DESCRIPTION
Connection Refused errors on LDP requests were being caught as ClientErrors, but do not have a `#response`, so were throwing no method on `nil` errors instead of something informative. This ensures that a useful error is always thrown.

I ran into this problem when messing around with `heidrun`.  I wrote a quick patch, and a test.  Maybe the test is a bit naive, since it relies on no activity on port 9999 on the host machine.  I couldn't find a way to get WebMock to mimic Connection Refused (with fairly minimal searching, I admit).