### PR TITLE
Add parser arguments to mapping definitions

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -34,13 +34,14 @@ module Krikri
     #
     # @param name [Symbol] a unique name for the mapper in the registry.
     # @param opts [Hash] options to pass to the mapping instance, options are:
-    #   :class
+    #   :class, :parser, and :parser_args
     # @yield A block passed through to the mapping instance containing the
     #   mapping in the language specified by MappingDSL
     def define(name, opts = {}, &block)
       klass = opts.fetch(:class, DPLA::MAP::Aggregation)
       parser = opts.fetch(:parser, Krikri::XmlParser)
-      map = Krikri::Mapping.new(klass, parser)
+      parser_args = opts.fetch(:parser_args, nil)
+      map = Krikri::Mapping.new(klass, parser, *parser_args)
       map.instance_eval(&block) if block_given?
       Registry.register!(name, map)
     end

--- a/lib/krikri/mapping.rb
+++ b/lib/krikri/mapping.rb
@@ -10,14 +10,19 @@ module Krikri
   class Mapping
     include MappingDSL
 
-    attr_reader :klass, :parser
+    attr_reader :klass, :parser, :parser_args
 
     ##
     # @param klass [Class] The model class to build in the mapping process.
     # @param parser [Class] The parser class with which to process resources.
-    def initialize(klass = DPLA::MAP::Aggregation, parser = Krikri::XmlParser)
+    # @param parser_args [Array] The arguments to pass to the parser when
+    #   processing records.
+    def initialize(klass = DPLA::MAP::Aggregation,
+                   parser = Krikri::XmlParser,
+                   *parser_args)
       @klass = klass
       @parser = parser
+      @parser_args = parser_args
     end
 
     ##
@@ -27,7 +32,7 @@ module Krikri
     def process_record(record)
       mapped_record = klass.new
       properties.each do |prop|
-        prop.to_proc.call(mapped_record, parser.parse(record))
+        prop.to_proc.call(mapped_record, parser.parse(record, *@parser_args))
       end
       mapped_record
     end

--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -20,10 +20,12 @@ module Krikri
     # Instantiates a parser object to wrap the record. Returns the record
     # as is if it is already parsed.
     #
-    # @param record the record to parse
+    # @param record [Krikri::OriginalRecord, Krikri::Parser] the record to parse
+    # @param args [Array, nil] the arguments to pass to the parser instance,
+    #   if any
     # @return [Krikri::Parser] a parsed record object
-    def self.parse(record)
-      record.is_a?(Krikri::Parser) ? record : new(record)
+    def self.parse(record, *args)
+      record.is_a?(Krikri::Parser) ? record : new(record, *args)
     end
 
     ##

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -40,6 +40,20 @@ describe Krikri::Mapper do
       Krikri::Mapper.define(:klass_map, class: klass)
     end
 
+    it 'passes parser to mapping' do
+      parser = Class.new
+      expect(Krikri::Mapping).to receive(:new)
+        .with(DPLA::MAP::Aggregation, parser).once
+      Krikri::Mapper.define(:klass_map, parser: parser)
+    end
+
+    it 'passes parser_args to mapping' do
+      args = [1,2,3]
+      expect(Krikri::Mapping).to receive(:new)
+        .with(DPLA::MAP::Aggregation, Krikri::XmlParser, *args).once
+      Krikri::Mapper.define(:klass_map, parser_args: args)
+    end
+
     it 'hits DSL methods' do
       expect_any_instance_of(Krikri::Mapping).to receive(:dsl_method_1)
         .with(:arg1, :arg2)

--- a/spec/lib/krikri/mapping_spec.rb
+++ b/spec/lib/krikri/mapping_spec.rb
@@ -2,9 +2,22 @@ require 'spec_helper'
 
 describe Krikri::Mapping do
 
-  let(:record) { build(:oai_dc_record) }
+  let(:target_class) { double }
+  let(:parser) { double }
+  let(:parser_args) { [1,2,3] }
+
+  describe '#new' do
+    it 'accepts target class, parser, and parser arguments' do
+      expect(described_class.new(target_class, parser, *parser_args))
+        .to have_attributes(klass: target_class,
+                            parser: parser,
+                            parser_args: parser_args)
+    end
+  end
 
   describe '#process_record' do
+    let(:record) { build(:oai_dc_record) }
+
     it 'creates a DPLA::MAP record' do
       expect(subject.process_record(record)).to be_a DPLA::MAP::Aggregation
     end
@@ -13,6 +26,23 @@ describe Krikri::Mapping do
       klass = DPLA::MAP::SourceResource
       new_mapping = Krikri::Mapping.new(klass)
       expect(new_mapping.process_record(record)).to be_a klass
+    end
+
+    context 'with parser' do
+      before do
+        target_instance = double
+        allow(target_class).to receive(:new).and_return(target_instance)
+        allow(target_instance).to receive(:my_property=).and_return('')
+        subject.my_property ''
+      end
+
+      subject { described_class.new(target_class, parser, *parser_args) }
+
+      it 'parses record before mapping' do
+        expect(parser)
+          .to receive(:parse).with(record, *parser_args).and_return(record)
+        subject.process_record(record)
+      end
     end
 
     context 'with static properties' do

--- a/spec/support/shared_examples/parser.rb
+++ b/spec/support/shared_examples/parser.rb
@@ -10,8 +10,15 @@ shared_examples_for 'a parser' do
   end
 
   describe '#parse' do
+    let(:args) { [1, 2, 3] }
     it 'wraps a record in this parser' do
       expect(described_class.parse(record)).to be_a described_class
+    end
+
+    it 'uses parser args' do
+      expect(described_class)
+        .to receive(:new).with(record, *args).and_return(:parsed)
+      expect(described_class.parse(record, *args)).to eq :parsed
     end
 
     it 'returns the record if already parsed' do


### PR DESCRIPTION
Krikri::Mapper::Agent receives only unparsed records, assuming that the
Mapping will handle parsing through `#process_record`.  The parser to
use is specified through the mapping definition with the `:parser`
option.

Previously, there was no way to pass arguments to the parser. Arguments
are not needed in most cases, but necessary for some `Krikri::XmlParser`
subclasses.  This adds `:parser_args`, allowing you to pass an array
of parser arguments when defining a mapping.

    Krikri::Mapper.define(:scdl_qdc,
		          :parser => Krikri::QdcParser,
    			  :parser_args => ['//qdc:qualifieddc']) do
      ...
    end