### PR TITLE
ISO Enrichment

### DIFF
--- a/lib/krikri/enrichments/iso_enrich.rb
+++ b/lib/krikri/enrichments/iso_enrich.rb
@@ -12,11 +12,15 @@ module Krikri::Enrichments
   #   'eng'     => 'http://lexvo.org/id/iso639-3/eng'
   #   'english' => 'http://lexvo.org/id/iso639-3/eng'
   #
+  # If no matches are found, returns a bnode with the input value as
+  # providedLabel.
+  #
   # If passed an ActiveTriples::Resource, the enrichment will:
   #
   #   - Perform the above text matching on any present `provededLabel`s,
-  #     returning empty if no matches are found.  If multiple values are
-  #     provided and multiple matches found, they will be deduplicated.
+  #     returning the original node if no results are found.  If multiple
+  #     values are provided and multiple matches found, they will be
+  #     deduplicated.
   #   - Leave DPLA::MAP::Controlled::Language objects that are not bnodes
   #     unaltered.
   #   - Remove any values which are not either bnodes or members of

--- a/lib/krikri/enrichments/iso_enrich.rb
+++ b/lib/krikri/enrichments/iso_enrich.rb
@@ -1,0 +1,82 @@
+module Krikri::Enrichments
+  ##
+  # Converts text fields and/or providedLabels to ISO 689-3 URIs (Lexvo)
+  #
+  # Transforms text values matching either (English) labels or ISO language
+  # codes from Lexvo into DPLA::MAP::Controlled::Language resources with
+  # appropriate URIs.
+  #
+  # For example:
+  #   'fin'     => 'http://lexvo.org/id/iso639-3/fin'
+  #   'finnish' => 'http://lexvo.org/id/iso639-3/fin'
+  #   'eng'     => 'http://lexvo.org/id/iso639-3/eng'
+  #   'english' => 'http://lexvo.org/id/iso639-3/eng'
+  #
+  # If passed an ActiveTriples::Resource, the enrichment will:
+  #
+  #   - Perform the above text matching on any present `provededLabel`s,
+  #     returning empty if no matches are found.  If multiple values are
+  #     provided and multiple matches found, they will be deduplicated.
+  #   - Leave DPLA::MAP::Controlled::Language objects that are not bnodes
+  #     unaltered.
+  #   - Remove any values which are not either bnodes or members of
+  #     DPLA::MAP::Controlled::Language.
+  #
+  # This enrichment sets `providedLabel` on any generated resource.
+  class IsoEnrich
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return enrich_node(value) if value.is_a?(ActiveTriples::Resource) &&
+        value.node?
+      return value if value.is_a?(DPLA::MAP::Controlled::Language)
+      return nil if value.is_a?(ActiveTriples::Resource)
+      enrich_literal(value)
+    end
+
+    def enrich_node(value)
+      labels = value.get_values(RDF::DPLA.providedLabel)
+      return nil if labels.empty?
+      langs = labels.map { |label| enrich_literal(label) }
+      langs.compact.uniq(&:rdf_subject)
+    end
+
+    def enrich_lang(value)
+      value.fetch
+      value
+    end
+
+    def enrich_literal(label)
+      return nil unless label.to_s
+      match = match_iso(label.to_s)
+      match ||= match_label(label.to_s)
+      match.providedLabel = label unless match.nil?
+      match
+    end
+
+    def match_iso(label)
+      from_terms(terms.map { |t| t.qname[1] }.select { |c| c == label.to_sym })
+    end
+
+    def match_label(label)
+      matches = terms.select do |t|
+        Array(t.label).map(&:downcase).include? label.downcase
+      end
+
+      from_terms(matches)
+    end
+
+    def terms
+      DPLA::MAP::Controlled::Language.list_terms
+    end
+
+    private
+
+    def from_terms(codes)
+      raise 'Found more than one matching ISO 639-3 codes: #{codes}' unless
+        codes.count <= 1
+      return nil if codes.empty?
+      DPLA::MAP::Controlled::Language.new(codes.first)
+    end
+  end
+end

--- a/lib/krikri/enrichments/iso_enrich.rb
+++ b/lib/krikri/enrichments/iso_enrich.rb
@@ -44,11 +44,6 @@ module Krikri::Enrichments
       langs.compact.uniq(&:rdf_subject)
     end
 
-    def enrich_lang(value)
-      value.fetch
-      value
-    end
-
     def enrich_literal(label)
       return nil unless label.to_s
       match = match_iso(label.to_s) || match_label(label.to_s)

--- a/lib/krikri/field_enrichment.rb
+++ b/lib/krikri/field_enrichment.rb
@@ -39,6 +39,7 @@ module Krikri
 
     def enrich_field(record, field_chain)
       field = field_chain.first
+      return record unless record.respond_to? field
       values = record.send(field)
       if field_chain.length == 1
         new_values = values.map { |v| enrich_value(v) }.flatten.compact

