### PR TITLE
DSL Methods & Resources

### DIFF
--- a/lib/krikri/mapping_dsl.rb
+++ b/lib/krikri/mapping_dsl.rb
@@ -30,7 +30,7 @@ module Krikri
 
     def add_child(name, opts = {}, &block)
       delete_property(name)
-      properties << ChildDeclaration.new(name, opts.fetch(:class), &block)
+      properties << ChildDeclaration.new(name, opts.delete(:class), opts, &block)
     end
 
     def add_property(name, value = nil, &block)

--- a/lib/krikri/mapping_dsl/parser_methods.rb
+++ b/lib/krikri/mapping_dsl/parser_methods.rb
@@ -4,9 +4,117 @@ module Krikri::MappingDSL
   module ParserMethods
     extend ActiveSupport::Concern
 
+    ##
+    # Gives access to delayed method calls on parsed record ValueArrays, to
+    # be executed at the time the mapping is processed.
+    #
+    # @return [RecordProxy] a RecordProxy providing delayed method calls against
+    #   a parsed record.
+    # @see Krikri::MappingDSL::ParserMethods::RecordProxy
     def record
-      lambda do |rec|
-        yield rec.root if block_given?
+      RecordProxy.new
+    end
+
+    ##
+    # Gives access to a delayed call for the `#local_name` of an OriginalRecord,
+    # to be executed at the time the mapping is processed.
+    #
+    # @return [Proc] a proc that, when called, returns the #local_name of the
+    #   OriginalRecord associated with the parsed record passed as its argument.
+    def local_name
+      lambda do |parsed|
+        parsed.record.local_name
+      end
+    end
+
+    ##
+    # Gives access to a delayed call for the `#rdf_subject` of an
+    # OriginalRecord, to be executed at the time the mapping is processed.
+    #
+    # @return [Proc] a proc that, when called, returns the #rdf_subject of the
+    #   OriginalRecord associated with the parsed record passed as its argument.
+    def record_uri
+      lambda do |parsed|
+        parsed.record.rdf_subject
+      end
+    end
+
+    ##
+    # This class acts as a proxy for a parsed record's nodes, wrapped in the
+    # class passed as the second argument. All methods available on the wrapper
+    # class are accepted via #method_missing, added to the #call_chain, and
+    # return `self`, allowing chained method calls.
+    #
+    #   record.field('dct:title').field('foaf:name')
+    #
+    # @see Krikri::Parser::ValueArray
+    class RecordProxy
+      attr_reader :value_class, :call_chain
+
+      ##
+      # Create a new RecordProxy object.
+      #
+      # @param call_chain [Array<Hash>] an array of hashes representing method
+      #   calls. Hashes need a :name (method name), :args (array of arguments),
+      #   and :block (a Proc to pass as a block). Defaults to [].
+      # @param klass [Class] a Class that acts as the target for delayed method
+      #   calls. Must respond to #build(record) and #values. Defaults to
+      #   Krikri::Parser::ValueArray
+      #
+      # @return [RecordProxy]
+      def initialize(call_chain = [], klass = Krikri::Parser::ValueArray)
+        @call_chain = call_chain
+        @value_class = klass
+      end
+
+      def dup
+        RecordProxy.new(call_chain.dup, value_class)
+      end
+
+      ##
+      # Wraps a given record in #value_class and applies the call chain;
+      # each method is sent to the result of the previous method. Finally,
+      # calls #values on the result.
+      #
+      # @param record A parsed record object (e.g. Krikri::Parser) to be sent to
+      #   value_class#build.
+      # @return the values resulting from the full run of the call chain
+      def call(record)
+        result = value_class.build(record)
+        call_chain.each do |message|
+          result = result.send(message[:name], *message[:args], &message[:block])
+        end
+        result.values
+      end
+
+      ##
+      # @return [Integer] the arity of self#call
+      # @see #call
+      def arity
+        1
+      end
+
+      ##
+      # Adds method to the call chain if it is a valid method for value_class.
+      #
+      # @return [RecordProxy] self, after adding the method to the call chain
+      #
+      # @raise [NoMethodError] when the method is unavailable on #value_class.
+      # @raise [ArgumentError] when the arity of the call does not match the
+      #   method on #value_class
+      def method_missing(name, *args, &block)
+        super unless respond_to? name
+
+        arity = value_class.instance_method(name).arity
+        raise ArgumentError, "Method #{name} called with #{args.length} " \
+        "arguments, expected #{arity}." unless arity < 0 || args.length == arity
+
+        call_chain << { name: name, args: args, block: block }
+        self
+      end
+
+      def respond_to?(name)
+        value_class.instance_methods.include?(name) || super
       end
     end
   end

