### PR TITLE
Avoids the rdf-marmotta Repository for SPARQL

### DIFF
--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -2,7 +2,7 @@ module Krikri
   ##
   # Implements SPARQL queries for finding RDF Resources by their PROV-O history.
   module ProvenanceQueryClient
-    SPARQL_CLIENT = SPARQL::Client.new(Krikri::Repository)
+    SPARQL_CLIENT = Repository.query_client
 
     module_function
 


### PR DESCRIPTION
SPARQL queries were routing through an incomplete RDF::Marmotta implementation. That implementation currently makes a lot of very broad queries (i.e. `CONSTRUCT :s, :p, :o`), which really ought to be avoided.