### PR TITLE
Change dependency from dpla-analysand to analysand

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -30,9 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"
   s.add_dependency "resque", "~>1.0"
-  # The line below can be switched to specify analysand 4.0.0.pre when it
-  # gets released
-  s.add_dependency "dpla-analysand", "4.0.0.pre.dpla.1"
+  s.add_dependency "analysand", "4.0.0"
   s.add_dependency "yajl-ruby"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Analysand 4.0.0 (officially released) fixes the workaround which introduced the
dependency on our prerelease for 1268f3b2a509b2cba0364d243722680733b9b0a7.