### PR TITLE
Add error logging to Harvester

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -42,10 +42,28 @@ module Krikri
     # is passed an instance of the agent, and a URI representing this Activity.
     def run
       if block_given?
+        update_attribute(:end_time, nil) if ended?
         set_start_time
-        yield agent_instance, rdf_subject
-        set_end_time
+        begin
+          yield agent_instance, rdf_subject
+        rescue => e
+          Rails.logger.error("Error performing Activity: #{id}\n" \
+                             "#{e.message}\n#{e.backtrace}")
+          raise e
+        ensure
+          set_end_time
+        end
       end
+    end
+
+    ##
+    # Indicates whether the activity has ended. Does not distinguish between
+    # successful and failed completion states.
+    #
+    # @return [Boolean] `true` if the activity has been marked as ended,
+    #   else `false`
+    def ended?
+      !self.end_time.nil?
     end
 
     ##

--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -102,7 +102,14 @@ module Krikri
     # @return [Boolean]
     def run(activity_uri = nil)
       log :info, 'harvest is running'
-      records.each { |rec| rec.save(activity_uri) }
+      records.each do |rec|
+        begin
+          rec.save(activity_uri)
+        rescue => e
+          log :error, "Error harvesting record:\n#{rec.content}\n\twith message:\n#{e.message}"
+          next
+        end
+      end
       log :info, 'harvest is done'
       true
     end

--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -17,4 +17,25 @@ describe Krikri::Harvester do
     end
   end
 
+  describe '#run' do
+    let(:records) { [double, double] }
+
+    before do
+      allow(subject).to receive(:records).and_return(records)
+    end
+
+    context 'when save fails' do
+      it 'logs error' do
+        records.each do |rec|
+          allow(rec).to receive(:save)
+                         .and_raise(StandardError.new('my message'))
+          allow(rec).to receive(:content).and_return 'content'
+        end
+        message =
+          "Error harvesting record:\ncontent\n\twith message:\nmy message"
+        expect(Rails.logger).to receive(:error).with(message).twice
+        subject.run
+      end
+    end
+  end
 end


### PR DESCRIPTION
~~I'm submitting this mostly for input.  @markbreedlove: thoughts?~~

Now with more complete error handling; more or less as discussed at https://dpla.slack.com/archives/tech/p1423166676000192.

 - Catches errors on individual records during `Harvester` runs, logging and passing over failed records.

 - Adds logging to `Activity#run`. Failed jobs are logged, the error is rethrown and the `end_time` is set for both successes and failures. Sets `end_time` to `nil` when a "ended" job restarts, so `end_time` should never be earlier than `start_time`.