### PR TITLE
Date Enrichments

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"
   s.add_dependency "therubyracer"
+  s.add_dependency "edtf"
   s.add_dependency "oai"
   s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -5,6 +5,7 @@ require 'krikri/ldp'
 require 'dpla/map'
 require 'rdf/marmotta'
 require 'oai/client'
+require 'edtf'
 
 require 'resque'
 

--- a/lib/krikri/enrichments/parse_date.rb
+++ b/lib/krikri/enrichments/parse_date.rb
@@ -1,0 +1,27 @@
+module Krikri::Enrichments
+  ##
+  # Normalizes date strings to EDTF or Date objects.
+  #
+  # Attempts to convert a string value to a Date object:
+  #
+  #   - Parses EDTF values, returns an appropriate EDTF object if
+  #     a match is found; then...
+  #   - Parses values in %m*%d*%Y format and returns a Date object if
+  #     appropriate.
+  #   - Parses values that match any of Date#parse's supported formats.
+  #
+  # If the value is not a `String` or is parsed as invalid by all
+  # parsers, the original value is returned unaltered.
+  #
+  # @see Date#parse
+  # @see https://github.com/inukshuk/edtf-ruby/blob/master/README.md Ruby EDTF
+  # @see http://www.loc.gov/standards/datetime/pre-submission.html EDTF Draft
+  class ParseDate
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      Krikri::Util::ExtendedDateParser.parse(value) || value
+    end
+  end
+end

--- a/lib/krikri/enrichments/timespan_split.rb
+++ b/lib/krikri/enrichments/timespan_split.rb
@@ -1,0 +1,75 @@
+module Krikri::Enrichments
+  ##
+  # Splits edm:TimeSpan labels and populates `#begin` and `#end`. Any values
+  # generated from string values are left as strings to be normalized by
+  # another enrichment.
+  #
+  # Ignores values that are neither a String or an edm:TimeSpan
+  #
+  # Converts string values to a timespan with the value as providedLabel
+  # and enriches as below.
+  #
+  # Populates the `#begin`, and `#end` properties of TimeSpan objects from
+  # `#providedLabel`. If a `#providedLabel` is present, but begin and end are
+  # missing, runs the `Krikri::Util::ExtendedDateParser`.
+  #
+  # Once a begin and end date are recognized, the enrichment checks their
+  # validity (that the begin date comes before any existing end dates, or vice
+  # versa) and writes whichever value(s) it finds empty.  The earliest/latest
+  # dates are used for begin/end, respectively.
+  #
+  # If more than one `#providedLabel` is given, each is processed in turn and
+  # the widest possible range is used.
+  #
+  # Returns the TimeSpan unaltered if both `#begin` and `#end` are present
+  # or valid values cannot be found for empty fields.
+  #
+  # @see Krikri::Util::ExtendedDateParser
+  class TimespanSplit
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      value = timespan_from_string(value) if value.is_a? String
+      return value unless value.is_a? DPLA::MAP::TimeSpan
+      populate_timespan(value)
+    end
+
+    def timespan_from_string(value)
+      timespan = DPLA::MAP::TimeSpan.new
+      timespan.providedLabel = value
+      timespan
+    end
+
+    def populate_timespan(timespan)
+      return timespan unless (timespan.begin.empty? || timespan.end.empty?) &&
+        !timespan.providedLabel.empty?
+
+      parsed = parse_labels(timespan.providedLabel)
+      return timespan if parsed.empty?
+      parsed.each do |date|
+        begin_date, end_date = span_from_date(date)
+        timespan.begin << begin_date
+        timespan.end << end_date
+      end
+      reduce_to_largest_span(timespan)
+      return timespan
+    end
+
+    def parse_labels(labels)
+      labels.map { |l| Krikri::Util::ExtendedDateParser.parse(l, true) }.compact
+    end
+
+    def span_from_date(date)
+      return [nil, nil] if date.nil?
+      return [date, date] if date.is_a? Date
+      [(date.respond_to?(:first) ? date.first : date.from),
+       (date.respond_to?(:last) ? date.last : date.to)]
+    end
+
+    def reduce_to_largest_span(timespan)
+      timespan.begin = timespan.begin.sort.first
+      timespan.end = timespan.end.sort.last
+      timespan
+    end
+  end
+end

