### PR TITLE
Compare records

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,22 +95,25 @@ models, and views.  For more information, see [Blacklight's website](https://git
 Sample Data
 -----------
 
-To index a sample aggregation into solr, from `/krikri/spec/internal`:
-    rake krikri:index_sample_aggregation
+To save a sample record to Solr and Marmotta, from `/krikri/spec/internal`:
 
-To index an _invalid_ sample aggregation into solr:
-    rake krikri:index_invalid_aggregation
+    rake krikri:samples:save_record
 
-To delete the sample aggregation:
-    rake krikri:delete_sample_aggregation
+To save an _invalid_ sample record to Solr and Marmotta:
 
-To create a sample institution and harvest source, from `/krikri/spec/internal`:
+    rake krikri:samples:save_invalid_record
 
-    rake krikri:create_sample_institution
+To delete all sample records:
+
+    rake krikri:samples:delete_record
+
+To save a sample institution and harvest source, from `/krikri/spec/internal`:
+
+    rake krikri:samples:save_institution
 
 To delete the sample institution and harvest source:
 
-    rake krikri:delete_sample_institution
+    rake krikri:samples:delete_institution
 
 
 Using Vagrant for development (experimental)

--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -27,7 +27,6 @@ module Krikri
       }
 
       # solr field configuration for search results/index views
-      config.index.title_field = 'sourceResource_title'
 
       # solr fields that will be treated as facets by the blacklight application
       #   The ordering of the field names is the order of the display
@@ -65,7 +64,7 @@ module Krikri
 
       # solr fields to be displayed in the index (search results) view
       #   The ordering of the field names is the order of the display
-      config.add_index_field 'id', :label => 'ID'
+      config.add_index_field 'sourceResource_title', :label => 'Title'
       config.add_index_field 'sourceResource_description',
                              :label => 'Description'
       config.add_index_field 'sourceResource_date_providedLabel',
@@ -78,11 +77,8 @@ module Krikri
       config.index.thumbnail_field = :preview_id
 
       config.show.route = { controller: 'records' }
-    end
 
-    def show
-      # This will show an original records alongside an enhanced record.
+      config.solr_document_model = Krikri::SearchIndexDocument
     end
-
   end
 end

--- a/app/controllers/krikri/validation_reports_controller.rb
+++ b/app/controllers/krikri/validation_reports_controller.rb
@@ -36,6 +36,8 @@ module Krikri
                              helper_method: 'make_this_a_link'
 
       config.show.route = { controller: 'records' }
+
+      config.solr_document_model = Krikri::SearchIndexDocument
     end
 
     private

--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -27,15 +27,28 @@ module Krikri
       # Instantiate and populate an existing OriginalRecord Resource.
       #
       # @param identifier [#to_s] a string representing the #local_name or
-      #   fully qualified URI for the resource.
+      #   fully qualified URI for the resource.  Identifier may have a mime type
+      #   extension, ie. '123.xml'.
       # @return [OriginalRecord] the instantiated record.
       # @raise when no matching record is found in the LDP datastore
       def load(identifier)
         identifier = identifier.to_s.split('/').last if
           identifier.start_with? base_uri
-        record = new(identifier)
+
+        if identifier.include?('.')
+          record = new(identifier.split('.').first)
+        else
+          record = new(identifier)
+        end
+
         raise "No #{self} found with id: #{identifier}" unless record.exists?
-        record.rdf_subject = nr_uri_from_headers(record.http_head)
+
+        if identifier.include?('.')
+          record.rdf_subject = "#{base_uri}/#{identifier}"
+        else
+          record.rdf_subject = nr_uri_from_headers(record.http_head)
+        end
+
         record.reload
       end
 

--- a/app/models/krikri/search_index_document.rb
+++ b/app/models/krikri/search_index_document.rb
@@ -1,0 +1,18 @@
+module Krikri
+  ##
+  # Subclass of Blacklight's SolrDocument.
+  # Represents a single document returned from a query to the search index.
+  class SearchIndexDocument < SolrDocument
+
+    ##
+    # Get the aggregation, populated with data from Marmotta, which corresponds
+    # to this SearchIndexDocument
+    # @return [DPLA::MAP::Aggregation, nil]
+    def aggregation
+      agg = DPLA::MAP::Aggregation.new(id)
+      return nil unless agg.exists?
+      agg.get
+      agg
+    end
+  end
+end

