### PR TITLE
Feature/date normalization

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"
   s.add_dependency "therubyracer"
+  s.add_dependency "edtf"
   s.add_dependency "oai"
   s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -5,6 +5,7 @@ require 'krikri/ldp'
 require 'dpla/map'
 require 'rdf/marmotta'
 require 'oai/client'
+require 'edtf'
 
 require 'resque'
 

--- a/lib/krikri/enrichments/parse_date.rb
+++ b/lib/krikri/enrichments/parse_date.rb
@@ -1,0 +1,28 @@
+module Krikri::Enrichments
+  ##
+  # Normalizes date strings to
+  #
+  #   StripPunctuation.new.enrich_value("\tmo!ominpa)(pa  \n .$%^ moominmama  ")
+  #   # => "\tmoominpapa  \n  moominmama  "
+  class ParseDate
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      date = Date.edtf(value)
+      begin
+        date ||= (parse_m_d_y(value) || Date.parse(value))
+      rescue ArgumentError
+        value
+      end
+    end
+
+    def parse_m_d_y(value)
+      begin
+        Date.strptime(value.gsub(/[^0-9]/, '-'), '%m-%d-%Y')
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/lib/krikri/enrichments/parse_date.rb
+++ b/lib/krikri/enrichments/parse_date.rb
@@ -1,9 +1,21 @@
 module Krikri::Enrichments
   ##
-  # Normalizes date strings to
+  # Normalizes date strings to EDTF or Date objects.
   #
-  #   StripPunctuation.new.enrich_value("\tmo!ominpa)(pa  \n .$%^ moominmama  ")
-  #   # => "\tmoominpapa  \n  moominmama  "
+  # Attempts to convert a string value to a Date object:
+  #
+  #   - Parses EDTF values, returns an appropriate EDTF object if
+  #     a match is found; then...
+  #   - Parses values in %m*%d*%Y format and returns a Date object if
+  #     appropriate.
+  #   - Parses values that match any of Date#parse's supported formats.
+  #
+  # If the value is not a `String` or is parsed as invalid by all
+  # parsers, the original value is returned unaltered.
+  #
+  # @see Date#parse
+  # @see https://github.com/inukshuk/edtf-ruby/blob/master/README.md Ruby EDTF
+  # @see http://www.loc.gov/standards/datetime/pre-submission.html EDTF Draft
   class ParseDate
     include Krikri::FieldEnrichment
 
@@ -11,7 +23,7 @@ module Krikri::Enrichments
       return value unless value.is_a? String
       date = Date.edtf(value)
       begin
-        date ||= (parse_m_d_y(value) || Date.parse(value))
+        date || (parse_m_d_y(value) || Date.parse(value))
       rescue ArgumentError
         value
       end

--- a/spec/lib/krikri/enrichments/parse_date_spec.rb
+++ b/spec/lib/krikri/enrichments/parse_date_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::ParseDate do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'parses calendar to ruby Date',
+              :start => 'May 15, 2014',
+              :end => Date.parse('2014-05-15')
+            },
+            { :string => 'parses ISO to ruby Date',
+              :start => '2014-05-15',
+              :end => Date.parse('2014-05-15')
+            },
+            { :string => 'parses slash to ruby Date',
+              :start => '5/7/2012',
+              :end => Date.parse('2012-05-07')
+            },
+            { :string => 'parses dot to ruby Date',
+              :start => '5.7.2012',
+              :end => Date.parse('2012-05-07')
+            },
+            { :string => 'parses Month, Year to ruby Date',
+              :start => 'July, 2015',
+              :end => Date.parse('2015-07-01')
+            },
+            { :string => 'parses M-D-Y to ruby Date',
+              :start => '12-19-2010',
+              :end => Date.parse('2010-12-19')
+            },
+            { :string => 'parses uncertain to EDTF',
+              :start => '2015?',
+              :end => Date.edtf('2015?')
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => "moominpapa",
+              :end => "moominpapa"
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end


### PR DESCRIPTION
Attempts to convert a string value to a Date object:
   - Parses EDTF values, returns an appropriate EDTF object if a match is found; otherwise...
   - Parses values in %m*%d*%Y format and returns a Date object if appropriate; otherwise...
   - Parses values that match any of Date#parse's supported formats.

If the value is not a `String` or is parsed as invalid by all parsers, the original value is returned unaltered.