--- a/lib/krikri/mapping_dsl/parser_methods.rb
+++ b/lib/krikri/mapping_dsl/parser_methods.rb
@@ -35,6 +35,8 @@ module Krikri::MappingDSL
     #   OriginalRecord associated with the parsed record passed as its argument.
     def record_uri
       lambda do |parsed|
+        raise "Tried to access subject URI for #{parsed.record}, " \
+        "but it is not saved." unless parsed.record.exists?
         parsed.record.rdf_subject
       end
     end

--- a/lib/krikri/mapping_dsl/rdf_subjects.rb
+++ b/lib/krikri/mapping_dsl/rdf_subjects.rb
@@ -13,7 +13,8 @@ module Krikri::MappingDSL
         value = @value
         lambda do |target, record|
           value = value.call(record) if value.respond_to? :call
-          raise 'URI must be set to a single value' if Array(value).count != 1
+          raise "URI must be set to a single value; got #{value}" if
+            Array(value).count != 1
           value = value.first if value.is_a? Enumerable
           return target.send(setter, value) unless block
           target.send(setter, instance_exec(value, &block))

--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -114,7 +114,16 @@ module Krikri
     # Methods defined on this class should return another ValueArray, an Array
     # of literal values (retrieved from Parser::Value#value), or a single
     # literal value.
-    class ValueArray < Array
+    class ValueArray
+      include Enumerable
+
+      delegate :<<, :[], :[]=, :each, :empty?, :map, :to_a, :to_ary,
+      :to => :@array
+
+      def initialize(array = [])
+        @array = array
+      end
+
       ##
       # @return [Array] literal values from the objects in this array.
       # @see Parser::Value#value
@@ -140,8 +149,16 @@ module Krikri
       # Wraps the result of Array#select in a ValueArray
       #
       # @see Array#select
-      def select(*)
-        self.class.new(super)
+      def select(*args, &block)
+        self.class.new(@array.select(*args, &block))
+      end
+
+      ##
+      # Wraps the result of Array#reject in a ValueArray
+      #
+      # @see Array#reject
+      def reject(*args, &block)
+        self.class.new(@array.reject(*args, &block))
       end
 
       ##

--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -75,7 +75,11 @@ module Krikri
       # @param name [#to_sym] an attribute name to query
       # @return [Boolean] true if `name` is an attribute of the current node
       def attribute?(name)
-        attributes.include?(name)
+        begin
+          attributes.include?(name)
+        rescue NotImplementedError
+          false
+        end
       end
 
       def method_missing(name, *args, &block)
@@ -143,6 +147,17 @@ module Krikri
           result = result.get_field(name)
         end
         result
+      end
+
+      ##
+      # Retrieves the first element of a ValueArray. Uses an optional argument
+      # to specify how many items to return. By design, it behaves similarly
+      # to Array#first, but it intentionally doesn't override it.
+      #
+      # @return [ValueArray] a Krikri::Parser::ValueArray for first n elements
+      def first_value(*args)
+        return self.class.new(@array.first(*args)) unless args.empty?
+        self.class.new([@array.first].compact)
       end
 
       ##

--- a/lib/krikri/parsers/json_parser.rb
+++ b/lib/krikri/parsers/json_parser.rb
@@ -48,8 +48,9 @@ module Krikri
         if @node[name].is_a?(Array)
           vals = @node[name].map { |node| self.class.new(node) }
         else
-          vals = self.class.new(@node[name])
+          vals = Array(self.class.new(@node[name]))
         end
+        vals.reject! { |n| n.node.nil? }
         Krikri::Parser::ValueArray.new(vals)
       end
 

