### PR TITLE
Simplify CouchdbHarvester#get_record

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -30,7 +30,9 @@ Gem::Specification.new do |s|
   s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"
   s.add_dependency "resque", "~>1.0"
-  s.add_dependency "dpla-analysand", "3.1.0.pre.dpla.1"
+  # The line below can be switched to specify analysand 4.0.0.pre when it
+  # gets released
+  s.add_dependency "dpla-analysand", "4.0.0.pre.dpla.1"
   s.add_dependency "yajl-ruby"
 
   s.add_development_dependency "sqlite3"

--- a/lib/krikri/harvesters/couchdb_harvester.rb
+++ b/lib/krikri/harvesters/couchdb_harvester.rb
@@ -68,19 +68,12 @@ module Krikri::Harvesters
     ##
     # Retrieves a specific document from CouchDB.
     #
-    # Currently, this implementation does not use Analysand::Database#get
-    # because of an issue where document IDs sent to that method are not
-    # properly escaped.
+    # Uses Analysand::Database#get!, which raises an exception if the
+    # document cannot be found.
     #
-    # @see Analysand::Viewing
-    # @see Analysand::StreamingViewResponse
-    # @see Analysand::Database#get
-    def get_record(identifier, opts = {})
-      view = opts[:view] || @opts[:view]
-      doc = client.view(view,
-                        key: identifier,
-                        include_docs: true,
-                        stream: true).docs.first.to_json
+    # @see Analysand::Database#get!
+    def get_record(identifier)
+      doc = client.get!(CGI.escape(identifier)).body.to_json
       @record_class.build(mint_id(identifier), doc, 'application/json')
     end
 


### PR DESCRIPTION
The prerelease of Analysand fixes a bug I reported where document IDs were
not getting escaped properly (yipdw/analysand#7). We don't need to call
a view request and can instead use `Analysand:Database#get!`.

Also fixes one of the CouchdbHarvester specs for `#get_record`, which was
not implemented properly.