--- a/lib/krikri/util/extended_date_parser.rb
+++ b/lib/krikri/util/extended_date_parser.rb
@@ -1,0 +1,147 @@
+module Krikri::Util
+  module ExtendedDateParser
+    module_function
+
+    ##
+    # Attempts to parse a string into a valid EDTF or `Date` format.
+    #
+    #   - Attempts to split `#providedLabel` on '-', '/', '..', 'to', 'until', and
+    #     looks for EDTF and `Date.parse` patterns on either side, setting them to
+    #     `#begin` and `#end`. Both split and unsplit dates are parsed as follows:
+    #   - Attempts to parse `#providedLabel` as an EDTF interval and populates
+    #     begin and end with their respective values.
+    #   - Attempts to match to a number of regular expressions which specify
+    #     ranges informally.
+    #   - Attempts to parse `#providedLabel` as a single date value with
+    #     `Date.parse` and enters that value to both `#begin` and `#end`.
+    #
+    # @param date_str [String] a string which may contain a date range
+    # @param allow_interval [Boolean] a flag specifing whethe to use
+    #   #range_match to look for range values.
+    #
+    # @return [Date, EDTF::Epoch, EDTF::Interval, nil] the date parsed or nil
+    def parse(date_str, allow_interval = false)
+      date_str.strip!
+      date_str.gsub!(/\s+/, ' ')
+      date = parse_interval(date_str) if allow_interval
+      date ||= parse_m_d_y(date_str)
+      date ||= Date.edtf(date_str.gsub('.', '-'))
+      date ||= partial_edtf(date_str)
+      date ||= decade_hyphen(date_str)
+      date ||= month_year(date_str)
+      date ||= decade_s(date_str)
+      date ||= hyphenated_partial_range(date_str)
+      date ||= parse_date(date_str)
+      date || nil
+    end
+
+    ##
+    # Matches a wide variety of date ranges separated by '..' or '-'
+    #
+    # @param str [String] a string which may contain a date range
+    # @return [Array(String)] the begining and ending dates of an identified
+    #    range
+    def range_match(str)
+      str = str.gsub('to', '-').gsub('until', '-')
+      regexp = %r{
+        ([a-zA-Z]{0,3}\s?[\d\-\/\.xu\?\~a-zA-Z]*,?\s?
+        \d{3}[\d\-xs][s\d\-\.xu\?\~]*)
+        \s*[-\.]+\s*
+        ([a-zA-Z]{0,3}\s?[\d\-\/\.xu\?\~a-zA-Z]*,?\s?
+        \d{3}[\d\-xs][s\d\-\.xu\?\~]*)
+      }x
+      regexp.match(str) do |m|
+        [m[1], m[2]]
+      end
+    end
+
+    ##
+    # Creates an EDTF::Interval from a string
+    #
+    # @param str [String] a string which may contain a date range
+    # @return [ETDF::Interval, nil] an EDTF object representing a date range
+    #   or nil if none can be found
+    #
+    # @see #range_match
+    def parse_interval(str)
+      match = range_match(str)
+      return nil if match.nil?
+
+      begin_date, end_date = match.map { |date| parse(date) || :unknown }
+
+      begin_date = begin_date.first if begin_date.respond_to? :first
+      end_date = end_date.last if end_date.respond_to? :last
+
+      EDTF::Interval.new(begin_date, end_date)
+    end
+
+    ##
+    # Runs `Date#parse`; if arguments are invalid (as with an invalid date
+    # string) returns `nil`.
+    #
+    # @return [Date, nil] the parsed date or nil
+    # @see Date#parse
+    def parse_date(*args)
+      begin
+        Date.parse(*args)
+      rescue ArgumentError
+        nil
+      end
+    end
+
+    ##
+    # Runs `Date#strptime` with '%m-%d-%Y'; if arguments are invalid (as with
+    # an invalid date string) returns `nil`.
+    #
+    # @param value [String] the string to parse
+    # @return [Date, nil] the parsed date or nil
+    # @see Date#strptime
+    def parse_m_d_y(value)
+      begin
+        Date.strptime(value.gsub(/[^0-9]/, '-'), '%m-%d-%Y')
+      rescue ArgumentError
+        nil
+      end
+    end
+
+    ##
+    # e.g. 01-2045
+    def month_year(str)
+      /^(\d{2})-(\d{4})$/.match(str) do |m|
+        Date.edtf("#{m[2]}-#{m[1]}")
+      end
+    end
+
+    ##
+    # e.g. 1990-92
+    def hyphenated_partial_range(str)
+      /^(\d{2})(\d{2})-(\d{2})$/.match(str) do |m|
+        Date.edtf("#{m[1]}#{m[2]}/#{m[1]}#{m[3]}")
+      end
+    end
+
+    ##
+    # e.g. 1970-08-01/02 or 1970-12/10
+    def partial_edtf(str)
+      /^(\d{4}(-\d{2})*)-(\d{2})\/(\d{2})$/.match(str) do |m|
+        Date.edtf("#{m[1]}-#{m[3]}/#{m[1]}-#{m[4]}")
+      end
+    end
+
+    ##
+    # e.g. 1990s
+    def decade_s(str)
+      /^(\d{3})0s$/.match(str) do |m|
+        Date.edtf("#{m[1]}x")
+      end
+    end
+
+    ##
+    # e.g. 199-
+    def decade_hyphen(str)
+      /^(\d{3})-$/.match(str) do |m|
+        Date.edtf("#{m[1]}x")
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/parse_date_spec.rb
+++ b/spec/lib/krikri/enrichments/parse_date_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::ParseDate do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'parses calendar to ruby Date',
+              :start => 'May 15, 2014',
+              :end => Date.parse('2014-05-15')
+            },
+            { :string => 'parses ISO to ruby Date',
+              :start => '2014-05-15',
+              :end => Date.parse('2014-05-15')
+            },
+            { :string => 'parses slash to ruby Date',
+              :start => '5/7/2012',
+              :end => Date.parse('2012-05-07')
+            },
+            { :string => 'parses dot to ruby Date',
+              :start => '5.7.2012',
+              :end => Date.parse('2012-05-07')
+            },
+            { :string => 'parses Month, Year to ruby Date',
+              :start => 'July, 2015',
+              :end => Date.parse('2015-07-01')
+            },
+            { :string => 'parses M-D-Y to ruby Date',
+              :start => '12-19-2010',
+              :end => Date.parse('2010-12-19')
+            },
+            { :string => 'parses uncertain to EDTF',
+              :start => '2015?',
+              :end => Date.edtf('2015?')
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => "moominpapa",
+              :end => "moominpapa"
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end

--- a/spec/lib/krikri/enrichments/timespan_split_spec.rb
+++ b/spec/lib/krikri/enrichments/timespan_split_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::TimespanSplit do
+  it_behaves_like 'a field enrichment'
+
+  context 'with a non-timespan object' do
+    it 'returns value' do
+      val = RDF::Node.new
+      expect(subject.enrich_value(val)).to be val
+    end
+  end
+
+  context 'with string' do
+    context 'ranged' do
+      it "parses to timespan" do
+        expect(subject.enrich_value('1993-1997')).to be_a DPLA::MAP::TimeSpan
+      end
+
+      it "sets begin on timespan" do
+        expect(subject.enrich_value('1993-1997').begin)
+          .to eql [Date.new(1993,1,1)]
+      end
+
+      it "sets end on timespan" do
+        expect(subject.enrich_value('1993-1997').end)
+          .to eql [Date.new(1997,12,31)]
+      end
+    end
+  end
+
+  context 'with timespan object' do
+    let(:timespan) do
+      build(:timespan, providedLabel: label, begin: begin_date, end: end_date)
+    end
+
+    let(:label) { nil }
+    let(:begin_date) { nil }
+    let(:end_date) { nil }
+
+    context 'with label' do
+      let(:label) { '199x - 2018' }
+
+      it 'adds begin date' do
+        expect(subject.enrich_value(timespan).begin)
+          .to eql [Date.new(1990, 1, 1)]
+      end
+
+      it 'adds end date' do
+        expect(subject.enrich_value(timespan).end)
+          .to eql [Date.new(2018, 12, 31)]
+      end
+
+      context 'and begin date' do
+        context 'earlier than parsed date' do
+          let(:begin_date) { Date.parse('-0002-01-01') }
+
+          it 'uses existing date' do
+            expect(subject.enrich_value(timespan).begin).to eql [begin_date]
+          end
+        end
+
+        context 'later than parsed date' do
+          let(:begin_date) { Date.parse('5002-01-01') }
+
+          it 'uses new date' do
+            expect(subject.enrich_value(timespan).begin)
+              .to eql [Date.new(1990, 1, 1)]
+          end
+        end
+      end
+
+      context 'and end date' do
+        context 'earlier than parsed date' do
+          let(:end_date) { Date.parse('-0002-01-01') }
+
+          it 'uses new date' do
+            expect(subject.enrich_value(timespan).end)
+              .to eql [Date.new(2018, 12, 31)]
+          end
+        end
+
+        context 'later than parsed date' do
+          let(:end_date) { Date.parse('5002-01-01') }
+
+          it 'uses existing date' do
+            expect(subject.enrich_value(timespan).end).to eql [end_date]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/util/extended_date_parser_spec.rb
+++ b/spec/lib/krikri/util/extended_date_parser_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Krikri::Util::ExtendedDateParser do
+  subject { described_class }
+
+  date_forms = [ '1992',
+                 '1992-12-01',
+                 '1992-12',
+                 '12-1992',
+                 '12-01-1992',
+                 '12.01.1992',
+                 '12/01/1992',
+                 # '01/01/199u', # this isn't valid EDTF and returns a bad date
+                 # '1992-11-uu?', # ETDF.rb doesn't support uu~
+                 '1992-12-01?',
+                 # '1992-11-uu~', # ETDF.rb doesn't support uu?
+                 '1992-12-01~',
+                 '1992-12-uu',
+                 '1992.12.01',
+                 '1992-12-01',
+                 '1992.12',
+                 '1992?',
+                 '199x',
+                 '1990s',
+                 '199-',
+                 'Dec 1992', # currently returns December 1
+                 'Dec 01 1992',
+                 'Dec 01, 1992'
+               ]
+
+  ranges = [ '-', 'to', 'until', '.', '......']
+
+  describe '#parse' do
+    date_forms.each do |str|
+      it "parses #{str} to timespan" do
+        result = subject.parse(str)
+        if result.is_a? EDTF::Decade
+          expect(result).to eq Date.edtf('199x')
+        else
+          expect(result).to eq Date.edtf('1992-12-01')
+            .send("#{result.precision}_precision".to_sym)
+        end
+      end
+    end
+  end
+
+  # describe '#range_match' do
+  #   ranges.each do |delim|
+  #     date_forms.each do |first|
+  #       date_forms.each do |last|
+  #         str = "#{first}  #{delim}  #{last}"
+  #         it "parses #{str} to start/end array" do
+  #           match = subject.range_match(str)
+  #           expect(match.length).to eq 2
+  #           expect(match.first).to include '199'
+  #           expect(match[1]).to include '199'
+  #           expect(subject.parse(match.first)).not_to be nil
+  #           expect(subject.parse(match[1])).not_to be nil
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+
+  describe '#partial_edtf' do
+    context 'with YYYY-MM-DD/DD' do
+      let(:start_date) { Date.new(2014,1,27) }
+      let(:end_date) { Date.new(2014,1,28) }
+
+      it 'parses date' do
+        expect(subject.partial_edtf('2014-01-27/28'))
+          .to have_attributes(:from => start_date,:to => end_date)
+      end
+
+      it 'gives nil for invalid date' do
+        expect(subject.partial_edtf('2014-01-98/28')).to eq nil
+      end
+    end
+
+    context 'with YYYY-MM/MM' do
+      let(:start_date) { Date.new(2014,1,1) }
+      let(:end_date) { Date.new(2014,3,1) }
+
+      it 'parses date' do
+        expect(subject.partial_edtf('2014-01/03'))
+          .to have_attributes(:from => start_date,:to => end_date)
+      end
+
+      it 'gives nil for invalid date' do
+        expect(subject.partial_edtf('2014-33/03')).to eq nil
+      end
+    end
+  end
+
+  describe '#month_year' do
+    let(:date) { Date.new(2014,2,1) }
+
+    it 'parses date' do
+      expect(subject.month_year('02-2014'))
+        .to eql date
+    end
+
+    it 'parses date' do
+      expect(subject.month_year('02-2014').precision)
+        .to eq :month
+    end
+  end
+
+  describe '#hyphenated_partial_range' do
+    let(:start_date) { Date.new(2013,1,1) }
+    let(:end_date) { Date.new(2014,1,1) }
+
+    it 'parses date' do
+      expect(subject.hyphenated_partial_range('2013-14'))
+        .to have_attributes(:from => start_date,:to => end_date)
+    end
+  end
+
+  describe '#decade_s' do
+    it 'parses date' do
+      expect(subject.decade_s('1990s'))
+        .to eq Date.edtf('199x')
+    end
+  end
+
+  describe '#decade_hyphen' do
+    it 'parses date' do
+      expect(subject.decade_hyphen('199-'))
+        .to eq Date.edtf('199x')
+    end
+  end
+end


### PR DESCRIPTION
Implements two date enrichments:

  - `ParseDate` converts string values in individual fields to `Date` objects.  This enrichment is meant to be run on TimeSpan attributes `#begin`/`#end` when they have been mapped directly.
  - `TimespanSplit` accepts a string value or a TimeSpan, and returns a timespan object with a single `#begin` and `#end`, if any can be found.  If no `#begin` and `#end` are set, they are parsed from `#providedLabel`.

Both rely on `Krikri::Util::ExtendedDateParser`, which parses strings to one of `Date`, `EDTF::Interval`, or `EDTF::Epoch`.  The last two represent date ranges; when they are returned to `TimespanSplit` it uses their methods to determine the start and end of the range. 