--- a/lib/krikri/parsers/json_parser.rb
+++ b/lib/krikri/parsers/json_parser.rb
@@ -46,10 +46,11 @@ module Krikri
 
       def get_child_nodes(name)
         if @node[name].is_a?(Array)
-          @node[name].map { |node| self.class.new(node) }
+          vals = @node[name].map { |node| self.class.new(node) }
         else
-          Array.new([self.class.new(@node[name])])
+          vals = self.class.new(@node[name])
         end
+        Krikri::Parser::ValueArray.new(vals)
       end
 
       def attribute(name)

--- a/lib/krikri/parsers/xml_parser.rb
+++ b/lib/krikri/parsers/xml_parser.rb
@@ -62,8 +62,8 @@ module Krikri
       private
 
       def get_child_nodes(name)
-        @node.xpath("#{@node.path}/#{name}", @namespaces)
-          .map { |node| self.class.new(node, @namespaces) }
+        Krikri::Parser::ValueArray.new(@node.xpath("#{@node.path}/#{name}", @namespaces)
+          .map { |node| self.class.new(node, @namespaces) })
       end
 
       def attribute(name)
@@ -71,7 +71,7 @@ module Krikri
       end
 
       def select_values
-        @node.children.select(&:text?)
+        Krikri::Parser::ValueArray.new(@node.children.select(&:text?))
       end
     end
   end

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -5,10 +5,10 @@ describe Krikri::Mapper do
     before do
       Krikri::Mapper.define(:integration) do
         sourceResource :class => DPLA::MAP::SourceResource do
-          title record { |rec| rec['dc:title'].map(&:value) }
+          title record.field('dc:title')
 
           creator :class => DPLA::MAP::Agent do
-            providedLabel record { |rec| rec['dc:creator'].map(&:value) }
+            providedLabel record.field('dc:creator')
           end
         end
       end

--- a/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
@@ -4,18 +4,49 @@ describe Krikri::MappingDSL::ChildDeclaration do
   subject { described_class.new(:my_property, klass) {} }
   let(:klass) { double }
 
-  describe '#to_proc' do
-    let(:mapping) { double }
-    let(:target) { double }
+  let(:target) { double }
+  let(:mapping) { double }
 
+  before do
+    allow(::Krikri::Mapping).to receive(:new).and_return(mapping)
+  end
+
+  describe '#to_proc' do
     before do
-      allow(::Krikri::Mapping).to receive(:new).and_return(mapping)
       allow(mapping).to receive(:process_record).with('').and_return(:value)
     end
 
-    it 'returns a proc' do
+    it 'sets value of property to result of process_record' do
       expect(target).to receive(:my_property=).with(:value)
       subject.to_proc.call(target, '')
+    end
+  end
+
+  context 'with each/as declarations' do
+    subject { described_class.new(:my_property, klass, opts) {  } }
+    let(:opts) { { :each => record_proxy, :as => :my_val } }
+    let(:record_proxy) { double }
+    let(:record_proxy_dup) { double }
+    let(:values) { [:a, :b, :c] }
+
+    before do
+      allow(target).to receive(:my_property).and_return(double)
+      allow(record_proxy).to receive(:call).and_return(values)
+      allow(record_proxy).to receive(:dup).and_return(record_proxy_dup)
+      allow(record_proxy_dup).to receive(:select).and_return(values.first)
+      allow(mapping).to receive(:process_record).with('').and_return(values.first)
+    end
+
+    it 'sets values of property to results of process_record' do
+      expect(target.my_property).to receive(:<<).with(values.first)
+        .exactly(3).times
+      subject.to_proc.call(target, '')
+    end
+
+    it 'defines DSL method for access to individual value' do
+      allow(target.my_property).to receive(:<<).with(values.first)
+      subject.to_proc.call(target, '')
+      expect(mapping.my_val).to eq values.first
     end
   end
 end

--- a/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
@@ -18,22 +18,142 @@ describe Krikri::MappingDSL::ParserMethods do
   let(:real) { Krikri::XmlParser.new(build(:oai_dc_record)) }
 
   describe '#record' do
