### PR TITLE
Update jettywrapper and lock to ~> 2.0

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "resque", "~>1.0"
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "jettywrapper"
+  s.add_development_dependency "jettywrapper", '~> 2.0'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -9,18 +9,13 @@ module Krikri
 
     ##
     # Add factory girl dependency for development
-    # Factory girl is used to generate sample data
-    # This must execute before run_required_generators
-    def insert_factory_girl_dependency
-      gem 'factory_girl_rails', group: :development, version: '~> 4.4.0'
-    end
-
-    ##
-    # Add jettywrapper dependency for development
+    # FactoryGirl is used to generate sample data
     # jettywrapper is used to spin up Jetty running Solr and Marmotta
     # This must execute before run_required_generators
-    def insert_jettywrapper_dependency
-      gem 'jettywrapper', group: :development, version: '~> 1.8.3'
+    def insert_development_dependencies
+      gem 'factory_girl_rails', group: :development, version: '~> 4.4.0'
+      gem 'jettywrapper', group: :development, version: '~> 2.0'
+      gem 'pry-rails', group: :development
     end
 
     ##


### PR DESCRIPTION
jettywrapper 2.0.0 was released today. Krikri's gemspec did not require a
specific version, but the generators were locking it to ~> 1.8.3, which
led to a version conflict.