### PR TITLE
Make Mapper#map's exception handling more robust

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -62,12 +62,26 @@ module Krikri
         begin
           Registry.get(name).process_record(rec)
         rescue => e
-          Rails.logger.error("Error processing mapping for #{rec.rdf_subject}" \
-                             "\n#{e.message}\n#{e.backtrace}")
+          desc = mapping_exception_desc(rec)
+          bt = e.backtrace.join("\n")
+          Rails.logger.error("Error processing mapping.\n" \
+                             "#{desc}\n#{e.message}\n#{bt}")
           nil
         end
       end
     end
+
+    ##
+    # Return a string that describes the object encountered by the exception
+    # handler in #map
+    def mapping_exception_desc(rec)
+      if defined? rec.content
+        "content:\n#{rec.content || '[no content]'}"
+      else
+        "object:\n#{rec.inspect}"
+      end
+    end
+    private_class_method :mapping_exception_desc
 
     ##
     # An application-wide registry of defined mappings

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -120,7 +120,7 @@ describe Krikri::Mapper do
 
         it 'logs errors and continues' do
           expect(Rails.logger)
-            .to receive(:error).with(start_with('Error processing mapping for'))
+            .to receive(:error).with(start_with('Error processing mapping'))
                  .exactly(3).times
           Krikri::Mapper.map(:my_map_2, records)
         end


### PR DESCRIPTION

This tries to make `Mapper#map` a little more resilient and print prettier messages.

If it has been given actual records, the typical case, it will log a message that starts with something like this:
```
[3] pry(main)> puts Krikri::Mapper.map(:scdl_qdc, r).first.dump :ttl
Error processing mapping.
content: <?xml version="1.0"?>
<record xmlns="http://www.openarchives.org/OAI/2.0/">
  <header>
[ ... ]
```
... with a newline-delimited stacktrace, like this:
```
scdl_qdc is not registered.
/home/dpla/krikri/lib/krikri/registry.rb:25:in `get'
/home/dpla/krikri/lib/krikri/mapper.rb:63:in `block in map'
/home/dpla/krikri/lib/krikri/mapper.rb:61:in `map'
/home/dpla/krikri/lib/krikri/mapper.rb:61:in `map'
(pry):3:in `<main>'
/home/dpla/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/pry-0.10.1/lib/pry/pry_instance.rb:355:in `eval'
[ ... ]
```

It it has been given some other kind of object (something without a `content` method), it will just use `#inspect` to print it out.  I figure that this is not the usual case, so I'm just printing the whole output of #inspect, instead of truncating it.  Let me know if you would really like it truncated, e.g. to 100 or 200 characters.  I just can't predict where the interesting information is going to be in that string.

I could see using `#inspect` for everything but it seems like showing the `@content` might give the quickest insight about what is wrong with a given mapping.  The method was originally printing `@rdf_subject` but, to my inexperienced eye, it seems that `@content` looks like it might be more interesting and more likely to be defined and non-nil.

I expect that this might need some refinement, so just let me know of you think that's the case.