--- a/app/views/krikri/records/show.html.erb
+++ b/app/views/krikri/records/show.html.erb
@@ -1,1 +1,19 @@
-This view will show an enriched record alongside its original record.
+<% content_for :title do %>QA Record: <%= @document.id.html_safe %><% end %>
+
+<div id="main-container" class="container">
+  <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
+
+  <h2>QA Record: <%= @document.id.html_safe %></h2>
+
+  <div class="row">
+    <div class="col-md-6 col-sm-6">
+      <h3>Enriched Record</h3>
+      <pre class="pre-scrollable"><%= render_enriched_record(@document) %></pre>
+    </div>
+
+    <div class="col-md-6 col-sm-6">
+      <h3>Original Record</h3>
+      <pre class="pre-scrollable"><%= render_original_record(@document) %></pre>
+    </div>
+  </div>
+</div>

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -77,6 +77,19 @@ module Krikri
           set_subject!(local_name_from_original_record)
         end
 
+        ##
+        # Get the persisted original record for this Aggregation.
+        # @return [Krikri::OriginalRecord, nil]
+        #
+        # An Exception will be raised if:
+        #   the original record id is invalid.
+        #   the original record has not been persisted to Marmotta.
+        #   there is a connection problem with  Marmotta.
+        def original_record
+          Krikri::OriginalRecord.load(originalRecord.first.rdf_subject
+            .to_s)
+        end
+
         private
 
         def local_name_from_original_record

--- a/lib/tasks/krikri.rake
+++ b/lib/tasks/krikri.rake
@@ -1,77 +1,115 @@
 require 'factory_girl_rails'
 include FactoryGirl::Syntax::Methods
 require 'dpla/map/factories'
+require '../../app/models/krikri/original_record.rb'
+require '../../spec/factories/krikri_original_record.rb'
 require 'open-uri'
 require 'resque/tasks'
 
 require 'krikri/index_service'
 
 namespace :krikri do
+  namespace :samples do
 
-  # Tasks will execute in spec/internal unless directory is changed
-  desc 'Index a valid sample aggregation'
-  task :index_sample_aggregation do
-    agg = build(:aggregation)
+    # Note: The content of the sample original record does not actually
+    # correspond to the content of the sample aggregation.
+    desc 'Save a sample record to Marmotta and Solr'
+    task :save_record => :environment do
+      original_record = build(:oai_dc_record)
+      original_record.save unless original_record.exists?
 
-    graph = agg.to_jsonld['@graph'][0]
+      # Make a DPLA::MAP::Aggregation with an original record instantiated as an
+      # ActiveTriples::Resource object.
+      agg = build(:aggregation,
+                  :originalRecord => ActiveTriples::Resource
+                                  .new(original_record.rdf_subject)
+            )
 
-    # prepend "krikri_sample" to @id so that sample data can be identified for
-    # deletion
-    graph['@id'] = 'krikri_sample' + graph['@id']
+      agg.mint_id!('krikri_sample')
 
-    Krikri::IndexService.add graph.to_json
-    Krikri::IndexService.commit
-  end
+      # Save to Marmotta
+      agg.save unless agg.exists?
 
-  desc 'Index aggregations with missing required values'
-  task :index_invalid_aggregation do
+      # Save to Solr
+      graph = agg.to_jsonld['@graph'].first
+      Krikri::IndexService.add graph.to_json
+      Krikri::IndexService.commit
+    end
 
-    agg = build(:aggregation,
-                :sourceResource => build(:source_resource, title: nil)
-    )
+    desc 'Save an invalid sample record to Marmotta and Solr'
+    task :save_invalid_record => :environment do
+      original_record = build(:json_record)
+      original_record.save unless original_record.exists?
 
-    graph = agg.to_jsonld['@graph'][0]
-    graph['@id'] = 'krikri_sample_invalid'
+      agg = build(:aggregation,
+                  :originalRecord => ActiveTriples::Resource
+                                      .new(original_record.rdf_subject),
+                  :sourceResource => build(:source_resource, title: nil)
+            )
 
-    Krikri::IndexService.add graph.to_json
-    Krikri::IndexService.commit
-  end
+      agg.mint_id!('krikri_sample_invalid')
 
-  desc 'Delete all sample aggregations from solr'
-  task :delete_sample_aggregation do
-    Krikri::IndexService.delete_by_query 'id:krikri_sample*'
-    Krikri::IndexService.commit
-  end
+      # Save to Marmotta
+      agg.save unless agg.exists?
 
