### PR TITLE
Add Krikri::Parsers::QdcParser

### DIFF
--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -12,4 +12,5 @@ module Krikri
   autoload :OaiDcParser,    'krikri/parsers/oai_dc_parser'
   autoload :JsonParser,     'krikri/parsers/json_parser'
   autoload :ModsParser,     'krikri/parsers/mods_parser'
+  autoload :QdcParser,      'krikri/parsers/qdc_parser'
 end

--- a/lib/krikri/parsers/qdc_parser.rb
+++ b/lib/krikri/parsers/qdc_parser.rb
@@ -1,0 +1,18 @@
+module Krikri
+  ##
+  # A Qualified Dublin Core parser. Uses XML parser with a root path to match
+  # the metadata path as harvested. The default root_path is the element used
+  # by CONTENTdm; this can be overridden as with all Krikri::XmlParsers, at
+  # the time of instantiation.
+  #
+  # @see Krikri::XmlParser
+  class QdcParser < XmlParser
+    def initialize(record, root_path = '//oai_qdc:qualifieddc', ns = {})
+      ns = {
+        qdc: 'http://epubs.cclrc.ac.uk/xmlns/qdc/',
+        oai_qdc: 'http://worldcat.org/xmlschemas/qdc-1.0/'
+      }.merge(ns)
+      super(record, root_path, ns)
+    end
+  end
+end

--- a/spec/factories/krikri_original_record.rb
+++ b/spec/factories/krikri_original_record.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   end
 
   factory :oai_dc_record, parent: :krikri_original_record do
-    content <<-EOS
+    content <<-EOS.strip_heredoc
 <?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014v-10-27T22:19:17Z</responseDate><request verb="GetRecord" identifier="oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><GetRecord><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
    <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
    <dc:creator>Bart Besamusca</dc:creator>
@@ -28,6 +28,36 @@ FactoryGirl.define do
   </oaiProvenance:originDescription>
 </oaiProvenance:provenance>
 </about></record></GetRecord></OAI-PMH>
+EOS
+  end
+
+  factory :cdm_qdc_record, parent: :krikri_original_record do
+    content <<-EOS.strip_heredoc
+<?xml version="1.0" encoding="UTF-8"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2015-01-26T19:32:57Z</responseDate><request verb="ListRecords" resumptionToken="p15799coll82:40000:oclc-cdm-allsets:0000-00-00:9999-99-99:oai_qdc" metadataPrefix="oai_qdc">http://digitallibrary.usc.edu/oai/oai.php</request><ListRecords><record><header><identifier>oai:digitallibrary.usc.edu:p15799coll117/0</identifier><datestamp>2012-11-07</datestamp><setSpec>p15799coll117</setSpec></header>
+<metadata>
+<oai_qdc:qualifieddc xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+<dc:title>Letter, Cornelia A. Kelley to Andrew Viterbi, February 25, 2000</dc:title>
+<dc:publisher>University of Southern California. Libraries</dc:publisher>
+<dcterms:created>2000/2000</dcterms:created>
+<dcterms:created>2000</dcterms:created>
+<dc:type>item</dc:type>
+<dcterms:isPartOf>Boston Latin School</dcterms:isPartOf>
+<dc:source>University of Southern California</dc:source>
+<dc:source>Box 1, Folder 2</dc:source>
+<dc:identifier>vit-m15</dc:identifier>
+<dcterms:isPartOf>vit-m1</dcterms:isPartOf>
+<dcterms:isPartOf>Andrew J. and Erna Viterbi Family Archives</dcterms:isPartOf>
+<dcterms:isPartOf>Academic Affiliations</dcterms:isPartOf>
+<dc:rights>There are materials within the archives that are marked confidential or proprietary, or that contain information that is obviously confidential. Examples of the latter include letters of references and recommendations for employment, promotions, and awards; nominations for awards and honors; resumes of colleagues of Dr. Viterbi; and grade reports of students in Dr. Viterbi&#x27;s classes at the University of California, Los Angeles, and the University of California, San Diego.; These restricted items were not scanned and, therefore, are not included in the USC Digital Archive.; Researchers wishing to see any of the restricted materials should consult with the USC Libraries Special Collections staff.</dc:rights>
+<dcterms:accessRights>There are materials within the archives that are marked confidential or proprietary, or that contain information that is obviously confidential. Examples of the latter include letters of references and recommendations for employment, promotions, and awards; nominations for awards and honors; resumes of colleagues of Dr. Viterbi; and grade reports of students in Dr. Viterbi&#x27;s classes at the University of California, Los Angeles, and the University of California, San Diego.; These restricted items were not scanned and, therefore, are not included in the USC Digital Archive.; Researchers wishing to see any of the restricted materials should consult with the USC Libraries Special Collections staff.</dcterms:accessRights>
+<dcterms:rightsHolder>USC Libraries Special Collections</dcterms:rightsHolder>
+<dc:rights>Doheny Memorial Library 206, 3550 Trousdale Parkway, Los Angeles, California,90089-0189, 213-740-4035, specol@usc.edu</dc:rights>
+<dc:identifier>VIT-000014</dc:identifier>
+<dc:identifier>http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll117/id/0</dc:identifier></oai_qdc:qualifieddc>
+</metadata>
+</record>
+</ListRecords>
+</OAI-PMH>
 EOS
   end
 

--- a/spec/lib/krikri/parsers/qdc_parser_spec.rb
+++ b/spec/lib/krikri/parsers/qdc_parser_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Krikri::QdcParser do
+  let(:record) { build(:cdm_qdc_record) }
+  subject { Krikri::QdcParser.new(record) }
+
+  it_behaves_like 'a parser'
+end


### PR DESCRIPTION
Adds a qualified Dublin Core parser. The default root node path is the
one used by CONTENTdm. This can be overridden (like all Krikri::XmlParsers)
at the time of instantiation.