-    it 'returns a callable proc' do
-      expect(subject.record).to be_a Proc
+    it 'returns a callable object' do
+      expect(subject.record).to respond_to :call
     end
 
     it 'has arity of 1 (for parsed record)' do
       expect(subject.record.arity).to eq 1
     end
 
-    context 'when passed record' do
+    it 'returns a RecordProxy' do
+      expect(subject.record)
+        .to be_a Krikri::MappingDSL::ParserMethods::RecordProxy
+    end
+  end
+
+  describe '#local_name' do
+    it 'calls local_name on the record' do
+      expect(record).to receive_message_chain(:record, :local_name)
+        .and_return('moomin')
+      expect(subject.local_name.call(record)).to eq 'moomin'
+    end
+  end
+
+  describe '#record_uri' do
+    it 'calls local_name on the record' do
+      expect(record).to receive_message_chain(:record, :rdf_subject)
+        .and_return('http://example.org/moomin')
+      expect(subject.record_uri.call(record)).to eq 'http://example.org/moomin'
+    end
+  end
+end
+
+describe Krikri::MappingDSL::ParserMethods::RecordProxy do
+  subject { described_class.new([], klass) }
+  let(:klass) { class_double(Krikri::Parser::ValueArray) }
+
+  it 'has attributes' do
+    expect(subject).to have_attributes(:value_class => klass, :call_chain => [])
+  end
+
+  describe '#dup' do
+    let(:duped) { subject.dup }
+
+    it 'shares call_chain content' do
+      expect(duped.call_chain).to eq subject.call_chain
+    end
+
+    it 'has a different call_chain object' do
+      expect(duped.call_chain).not_to be subject.call_chain
+    end
+
+    it 'shares a value class' do
+      expect(duped.value_class).to eq subject.value_class
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(klass).to receive(:build).with(record).and_return(value)
+      allow(value).to receive(:values).and_return([:my_value])
+    end
+
+    subject { described_class.new(call_chain, klass) }
+    let(:record) { double }
+    let(:value) { double }
+
+    let(:call_chain) do
+      [{ :name => :my_method,
+         :args => [:moomin, :snorkmaiden],
+         :block => Proc.new {}
+       },
+       { :name => :second_method,
+         :args => [:too_ticky],
+         :block => nil
+       }]
+    end
+
+    it 'calls chain' do
+      call_chain.each do |spec|
+        expect(value).to receive(spec[:name]).ordered
+          .with(*spec[:args], &spec[:block]).and_return(value)
+      end
+      subject.call(record)
+    end
+
+    it 'casts result to values' do
+      call_chain.each do |spec|
+        allow(value).to receive(spec[:name]).and_return(value)
+      end
+      expect(subject.call(record)).to eq [:my_value]
+    end
+  end
+
+  describe '#arity' do
+    it 'returns arity for #call' do
+      expect(subject.arity).to eq described_class.instance_method(:call).arity
+    end
+  end
+
+  describe 'method calls' do
+    it 'rejects calls for methods undefined on @value_class' do
+      expect { subject.undefined_method }.to raise_error NoMethodError
+    end
+
+    it "knows it won't respond to undefined on @value_class" do
+      expect(subject.respond_to?(:undefined_method)).to eq false
+    end
+
+    context 'when method exists' do
       before do
-        allow(record).to receive(:root).and_return(:value)
+        allow(klass).to receive(:instance_methods).and_return([:field])
+        allow(klass).to receive(:instance_method).with(:field)
+          .and_return(instance_double(UnboundMethod, :arity => 1))
       end
 
-      it 'record to given block' do
-        expect { |blk| subject.record(&blk).call(record) }
-          .to yield_with_args(:value)
+      it "knows it will respond to the method" do
+        expect(subject.respond_to?(:field)).to eq true
+      end
+
+      it 'raises an error when not matching arity' do
+        expect { subject.field }.to raise_error ArgumentError
+      end
+
+      it 'adds method to call chain' do
+        subject.field(:moomin).field(:valley) {}
+        expect(subject.call_chain).to match([{ :name => :field,
+                                               :args => [:moomin],
+                                               :block => nil
+                                             },
+                                             { :name => :field,
+                                               :args => [:valley],
+                                               :block => an_instance_of(Proc)
+                                             }])
+      end
+
+      it 'returns itself' do
+        expect(subject.field(:moomin).field(:valley) {}).to eq subject
       end
     end
   end

