### PR TITLE
Install Jetty config using generator; tweak MARMOTTA_HOME

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,10 @@ desc "Run all specs in spec directory (excluding plugin specs) in an engine_cart
 task :ci => ['jetty:clean', 'engine_cart:generate'] do
   Rake::Task['jetty:config'].invoke
 
-  Jettywrapper.wrap(quiet: true, jetty_port: 8983, :startup_wait => 30) do
+  Jettywrapper.wrap(quiet: true,
+                    jetty_port: 8983,
+                    startup_wait: 30,
+                    java_opts: ["-Dmarmotta.home=#{MARMOTTA_HOME}"]) do
     Rake::Task["spec"].invoke
   end
 end

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -26,6 +26,12 @@ module Krikri
     end
 
     ##
+    # Add jetty configuration
+    def configure_jetty
+      copy_file '../../../../config/jetty.yml', 'config/jetty.yml'
+    end
+
+    ##
     # Install Devise
     # Devise is a dependency, and is specified in krikri.gemspec,
     # but it requires some setup if it's generated into

--- a/lib/tasks/jetty.rake
+++ b/lib/tasks/jetty.rake
@@ -2,9 +2,9 @@ require 'fileutils'
 require 'jettywrapper'
 
 namespace :jetty do
-  Jettywrapper.url = "https://github.com/dpla/marmotta-jetty/archive/3.3.0-solr-4.9.0.zip"
+  Jettywrapper.url = 'https://github.com/dpla/marmotta-jetty/archive/3.3.0-solr-4.9.0.zip'
 
-  MARMOTTA_HOME = ENV['MARMOTTA_HOME'] || File.expand_path(File.join(Jettywrapper.app_root, 'marmotta'))
+  MARMOTTA_HOME = ENV['MARMOTTA_HOME'] || File.expand_path(File.join(Jettywrapper.app_root, 'jetty', 'marmotta'))
 
   desc 'Configure solr schema'
   task :config do
@@ -18,5 +18,4 @@ namespace :jetty do
     FileUtils.rm_rf(MARMOTTA_HOME)
     Jettywrapper.clean
   end
-
 end


### PR DESCRIPTION
* Install Jetty configuration when running generator
* MARMOTTA_HOME:
    * Use `#{app_root}/jetty/marmotta` by default instead of `#{app_root)/marmotta`
    * Set MARMOTTA_HOME when running rake ci