### PR TITLE
Normalize OAI output

### DIFF
--- a/spec/factories/krikri_original_record.rb
+++ b/spec/factories/krikri_original_record.rb
@@ -17,7 +17,17 @@ FactoryGirl.define do
    <dc:contributor>Bart Besamusca</dc:contributor>
    <dc:type>model</dc:type>
    <dc:language>eng</dc:language>
-</oai_dc:dc></metadata></record></GetRecord></OAI-PMH>
+</oai_dc:dc></metadata>
+<about>
+  <oaiProvenance:provenance xmlns:oaiProvenance="http://www.openarchives.org/OAI/2.0/provenance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/provenance http://www.openarchives.org/OAI/2.0/provenance.xsd">
+    <oaiProvenance:originDescription harvestDate="2015-01-07" altered="true">
+    <oaiProvenance:baseURL>http://cdm16694.contentdm.oclc.org/oai/oai.php</oaiProvenance:baseURL>
+    <oaiProvenance:identifier>oai:cdm16694.contentdm.oclc.org:R6A001/1</oaiProvenance:identifier>
+    <oaiProvenance:datestamp>2015-01-07</oaiProvenance:datestamp>
+    <oaiProvenance:metadataNamespace>http://www.openarchives.org/OAI/2.0/</oaiProvenance:metadataNamespace>
+  </oaiProvenance:originDescription>
+</oaiProvenance:provenance>
+</about></record></GetRecord></OAI-PMH>
 EOS
   end
 

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -76,7 +76,16 @@ describe Krikri::Harvesters::OAIHarvester do
    <dc:contributor>Bart Besamusca</dc:contributor>
    <dc:type>model</dc:type>
    <dc:language>eng</dc:language>
-</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000013</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+</oai_dc:dc></metadata><about>
+<oaiProvenance:provenance xmlns:oaiProvenance="http://www.openarchives.org/OAI/2.0/provenance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/provenance http://www.openarchives.org/OAI/2.0/provenance.xsd">
+<oaiProvenance:originDescription harvestDate="2015-01-07" altered="true">
+<oaiProvenance:baseURL>http://cdm16694.contentdm.oclc.org/oai/oai.php</oaiProvenance:baseURL>
+<oaiProvenance:identifier>oai:cdm16694.contentdm.oclc.org:R6A001/1</oaiProvenance:identifier>
+<oaiProvenance:datestamp>2015-01-07</oaiProvenance:datestamp>
+<oaiProvenance:metadataNamespace>http://www.openarchives.org/OAI/2.0/</oaiProvenance:metadataNamespace>
+</oaiProvenance:originDescription>
+</oaiProvenance:provenance>
+</about></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000013</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
    <dc:title>Aberystwyth, National Library of Wales, 5667 E</dc:title>
    <dc:creator>Bart Besamusca</dc:creator>
    <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000013</dc:identifier>
@@ -180,11 +189,12 @@ describe Krikri::Harvesters::OAIHarvester do
 
       describe '#get_record' do
         before do
-          allow(result).to receive(:doc).and_return('')
+          allow(result).to receive(:record).and_return(oai_record)
         end
 
         let(:identifier) { 'comet_moominland' }
         let(:request_type) { :get_record }
+        let(:oai_record) { OAI::Record.new(REXML::Element.new) }
 
         it 'sends request with option' do
           expect(subject.client).to receive(request_type)
@@ -236,4 +246,3 @@ describe Krikri::Harvester::Registry do
     end
   end
 end
-

--- a/spec/support/shared_examples/harvester.rb
+++ b/spec/support/shared_examples/harvester.rb
@@ -51,11 +51,17 @@ shared_examples 'a harvester' do
     end
   end
 
-  it 'can get an individual record' do
-    expect(harvester.get_record(harvester.record_ids.first))
-      .to be_a Krikri::OriginalRecord
-  end
+  describe '#get_record' do
+    it 'gets an individual record' do
+      expect(harvester.get_record(harvester.record_ids.first))
+        .to be_a Krikri::OriginalRecord
+    end
 
+    it 'returns a normalized record' do
+      expect(harvester.get_record(harvester.record_ids.first).content)
+        .to eq harvester.records.first.content
+    end
+  end
   describe '#run' do
     it 'saves the OriginalRecords' do
       # TODO: Is this fragile? Should it change when original records have


### PR DESCRIPTION
Ensures that OAI `#records` and `#get_record` return the same result (content) for a given identifier.

Unfortunately, `OAI:Record` hides its raw XML, so it is necessary to rebuild the record from its parts.  The alternative is to monkeypatch an `element` attribute.

```ruby
class OAI::Record
  attr_reader :element

  def initialize(element)
    @element = element
    @status = get_attribute(element, 'status')
    @identifier = xpath(element, './/identifier')
    @datestamp = xpath(element, './/datestamp')
    @set_spec = xpath_all(element, './/setSpec')
  end
end
```
https://github.com/code4lib/ruby-oai/blob/master/lib/oai/client/record.rb

This ignores OAI provenance content from `<about>...</about>`.