### PR TITLE
Streamline and improve Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ require 'jettywrapper'
 import 'lib/tasks/jetty.rake'
 
 desc "Run all specs in spec directory (excluding plugin specs) in an engine_cart-generated app"
-task :ci => ['jetty:clean', 'engine_cart:generate'] do
+task :ci => ['jetty:clean', 'engine_cart:clean', 'engine_cart:generate'] do
   Rake::Task['jetty:config'].invoke
 
   Jettywrapper.wrap(quiet: true,

--- a/lib/tasks/jetty.rake
+++ b/lib/tasks/jetty.rake
@@ -4,7 +4,10 @@ require 'jettywrapper'
 namespace :jetty do
   Jettywrapper.url = 'https://github.com/dpla/marmotta-jetty/archive/3.3.0-solr-4.9.0.zip'
 
-  MARMOTTA_HOME = ENV['MARMOTTA_HOME'] || File.expand_path(File.join(Jettywrapper.app_root, 'jetty', 'marmotta'))
+  DEFAULT_MARMOTTA = File.expand_path(File.join(Jettywrapper.app_root,
+                                                'jetty',
+                                                'marmotta'))
+  MARMOTTA_HOME = ENV['MARMOTTA_HOME'] || DEFAULT_MARMOTTA
 
   desc 'Configure solr schema'
   task :config do
@@ -13,9 +16,10 @@ namespace :jetty do
        'jetty/solr/development-core/conf/solrconfig.xml')
   end
 
-  desc 'Remove the jetty and marmotta directories and recreate them'
-  task :clean do
-    FileUtils.rm_rf(MARMOTTA_HOME)
-    Jettywrapper.clean
+  desc 'Empty the Marmotta home directory used by Jettywrapper'
+  task :clean_marmotta_home do
+    FileUtils.rm_rf(MARMOTTA_HOME) unless MARMOTTA_HOME == DEFAULT_MARMOTTA
   end
+
+  task :clean => [:clean_marmotta_home]
 end


### PR DESCRIPTION
* `rake ci` now invokes `engine_cart:clean` before running `engine_cart:generate`,
to allow for improved local testing by developers before pushing up their commits.
* Adds new `jetty:clean_marmotta_home` task, which deletes `MARMOTTA_HOME` if defined
to something other than the default. If `MARMOTTA_HOME` is set to the default, it will
automatically get removed by `jetty:clean`.
* Makes `jetty:clean_marmotta_home` a prerequsite for `jetty:clean`. This also removes a
second (accidental) invokation of `jetty:clean` from the previous tasks file.
* <strike>Adds a dependency on `rubyzip`, now required by Jettywrapper >= 2.0.1. Declaring
`rubyzip` as a development dependency was not adequate for some reason</strike> **Fixed by Jettywrapper >= 2.0.2**