### PR TITLE
Skip unavailiable fields in FieldEnrichment

### DIFF
--- a/lib/krikri/field_enrichment.rb
+++ b/lib/krikri/field_enrichment.rb
@@ -39,6 +39,7 @@ module Krikri
 
     def enrich_field(record, field_chain)
       field = field_chain.first
+      return record unless record.respond_to? field
       values = record.send(field)
       if field_chain.length == 1
         new_values = values.map { |v| enrich_value(v) }.flatten.compact

--- a/spec/support/shared_examples/enrichment.rb
+++ b/spec/support/shared_examples/enrichment.rb
@@ -159,10 +159,18 @@ shared_examples 'a field enrichment' do
 
       context 'when node is missing property' do
         before do
-          enriched.sourceResource.first.creator << ActiveTriples::Resource.new
+          record.sourceResource.first.creator << node
         end
 
-        it 'leaves node unaltered'
+        let(:node) do
+          creator = ActiveTriples::Resource.new
+          creator.set_value(RDF::DC.title, 'moomin')
+          creator
+        end
+
+        it 'leaves node unaltered' do
+          expect(record.sourceResource.first.creator).to include node
+        end
       end
     end
   end


### PR DESCRIPTION
Given a field chain like `{ :sourceResource => { :creator => :label } }`, values of `creator` that don't have a property `label` would previously cause the enrichment to fail.  Now they are simply passed over.