### PR TITLE
Allow Registry to force-register items

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -41,7 +41,7 @@ module Krikri
       klass = opts.fetch(:class, DPLA::MAP::Aggregation)
       map = Krikri::Mapping.new((klass if klass))
       map.instance_eval(&block) if block_given?
-      Registry.register(name, map)
+      Registry.register!(name, map)
     end
 
     ##

--- a/lib/krikri/registry.rb
+++ b/lib/krikri/registry.rb
@@ -28,6 +28,10 @@ module Krikri
 
       def register(name, item)
         raise "#{name} is already registered." if registered? name
+        register!(name, item)
+      end
+
+      def register!(name, item)
         instance[name] = item
       end
 

--- a/spec/lib/krikri/registry_spec.rb
+++ b/spec/lib/krikri/registry_spec.rb
@@ -17,6 +17,11 @@ describe Krikri::Registry do
         described_class.register(:mock, Class.new)
       end.to raise_error 'mock is already registered.'
     end
+    it 'does not error when force-registered' do
+      expect do
+        described_class.register!(:mock, Class.new)
+      end.not_to raise_error
+    end
   end
 
   describe '#registered?' do


### PR DESCRIPTION
Add #register! in addition to existing #register

This accompanies a forthcoming PR in Heidrun that will allow Heidrun Resque workers to be started.