--- a/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
@@ -41,10 +41,18 @@ describe Krikri::MappingDSL::ParserMethods do
   end
 
   describe '#record_uri' do
-    it 'calls local_name on the record' do
+    it 'gets uri for record ' do
+      allow(record).to receive_message_chain(:record, :exists?)
+        .and_return(true)
       expect(record).to receive_message_chain(:record, :rdf_subject)
         .and_return('http://example.org/moomin')
       expect(subject.record_uri.call(record)).to eq 'http://example.org/moomin'
+    end
+
+    it 'raises an error when record does not exist' do
+      allow(record).to receive_message_chain(:record, :exists?)
+        .and_return(false)
+      expect { subject.record_uri.call(record) }.to raise_error
     end
   end
 end

--- a/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
@@ -105,7 +105,7 @@ describe Krikri::MappingDSL::RdfSubjects do
 
         it 'raises an error' do
           expect { subject.to_proc.call(mapped, '') }
-            .to raise_error 'URI must be set to a single value'
+            .to raise_error "URI must be set to a single value; got #{value}"
         end
       end
     end

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -11,7 +11,7 @@ describe Krikri::Parser::ValueArray do
   end
 
   it 'is an Array' do
-    expect(subject).to be_a Array
+    expect(subject.to_a).to be_a Array
   end
 
   describe '.build' do
@@ -57,6 +57,17 @@ describe Krikri::Parser::ValueArray do
 
     it 'returns an instance of its class' do
       expect(subject.select {}).to be_a described_class
+    end
+  end
+
+  describe '#reject' do
+    it 'creates new array not containing rejected values' do
+      expect(subject.reject { |v| v.value == 'value_1'})
+        .not_to include(values[1])
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.reject {}).to be_a described_class
     end
   end
 

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -34,6 +34,8 @@ describe Krikri::Parser::ValueArray do
         nested_field = instance_double(Krikri::Parser::Value)
         allow(val).to receive(:[]).with(:field_name)
           .and_return(nested_field)
+        allow(val).to receive(:[]).with(:nonexistent_field)
+          .and_return(described_class.new([]))
         allow(nested_field).to receive(:[]).with(:nested_name)
           .and_return(:final_value)
       end
@@ -44,8 +46,35 @@ describe Krikri::Parser::ValueArray do
         .to contain_exactly(:final_value, :final_value, :final_value)
     end
 
+    it 'returns nil for a nonexistent field' do
+      expect(subject.field(:nonexistent_field)).to be_empty
+    end
+
     it 'returns an instance of its class' do
       expect(subject.field(:field_name)).to be_a described_class
