### PR TITLE
Add convenience constants to Krikri::MappingDSL

### DIFF
--- a/lib/krikri/mapping_dsl.rb
+++ b/lib/krikri/mapping_dsl.rb
@@ -13,6 +13,14 @@ module Krikri
     include ParserMethods
     include RdfSubjects
 
+    DCMITYPE_LABELS = RDF::DCMITYPE.select(&:class?).map { |t| t.label.downcase }
+
+    # TODO: Discuss with Content Team. `dpla_map` currently constrains
+    # genre (edm:hasType) to AAT terms; these are not all AAT terms.
+    GENRE_LABELS = ['book', 'film/video', 'manuscript', 'maps', 'music',
+                    'musical score', 'newspapers', 'nonmusic',
+                    'photograph/pictorial works', 'serial']
+
     def properties
       @properties ||= []
     end


### PR DESCRIPTION
* Add Krikri::MappingDSL::DCMITYPE_LABELS
* Add Krikri::MappingDSL::GENRE_LABELS

Note that the proposed genre labels may be out of alignment with MAPv4, and `dpla/map` (which suggests that all terms assigned to `genre`/`edm:hasType` should be from AAT).