--- a/spec/lib/krikri/enrichments/iso_enrich_spec.rb
+++ b/spec/lib/krikri/enrichments/iso_enrich_spec.rb
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+describe Krikri::Enrichments::IsoEnrich do
+  it_behaves_like 'a field enrichment'
+
+  let(:english) { RDF::URI('http://lexvo.org/id/iso639-3/eng') }
+  let(:finnish) { RDF::URI('http://lexvo.org/id/iso639-3/fin') }
+
+  shared_examples 'match finder' do |method, label|
+    it 'returns a DPLA::MAP Language' do
+      expect(subject.send(method, label))
+        .to be_a DPLA::MAP::Controlled::Language
+    end
+
+    context 'with no matches' do
+      it 'returns nil' do
+        expect(subject.send(method, 'NOT A REAL LANG')).to be nil
+      end
+    end
+  end
+
+  context 'with string values' do
+    it 'finds a uri value' do
+      expect(subject.enrich_value('finnish'))
+        .to have_attributes(:rdf_subject => finnish)
+    end
+
+    it 'sets providedLabel' do
+      expect(subject.enrich_value('finnish'))
+        .to have_attributes(:providedLabel => ['finnish'])
+    end
+
+    it 'gives nil for invalid values' do
+      expect(subject.enrich_value('INVALID'))
+        .to be nil
+    end
+  end
+
+  context 'with a language resource' do
+    let(:lang) { DPLA::MAP::Controlled::Language.new('eng') }
+
+    it 'leaves the correct URI' do
+      expect(subject.enrich_value(lang))
+        .to have_attributes(:rdf_subject => english)
+    end
+  end
+
+  context 'with node' do
+    let(:lang) do
+      lang = ActiveTriples::Resource.new
+      lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'eng')
+    end
+
+    it 'enriches from providedLabel' do
+      expect(subject.enrich_value(lang))
+        .to contain_exactly(have_attributes(:rdf_subject => english))
+    end
+
+    it 'sets providedLabel' do
+      expect(subject.enrich_value(lang))
+        .to contain_exactly(have_attributes(:providedLabel => ['eng']))
+    end
+
+    context 'with no matching values' do
+      before do
+        lang.clear
+        lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'moomin language')
+      end
+
+      it 'returns no values' do
+        expect(subject.enrich_value(lang)).to be_empty
+      end
+    end
+
+    context 'with multiple providedLabels' do
+      context 'when labels match' do
+        before do
+          lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'eng')
+          lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'english')
+        end
+
+        it 'squashes to a single value' do
+          expect(subject.enrich_value(lang))
+            .to contain_exactly(have_attributes(:rdf_subject => english))
+        end
+      end
+
+      context 'when labels point to different resources' do
+        before do
+          lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'eng')
+          lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'finnish')
+          lang << RDF::Statement(lang, RDF::DPLA.providedLabel, 'NOT REAL')
+        end
+
+        it 'keeps both matches' do
+          expect(subject.enrich_value(lang))
+            .to contain_exactly(have_attributes(:rdf_subject => english),
+                                have_attributes(:rdf_subject => finnish))
+        end
+      end
+    end
+  end
+
+  describe '#match_iso' do
+    include_examples 'match finder', :match_iso, 'eng'
+
+    it 'finds URIs for 3 letter ISO codes' do
+      expect(subject.match_iso('eng').rdf_subject)
+        .to eq english
+    end
+  end
+
+  describe '#match_label' do
+    include_examples 'match finder', :match_label, 'finnish language'
+    it 'finds URIs that match explicit labels from Lexvo' do
+      expect(subject.match_label('finnish language').rdf_subject)
+        .to eq finnish
+    end
+  end
+end

--- a/spec/support/shared_examples/enrichment.rb
+++ b/spec/support/shared_examples/enrichment.rb
@@ -159,10 +159,18 @@ shared_examples 'a field enrichment' do
 
       context 'when node is missing property' do
         before do
-          enriched.sourceResource.first.creator << ActiveTriples::Resource.new
+          record.sourceResource.first.creator << node
         end
 
-        it 'leaves node unaltered'
+        let(:node) do
+          creator = ActiveTriples::Resource.new
+          creator.set_value(RDF::DC.title, 'moomin')
+          creator
+        end
+
+        it 'leaves node unaltered' do
+          expect(record.sourceResource.first.creator).to include node
+        end
       end
     end
   end


### PR DESCRIPTION
Converts text fields and/or providedLabels to ISO 689-3 URIs (Lexvo), searching for exact matches on 3 letter codes and labels.

Transforms text values matching either (English) labels or ISO language codes from Lexvo into DPLA::MAP::Controlled::Language resources with appropriate URIs.

For example:
```ruby
      'fin'     => 'http://lexvo.org/id/iso639-3/fin'
      'finnish' => 'http://lexvo.org/id/iso639-3/fin'
      'eng'     => 'http://lexvo.org/id/iso639-3/eng'
      'english' => 'http://lexvo.org/id/iso639-3/eng'
```
If no matches are found, returns a bnode with the input value as providedLabel.

If passed an ActiveTriples::Resource, the enrichment will:
  - Perform the above text matching on any present `providedLabel`s,  returning the original node if no results are found.
    - If a match is found, the resource is replaced by one with the appropriate URI.
    - If multiple values are provided and multiple matches found, they will be deduplicated.
  - Leave DPLA::MAP::Controlled::Language objects that are not bnodes unaltered.
  - Remove any values which are not either bnodes or members of  DPLA::MAP::Controlled::Language.

I'll discuss it with @guegueng and @rudeamy on 2/3. 