### PR TITLE
Mapper error logging & empty DSL URI

### DIFF
--- a/lib/krikri/mapping_dsl/rdf_subjects.rb
+++ b/lib/krikri/mapping_dsl/rdf_subjects.rb
@@ -13,7 +13,9 @@ module Krikri::MappingDSL
         value = @value
         lambda do |target, record|
           value = value.call(record) if value.respond_to? :call
-          raise "URI must be set to a single value; got #{value}" if
+          return target.rdf_subject if Array(value).empty?
+          raise "Error mapping #{record}, #{target}\t" \
+                "URI must be set to a single value; got #{value}" if
             Array(value).count != 1
           value = value.first if value.is_a? Enumerable
           return target.send(setter, value) unless block

--- a/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
@@ -100,12 +100,28 @@ describe Krikri::MappingDSL::RdfSubjects do
         let(:array_value) { [value] }
       end
 
+      context 'with no values' do
+        let(:value) { [] }
+        let(:node) { RDF::Node.new }
+
+        before { allow(mapped).to receive(:rdf_subject).and_return(node) }
+
+        it 'gives the bnode subject' do
+          expect(subject.to_proc.call(mapped, '')).to eq node
+        end
+
+        it 'leaves the rdf_subject untouched' do
+          expect(mapped).not_to receive(:set_subject!)
+          subject.to_proc.call(mapped, '')
+        end
+      end
+
       context 'with too many values' do
         let(:value) { ['http://example.org/1', 'http://example.org/2'] }
 
         it 'raises an error' do
           expect { subject.to_proc.call(mapped, '') }
-            .to raise_error "URI must be set to a single value; got #{value}"
+            .to raise_error
         end
       end
     end


### PR DESCRIPTION
Adds error handling and logging for `Mapper` activities. These are handled similarly to `Harvester` error handling, this passes over failures on mapped records and logs the error message.

A separate commit addresses cases where empty value sets are passed to URI in the DSL.