+    end
+  end
+
+  describe '#first_value' do
+    it 'returns a single item ValueArray without an arguments' do
+      expect(subject.first_value).to contain_exactly values[0]
+    end
+
+    it 'returns only requested items when called with an argument' do
+      expect(subject.first_value(2)).to contain_exactly(values[0], values[1])
+      expect(subject.first_value(2).count).to eq(2)
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.first_value).to be_a described_class
+    end
+
+    context 'with empty field' do
+      let(:values) { [] }
+
+      it 'returns an empty ValueArray' do
+        expect(subject.first_value).to be_empty
+      end
     end
   end
 

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Krikri::Parser::ValueArray do
+  subject { described_class.new(values) }
+  let(:values) do
+    vs = []
+    3.times do |n|
+      vs << double('value', :value => "value_#{n}")
+    end
+    vs
+  end
+
+  it 'is an Array' do
+    expect(subject).to be_a Array
+  end
+
+  describe '.build' do
+    let(:record) { instance_double(Krikri::Parser, :root => :root_node) }
+
+    it 'builds with root node' do
+      expect(described_class.build(record)).to contain_exactly(:root_node)
+    end
+  end
+
+  describe '#values' do
+    it 'gives values for items in array' do
+      expect(subject.values).to eq ['value_0', 'value_1', 'value_2']
+    end
+  end
+
+  describe '#field' do
+    before do
+      values.each do |val|
+        nested_field = instance_double(Krikri::Parser::Value)
+        allow(val).to receive(:[]).with(:field_name)
+          .and_return(nested_field)
+        allow(nested_field).to receive(:[]).with(:nested_name)
+          .and_return(:final_value)
+      end
+    end
+
+    it 'gives values from a field' do
+      expect(subject.field(:field_name, :nested_name))
+        .to contain_exactly(:final_value, :final_value, :final_value)
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.field(:field_name)).to be_a described_class
+    end
+  end
+
+  describe '#select' do
+    it 'creates new array with selected values' do
+      expect(subject.select { |v| v.value == 'value_1'})
+        .to contain_exactly(values[1])
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.select {}).to be_a described_class
+    end
+  end
+
+  describe '#match_attribute' do
+    before do
+      values.each { |val| allow(val).to receive(:attribute?).and_return(false) }
+    end
+
+
+    it 'selects values by their attributes' do
+      allow(values[0]).to receive(:attribute?).with(:type).and_return(true)
+      allow(values[0]).to receive(:type).and_return('Moomin')
+      allow(values[1]).to receive(:attribute?).with(:type).and_return(true)
+      allow(values[1]).to receive(:type).and_return('mummi')
+      expect(subject.match_attribute(:type, 'moomin'))
+        .to contain_exactly(values[0])
+    end
+  end
+end

--- a/spec/support/shared_examples/parser.rb
+++ b/spec/support/shared_examples/parser.rb
@@ -22,6 +22,10 @@ shared_examples_for 'a parser value' do
   end
 
   describe '#[]' do
+    it 'gives a ValueArray' do
+      expect(value[child]).to be_a Krikri::Parser::ValueArray
+    end
+
     it 'retrieves a child node' do
       expect(value[child]).to include(an_instance_of(described_class))
     end

--- a/spec/support/shared_examples/parser.rb
+++ b/spec/support/shared_examples/parser.rb
@@ -29,6 +29,10 @@ shared_examples_for 'a parser value' do
     it 'retrieves a child node' do
       expect(value[child]).to include(an_instance_of(described_class))
     end
+
+    it 'gives an empty ValueArray for non-nodes' do
+      expect(value['fake']).to be_empty
+    end
   end
 
   describe '#child?' do


### PR DESCRIPTION
Adds functionality to the mapping DSL for creating instances of a resource class from each of a given parser node's values and for accessing parsed values in a more human readable fashion.

Creates a `RecordProxy` in the mapping DSL context. The special DSL method `#record` now returns an instance of this class.  The class accepts a call chain, with method names, their arguments (and blocks to pass through) which will be called against the parsed record (via `ValueArray`) when the record is processed.  `RecordProxy` mimics `Proc` in that it has `#call` and `#arity` methods.  This allows the rest of the DSL's interface to stay the same.

Adds a `ValueArray`, which encapsulates common access patterns for parsed record nodes.  `ValueArray`'s methods return instances of itself, as they intended to be chained. E.g. 

```ruby 
val.field(:creator).select { |v| v.some_attribute == 'attribute value' }
```

`ValueArray` should be extended over time to wrap more of `Array`'s functionality and capture any emerging patterns.

Lastly, this enhances `ChildDeclaration` to accept optional `:each` and `:as` options.  These options specify that an instance of the requested child class will be created for each value in the `Proc` (or `RecordProxy`) passed to `:each`, and that the matching values will be accessible as a method registered in the block's scope with the name passed to `:as`.  

```ruby
Krikri::Mapper.define(:esdn_mods) do
  sourceResource :class => DPLA::MAP::SourceResource do
    contributor :class => DPLA::MAP::Agent, :each => record.field('mods:name').select { |name| name['mods:role'].map(&:value).include?('contributor') }, :as => :contrib do
      providedLabel contrib.field('mods:namePart')
    end
  
    creator :class => DPLA::MAP::Agent, :each => record.field('mods:name').select { |name| name['mods:role'].map(&:value).include?('creator') }, :as => :creator_role do
      providedLabel creator_role.field('mods:namePart')
    end
 end
```