### PR TITLE
Add ability select multiple fields from ValueArray

### DIFF
--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -28,18 +28,53 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
-  describe '#field' do
+  shared_context 'with fields' do
     before do
       values.each do |val|
         nested_field = instance_double(Krikri::Parser::Value)
         allow(val).to receive(:[]).with(:field_name)
-          .and_return(nested_field)
+                       .and_return(nested_field)
         allow(val).to receive(:[]).with(:nonexistent_field)
-          .and_return(described_class.new([]))
+                       .and_return(described_class.new([]))
         allow(nested_field).to receive(:[]).with(:nested_name)
-          .and_return(:final_value)
+                                .and_return(:final_value)
       end
     end
+  end
+
+  describe '#[]=' do
+    it 'raises error when invalid values are added' do
+      expect { subject[0] = 1 }
+        .to raise_error described_class::InvalidParserValueError
+    end
+
+    it 'adds item to array' do
+      value = Krikri::Parser::Value.new
+      subject[0] = value
+      expect(subject).to include value
+    end
+  end
+
+  describe '#<<' do
+    it 'raises error when invalid values are added' do
+      expect { subject << 1 }
+        .to raise_error described_class::InvalidParserValueError
+    end
+
+    it 'adds to count' do
+      value = Krikri::Parser::Value.new
+      expect { subject << value }.to change { subject.count }.by(1)
+    end
+
+    it 'adds item to array' do
+      value = Krikri::Parser::Value.new
+      subject << value
+      expect(subject).to include value
+    end
+  end
+
+  describe '#field' do
+    include_context 'with fields'
 
     it 'gives values from a field' do
       expect(subject.field(:field_name, :nested_name))
@@ -52,6 +87,42 @@ describe Krikri::Parser::ValueArray do
 
     it 'returns an instance of its class' do
       expect(subject.field(:field_name)).to be_a described_class
+    end
+  end
+
+  describe '#fields' do
+    include_context 'with fields'
+
+    it 'returns single field' do
+      expect(subject.fields(:field_name))
+        .to contain_exactly(*subject.field(:field_name))
+    end
+
+    it 'returns single field when passed as array' do
+      expect(subject.fields([:field_name]))
+        .to contain_exactly(*subject.field(:field_name))
+    end
+
+    it 'returns nested fields when passed as array' do
+      expect(subject.fields([:field_name, :nested_name]))
+        .to contain_exactly(*subject.field(:field_name, :nested_name))
+    end
+
+    it 'returns union of fields when some are nested' do
+      expect(subject.fields([:field_name, :nested_name], :field_name))
+        .to contain_exactly(*subject.field(:field_name)
+                             .concat(subject.field(:field_name, :nested_name)))
+    end
+
+    it 'returns union of fields when all are nested' do
+      expect(subject.fields([:field_name, :nested_name], [:field_name]))
+        .to contain_exactly(*subject.field(:field_name)
+                              .concat(subject.field(:field_name, :nested_name)))
+    end
+
+    it 'returns union of fields when some are nonexistent' do
+      expect(subject.fields([:field_name, :nested_name], [:nonexistent_field]))
+        .to contain_exactly(*subject.field(:field_name, :nested_name))
     end
   end
 
@@ -78,6 +149,29 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#concat' do
+    it 'gives union of two arrays' do
+      vals = subject.to_a.dup
+      expect(subject.concat(vals)).to contain_exactly(*vals.concat(vals))
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.concat(subject)).to be_a described_class
+    end
+  end
+
+  describe '#flatten' do
+    it do
+      vals = subject.to_a.dup
+      new_val_arry = described_class.new(subject)
+      expect(new_val_arry.flatten).to contain_exactly(*vals)
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.flatten).to be_a described_class
+    end
+  end
+
   describe '#select' do
     it 'creates new array with selected values' do
       expect(subject.select { |v| v.value == 'value_1'})
@@ -92,7 +186,7 @@ describe Krikri::Parser::ValueArray do
   describe '#reject' do
     it 'creates new array not containing rejected values' do
       expect(subject.reject { |v| v.value == 'value_1'})
-        .not_to include(values[1])
+        .not_to include values[1]
     end
 
     it 'returns an instance of its class' do
@@ -104,7 +198,6 @@ describe Krikri::Parser::ValueArray do
     before do
       values.each { |val| allow(val).to receive(:attribute?).and_return(false) }
     end
-
 
     it 'selects values by their attributes' do
       allow(values[0]).to receive(:attribute?).with(:type).and_return(true)


### PR DESCRIPTION
Creates `ValueArray#fields` which accepts multiple fields/chains and gives their union.

Also adds:
  - `ValueArray#[]=` with type checking
  - `ValueArray#<<` with type checking
  - `ValueArray#flatten` to return a new `ValueArray`
  - `ValueArray#concat` to return a new `ValueArray`