-  desc 'Create sample institution and harvest source'
-  # the '=> :environment' dependency gives task access to ActiveRecord models
-  task :create_sample_institution => :environment do
+      # Save to Solr
+      graph = agg.to_jsonld['@graph'].first
+      Krikri::IndexService.add graph.to_json
+      Krikri::IndexService.commit
+    end
 
-    unless Krikri::Institution.find_by(name: 'Krikri Sample Institution')
+    desc 'Delete all sample records from Marmotta and Solr'
+    task :delete_record => :environment do
+      # Delete aggregation from Marmotta
+      agg = DPLA::MAP::Aggregation.new
+      agg.mint_id!('krikri_sample')
+      agg.delete! if agg.exists?
 
-      institution = Krikri::Institution.create(
-        name: 'Krikri Sample Institution',
-        notes: 'These are notes about the Krikri Sample Institution.'
-      )
+      agg = DPLA::MAP::Aggregation.new
+      agg.mint_id!('krikri_sample_invalid')
+      agg.delete! if agg.exists?
 
-      Krikri::HarvestSource.create(
-        institution_id: institution.id,
-        name: 'OAI feed',
-        source_type: 'OAI',
-        metadata_schema: 'MARC',
-        uri: 'http://www.example.com',
-        notes: 'These are notes about the Krikri Sample Source.'
-      )
+      # Delete original records from Marmotta
+      original_record = build(:oai_dc_record)
+      original_record.delete! if original_record.exists?
 
+      original_record = build(:json_record)
+      original_record.delete! if original_record.exists?
+
+      # Delete all sample records from Solr
+      Krikri::IndexService.delete_by_query 'id:*krikri_sample*'
+      Krikri::IndexService.commit
+    end
+
+    desc 'Save sample institution and harvest source'
+    # the '=> :environment' dependency gives task access to ActiveRecord models
+    task :save_institution => :environment do
+
+      unless Krikri::Institution.find_by(name: 'Krikri Sample Institution')
+
+        institution = Krikri::Institution.create(
+          name: 'Krikri Sample Institution',
+          notes: 'These are notes about the Krikri Sample Institution.'
+        )
+
+        Krikri::HarvestSource.create(
+          institution_id: institution.id,
+          name: 'OAI feed',
+          source_type: 'OAI',
+          metadata_schema: 'MARC',
+          uri: 'http://www.example.com',
+          notes: 'These are notes about the Krikri Sample Source.'
+        )
+
+      end
+    end
+
+    desc 'Delete sample institution and harvest source'
+    task :delete_institution => :environment do
+      # any harvest sources associated with sample institution will be
+      # destroyed through dependent_destroy
+      institution = Krikri::Institution.find_by(name: 'Krikri Sample Institution')
+      institution.destroy if institution
     end
   end
-
-  desc 'Delete sample institution and harvest source'
-  task :delete_sample_institution => :environment do
-    # any harvest sources associated with sample institution will be
-    # destroyed through dependent_destroy
-    institution = Krikri::Institution.find_by(name: 'Krikri Sample Institution')
-    institution.destroy if institution
-  end
-
 end

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -504,7 +504,7 @@ v         currently supported on types that are sorted internally as strings
    <!-- set multiValued to true in order to copyfield -->
    <field name="text" type="text" indexed="true" stored="false" multiValued="true" />
 
-   <field name="type" type="string" indexed="false" stored="false" />
+   <field name="type" type="string" indexed="false" stored="false" multiValued="true" />
 
    <field name="dataProvider_id" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="dataProvider_type" type="string" indexed="false" stored="false" />

