### PR TITLE
Random record generator

### DIFF
--- a/app/views/krikri/records/show.html.erb
+++ b/app/views/krikri/records/show.html.erb
@@ -5,6 +5,9 @@
 
   <h2>QA Record: <%= @document.id.html_safe %></h2>
 
+  <%= button_to 'Random record', random_record_url,
+    :class => "btn btn-primary", :method => :get %>
+
   <div class="row">
     <div class="col-md-6 col-sm-6">
       <h3>Enriched Record</h3>

--- a/lib/krikri/random_record_generator.rb
+++ b/lib/krikri/random_record_generator.rb
@@ -1,0 +1,19 @@
+module Krikri
+  # Gets random records from the search index
+  class RandomRecordGenerator
+
+    def initialize
+      @solr_repo = Blacklight::SolrRepository.new(Blacklight::Configuration.new)
+    end
+
+    # @return Krikri::SearchIndexDocument
+    def record
+      solr_params = { :id => "*:*",
+                      :sort => "random_#{rand(9999)} desc",
+                      :rows => 1 }
+      query_result = @solr_repo.search(solr_params)
+      solr_response = Blacklight::SolrResponse.new(query_result, solr_params)
+      Krikri::SearchIndexDocument.new(solr_response.docs.first)
+    end
+  end
+end

--- a/lib/krikri/search_results_helper_behavior.rb
+++ b/lib/krikri/search_results_helper_behavior.rb
@@ -65,7 +65,7 @@ module Krikri
         return error_msg(e.message)
       end
 
-      return error_msg('Original record not found.') unless 
+      return error_msg('Original record not found.') unless
         original_record.present?
       prettify_string(original_record.to_s, original_record.content_type)
     end
@@ -96,6 +96,10 @@ module Krikri
 
     def error_msg(message = '')
       "There was a problem getting the record.\n\n#{message}"
+    end
+
+    def random_record_url
+      url_for_document(Krikri::RandomRecordGenerator.new.record)
     end
   end
 end


### PR DESCRIPTION
This adds the ability to view a random record to the QA interface.  A record is randomly selected from Solr and displayed in the `records#show` view.  

To test in your browser window:

1. Generate test app and start jetty.
2. Index a sample record:

```bash
cd spec/internal
bundle exec rake krikri:samples:save_record
```

3. If you want to test the random selection, index more sample records, from the rails console:

```ruby
include FactoryGirl::Syntax::Methods
require 'dpla/map/factories'
agg = build(:aggregation)
agg.mint_id!('sample2')
graph = agg.to_jsonld['@graph'].first
Krikri::IndexService.add graph.to_json
Krikri::IndexService.commit
```

4. Start the rails server and open [http://localhost:3000/krikri/records/http:%2F%2Flocalhost:8983%2Fmarmotta%2Fldp%2Fitems%2Fkrikri_sample](http://localhost:3000/krikri/records/http:%2F%2Flocalhost:8983%2Fmarmotta%2Fldp%2Fitems%2Fkrikri_sample) in your browser window.

5. Click on the "Random Record" button.  The page should refresh with one of the two records you've saved, randomly selected.

I did not write a unit test for RandomRecordGenerator b/c it seemed like I would just be stubbing out a lot of Blacklight functionality.  If anyone thinks a unit test would be helpful, please advise.