### PR TITLE
Retry LDP requests on certain Errors

### DIFF
--- a/lib/krikri/ldp/resource.rb
+++ b/lib/krikri/ldp/resource.rb
@@ -11,6 +11,13 @@ module Krikri::LDP
     # @return [Faraday::Connection] a connection to the configured LDP endpoint
     def ldp_connection
       @ldp_conn ||= Faraday.new(ldp_ns) do |conn|
+        conn.request :retry, max: 4, interval: 0.025,
+                     interval_randomness: 0.5, backoff_factor: 2,
+                     exceptions: [Faraday::ConnectionFailed,
+                                  'Errno::ETIMEDOUT',
+                                  'Timeout::Error',
+                                  'Error::TimeoutError',
+                                  Faraday::TimeoutError]
         conn.use Faraday::Response::RaiseError
         conn.use FaradayMiddleware::FollowRedirects, limit: 3
         conn.adapter Faraday.default_adapter

--- a/spec/ldp/resource_spec.rb
+++ b/spec/ldp/resource_spec.rb
@@ -21,14 +21,22 @@ describe Krikri::LDP::Resource do
       # add required interface to DummyResourcey
       class DummyResource
         def rdf_subject
-          RDF::URI(File.join(Krikri::Settings['marmotta']['ldp'],
-                             '/moomin-papa'))
+          RDF::URI(Krikri::Settings['marmotta']['ldp']) / 'moomin-papa'
         end
       end
     end
 
     after do
       RDF::Marmotta.new(Krikri::Settings['marmotta']['base']).clear!
+    end
+
+    context 'with bad header' do
+      it do
+        error = Net::HTTPBadResponse.new("alue\" : \"1\"")
+        expect_any_instance_of(Faraday::Adapter::NetHttp)
+          .to receive(:perform_request).at_least(4).times.and_raise(error)
+        expect { subject.get }.to raise_error
+      end
     end
 
     context 'without marmotta connection' do


### PR DESCRIPTION
This will retry the errors we have been seeing a maximum of four times, starting with a 0.025-0.0375 second delay, and doubling that interval for each retry.  The longest delay would be 0.2-0.3 seconds.