### PR TITLE
Add `#header` node to OAI Parsers (and DSL method)

### DIFF
--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -1,5 +1,5 @@
 ##
-# Require 'blacklight' before 'krikri/engine' to ensure that view order is 
+# Require 'blacklight' before 'krikri/engine' to ensure that view order is
 # configured properly.
 require 'rails'
 require 'devise'
@@ -7,10 +7,10 @@ require 'blacklight'
 require "krikri/engine"
 
 module Krikri
-  autoload :XmlParser,      'krikri/parsers/xml_parser'
-  # autoload Krikri::OaiDcParser
-  autoload :OaiDcParser,    'krikri/parsers/oai_dc_parser'
-  autoload :JsonParser,     'krikri/parsers/json_parser'
-  autoload :ModsParser,     'krikri/parsers/mods_parser'
-  autoload :QdcParser,      'krikri/parsers/qdc_parser'
+  autoload :XmlParser,        'krikri/parsers/xml_parser'
+  autoload :OaiDcParser,      'krikri/parsers/oai_dc_parser'
+  autoload :JsonParser,       'krikri/parsers/json_parser'
+  autoload :ModsParser,       'krikri/parsers/mods_parser'
+  autoload :QdcParser,        'krikri/parsers/qdc_parser'
+  autoload :OaiParserHeaders, 'krikri/parsers/oai_parser_headers'
 end

--- a/lib/krikri/mapping_dsl/parser_methods.rb
+++ b/lib/krikri/mapping_dsl/parser_methods.rb
@@ -42,6 +42,20 @@ module Krikri::MappingDSL
     end
 
     ##
+    # Gives access to a delayed call for the `#header` of a parsed record.
+    #
+    # @return [Proc] a proc that, when called, returns the #rdf_subject of the
+    #   OriginalRecord associated with the parsed record passed as its argument.
+    # @todo consider a more generalized approach
+    def header
+      lambda do |parsed|
+        raise "#{parsed} does not have a `header`" unless
+          parsed.respond_to? :header
+        parsed.header
+      end
+    end
+
+    ##
     # This class acts as a proxy for a parsed record's nodes, wrapped in the
     # class passed as the second argument. All methods available on the wrapper
     # class are accepted via #method_missing, added to the #call_chain, and

--- a/lib/krikri/parsers/oai_dc_parser.rb
+++ b/lib/krikri/parsers/oai_dc_parser.rb
@@ -4,6 +4,8 @@ module Krikri
   # metadata path as harvested from OAI-PMH.
   # @see Krikri::XmlParser
   class OaiDcParser < XmlParser
+    include Krikri::OaiParserHeaders
+
     def initialize(record, root_path = '//oai_dc:dc')
       super
     end

--- a/lib/krikri/parsers/oai_parser_headers.rb
+++ b/lib/krikri/parsers/oai_parser_headers.rb
@@ -1,0 +1,20 @@
+module Krikri
+  ##
+  # Concern for Krikri::XmlParsers with oai-style headers
+  # @example
+  #    class MyOaiParser < Krikri::XmlParser
+  #      include Krikri::OaiParserHeaders
+  #    end
+  module OaiParserHeaders
+    extend ActiveSupport::Concern
+
+    ##
+    # @return [Krikri::Parser::ValueArray] a ValueArray containing the
+    #   header node as a `Value` of this parser class
+    def header
+      header_node = Nokogiri::XML(record.to_s).at_xpath('//xmlns:header')
+      Krikri::Parser::ValueArray
+        .new([self.class::Value.new(header_node, root.namespaces)])
+    end
+  end
+end

--- a/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
@@ -15,7 +15,6 @@ describe Krikri::MappingDSL::ParserMethods do
   subject { DummyParserImpl.new }
 
   let(:record) { instance_double('Krikri::XmlParser') }
-  let(:real) { Krikri::XmlParser.new(build(:oai_dc_record)) }
 
   describe '#record' do
     it 'returns a callable object' do
@@ -53,6 +52,24 @@ describe Krikri::MappingDSL::ParserMethods do
       allow(record).to receive_message_chain(:record, :exists?)
         .and_return(false)
       expect { subject.record_uri.call(record) }.to raise_error
+    end
+  end
+
+  describe 'header' do
+    let(:record) { double }
+
+    it 'gets the header from the record passed' do
+      allow(record).to receive(:respond_to?).with(:header)
+                        .and_return(true)
+      allow(record).to receive(:header).and_return(:header_array)
+      expect(subject.header.call(record)).to eq (:header_array)
+    end
+
+    it 'gets the header from the record passed' do
+      allow(record).to receive(:respond_to?).with(:header)
+                        .and_return(false)
+      expect { subject.header.call(record) }
+        .to raise_error "#{record} does not have a `header`"
     end
   end
 end

--- a/spec/lib/krikri/parsers/oai_dc_parser_spec.rb
+++ b/spec/lib/krikri/parsers/oai_dc_parser_spec.rb
@@ -5,4 +5,5 @@ describe Krikri::OaiDcParser do
   let(:record) { build(:oai_dc_record) }
 
   it_behaves_like 'a parser'
+  it_behaves_like 'a parser with oai headers'
 end

--- a/spec/support/shared_examples/oai_parser_headers.rb
+++ b/spec/support/shared_examples/oai_parser_headers.rb
@@ -1,0 +1,12 @@
+shared_examples 'a parser with oai headers' do
+  describe '#header' do
+    it 'has a header' do
+      expect(subject.header).to be_a Krikri::Parser::ValueArray
+    end
+
+    it 'has children' do
+      expect(subject.header.first.children)
+        .to include('xmlns:identifier', 'xmlns:datestamp', 'xmlns:setSpec')
+    end
+  end
+end


### PR DESCRIPTION
Adds a mixin module `OaiParserHeaders` for use with `XmlParser` classes.  This module adds a `#header` method which gives access to the `<oai:header>` tag and its members, even when that tag is out of scope of the root node.

Adds a specialized method to the mapping DSL via `ParserMethods` to access the header.  This method raises an error if no header exists.