--- a/spec/helpers/krikri/records_helper_spec.rb
+++ b/spec/helpers/krikri/records_helper_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe Krikri::RecordsHelper, :type => :helper do
+  include Krikri::SearchResultsHelperBehavior
+
+  let(:document) { double }
+  let(:agg) { build(:aggregation) }
+  let(:original) { double }
+
+  describe '#render_enriched_record' do
+    context 'with existing aggregation' do
+      before(:each) do
+        allow(document).to receive(:aggregation).and_return(agg)
+      end
+
+      it 'returns json String' do
+        result = helper.render_enriched_record(document)
+        expect { JSON.parse(result) }.not_to raise_error
+      end
+    end
+
+    context 'without existing aggregation' do
+      before(:each) do
+        allow(document).to receive(:aggregation).and_return(nil)
+      end
+
+      it 'returns an error message' do
+        expect(helper.render_enriched_record(document)).to be_a(String)
+      end
+
+    end
+
+    describe '#render_original_record' do
+      context 'with existing aggregation' do
+        before(:each) do
+          allow(document).to receive(:aggregation).and_return(agg)
+        end
+
+        context 'with original record' do
+          before(:each) do
+            allow(agg).to receive(:original_record).and_return(original)
+          end
+
+          context 'if content is json' do
+            before(:each) do
+              content = { 'a' => 'b' }.to_json
+              allow(original).to receive(:to_s).and_return(content)
+              allow(original).to receive(:content_type)
+                .and_return('application/json')
+            end
+
+            it 'returns json String' do
+              result = helper.render_original_record(document)
+              expect { JSON.parse(result) }.not_to raise_error
+            end
+          end
+
+          context 'if content is xml' do
+            before(:each) do
+              content = '<?xml version="1.0"?>hello</xml>'
+              allow(original).to receive(:to_s).and_return(content)
+              allow(original).to receive(:content_type).and_return('text/xml')
+            end
+
+            it 'renders String' do
+              result = helper.render_original_record(document)
+              expect(result).to be_a(String)
+            end
+          end
+
+          context 'if content is String' do
+            before(:each) do
+              allow(original).to receive(:to_s).and_return('content string')
+              allow(original).to receive(:content_type).and_return('text/plain')
+            end
+
+            it 'renders String' do
+              result = helper.render_original_record(document)
+              expect(result).to eq 'content string'
+            end
+          end
+        end
+
+        context 'without original record' do
+          before(:each) do
+            allow(agg).to receive(:original_record).and_return(nil)
+          end
+
+          it 'returns an error message' do
+            expect(helper.render_original_record(document)).to be_a(String)
+          end
+        end
+      end
+
+      context 'without existing aggregation' do
+        before(:each) do
+          allow(document).to receive(:aggregation).and_return(nil)
+        end
+
+        it 'returns an error message' do
+          expect(helper.render_original_record(document)).to be_a(String)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/index_service_spec.rb
+++ b/spec/lib/krikri/index_service_spec.rb
@@ -6,22 +6,38 @@ describe Krikri::IndexService do
   let(:solr) { RSolr.connect }
 
   describe '#solr_doc' do
-    it 'converts JSON into Solr-compatible hash' do
-      json = { 'a' => '1', 'b' => { 'c' => '2', 'd' => '3' } }.to_json
-      flat_hash = { 'a' => '1', 'b_c' => '2', 'b_d' => '3' }
-      result = subject.class_eval { solr_doc(json) }
-      expect(result).to eq flat_hash
-    end
 
-    it 'removes special character strings from keys' do
-      json = {
-        'http://www.geonames.org/ontology#a' => '1',
-        'http://www.w3.org/2003/01/geo/wgs84_pos#b' => '2',
-        '@c' => '3'
-      }.to_json
-      flat_hash = { 'a' => '1', 'b' => '2', 'c' => '3' }
-      result = subject.class_eval { solr_doc(json) }
-      expect(result).to eq flat_hash
+    context 'without models' do
+
+      before :each do
+        fake_schema_keys = ['a', 'b', 'c', 'b_c', 'b_d']
+        allow(subject).to receive(:schema_keys).and_return(fake_schema_keys)
+      end
+
+      it 'converts JSON into Solr-compatible hash' do
+        json = { 'a' => '1', 'b' => { 'c' => '2', 'd' => '3' } }.to_json
+        flat_hash = { 'a' => '1', 'b_c' => '2', 'b_d' => '3' }
+        result = subject.class_eval { solr_doc(json) }
+        expect(result).to eq flat_hash
+      end
+
+      it 'removes special character strings from keys' do
+        json = {
+          'http://www.geonames.org/ontology#a' => '1',
+          'http://www.w3.org/2003/01/geo/wgs84_pos#b' => '2',
+          '@c' => '3'
+        }.to_json
+        flat_hash = { 'a' => '1', 'b' => '2', 'c' => '3' }
+        result = subject.class_eval { solr_doc(json) }
+        expect(result).to eq flat_hash
+      end
+
+      it 'removes keys that are not in solr schema' do
+        json = { 'a' => '1', 'invalid_key' => '0' }.to_json
+        valid_hash = { 'a' => '1' }
+        result = subject.class_eval { solr_doc(json) }
+        expect(result).to eq valid_hash
+      end
     end
 
     context 'with models' do
