### PR TITLE
Require ActiveSupport core_ext for Strings in OriginalRecord factories

### DIFF
--- a/spec/factories/krikri_original_record.rb
+++ b/spec/factories/krikri_original_record.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/strip'
+
 FactoryGirl.define do
 
   factory :krikri_original_record, class: Krikri::OriginalRecord do


### PR DESCRIPTION
Builds were failing on dpla/KriKri#86, @AudreyAltman's compare records PR. Looking at [Travis logs](https://travis-ci.org/dpla/KriKri/builds/49515202#L755) for the failed build, running the database migrations (called by the Devise-related generator steps) were failing, because of a `NoMethodError` for `String#strip_heredoc`. This change introduces the minimal dependency on the specific ActiveSupport core extensions module used in the OriginalRecord factories.