### PR TITLE
Fixup Guardfile to use new guard-rspec syntax

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', :version => 2 do
+guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/krikri.rb$})     { |m| "spec/krikri_spec.rb" }
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
Fixes 'Guard::RSpec error: No cmd option specified, unable to run specs' error (see
http://stackoverflow.com/questions/25034530).