@@ -42,6 +58,14 @@ describe Krikri::IndexService do
       it 'posts DPLA MAP JSON to solr' do
         response = solr.get('select', :params => { :q => '' })['response']
         expect(response['numFound']).to eq 1
+      end
+    end
+
+    describe '#schema_keys' do
+      it 'returns an Array of keys' do
+        result = subject.schema_keys
+        expect(result).to be_a(Array)
+        expect(result).not_to be_empty
       end
     end
   end

--- a/spec/models/dpla/map/aggregation_spec.rb
+++ b/spec/models/dpla/map/aggregation_spec.rb
@@ -65,4 +65,27 @@ describe DPLA::MAP::Aggregation do
       end
     end
   end
+
+  describe '#original_record' do
+
+    context 'with original record' do
+      let(:original_record) { Krikri::OriginalRecord.build('123', 'abc') }
+
+      before do
+        original_record.save
+        subject.originalRecord = ActiveTriples::Resource
+          .new(original_record.rdf_subject.to_s)
+      end
+
+      it 'returns OriginalRecord object' do
+        expect(subject.original_record).to eq(original_record)
+      end
+    end
+
+    context 'without original record' do
+      it 'raises an error' do
+        expect { subject.original_record }.to raise_error
+      end
+    end
+  end
 end

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -55,6 +55,19 @@ describe Krikri::OriginalRecord do
           expect(described_class.load(uri).local_name).to eq identifier
         end
       end
+
+      context 'when passed an identifier with a mime type extension' do
+        let(:id_ext) { "#{identifier}.xml"}
+
+        it 'sets #local_name without extension' do
+          expect(described_class.load(id_ext).local_name).to eq(identifier)
+        end
+
+        it 'sets rdf_subject with extension' do
+          expect(described_class.load(id_ext).rdf_subject.to_s)
+            .to end_with(id_ext)
+        end
+      end
     end
   end
 

--- a/spec/models/search_index_document_spec.rb
+++ b/spec/models/search_index_document_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Krikri::SearchIndexDocument, type: :model do
+
+  subject do
+    Krikri::SearchIndexDocument.new(id: '0123')
+  end
+
+  it 'is a SolrDocument' do
+    expect(subject).to be_a SolrDocument
+  end
+
+  describe '#aggregation' do
+
+    it 'creates a DPLA::MAP::Aggregation with its id' do
+      expect(DPLA::MAP::Aggregation).to receive(:new).with('0123')
+        .and_return(DPLA::MAP::Aggregation.new('0123'))
+      subject.aggregation
+    end
+
+    context 'with existing Marmotta record' do
+
+      before :each do
+        allow_any_instance_of(DPLA::MAP::Aggregation).to receive(:exists?)
+          .and_return(true)
+      end
+
+      it 'gets data from Marmotta' do
+        expect_any_instance_of(DPLA::MAP::Aggregation).to receive(:get)
+        subject.aggregation
+      end
+
+      it 'returns a DPLA::MAP::Aggregation' do
+        allow_any_instance_of(DPLA::MAP::Aggregation).to receive(:get)
+        expect(subject.aggregation)
+          .to be_instance_of(DPLA::MAP::Aggregation)
+      end
+    end
+
+    context 'without existing Marmotta record' do
+
+      before :each do
+        allow_any_instance_of(DPLA::MAP::Aggregation).to receive(:exists?)
+          .and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(subject.aggregation).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
View original record and enhanced record side-by-side
* SearchIndexDocument model (subclass of SolrDocument) allows a single document returned from a Solr query to be associated with its DPLA::MAP::Aggregation
* New initializer mix-in to DPLA::MAP::Aggregation allows aggregation to be associated with its original record
* Allows OriginalRecord to be loaded from an identifier with a mime type extension
* Rake tasks save sample aggregations and original records to Marmotta
* New records#show view with helper methods in SearchResultsHelperBehavior
* IndexService does not attempt to index fields that are not defined in the Solr schema

To test in browser:
* Generate test app with engine cart
* You may need to `stop`, `clean`, and `config` jetty
* Follow new instructions in `README.md` to save a sample valid and/or invalid record
* Open `/krikri/records` in your browser and click on a record to view `records#show`