### PR TITLE
Add set access, multiple harvests and blacklisting to OAIHarvester

### DIFF
--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -60,13 +60,34 @@ module Krikri::Harvesters
       end
     end
 
-    # TODO: normalize records; there will be differences in XML
-    # for different requests
+    ##
+    # Gets a single record with the given identifier from the OAI endpoint
+    #
+    # @param identifier [#to_s] the identifier of the record to get
+    # @param opts [Hash] options to pass to the OAI client
     def get_record(identifier, opts = {})
       opts[:identifier] = identifier
       opts = opts.merge(@opts)
       @record_class.build(mint_id(identifier),
                           record_xml(client.get_record(opts).record))
+    end
+
+    ##
+    # Lists the sets available from the OAI endpoint. Accepts a block to
+    # pass to `#map` on the resulting array.
+    #
+    # @example:
+    #
+    #   sets(&:spec)
+    #
+    # @param opts [Hash] options to pass to the OAI client
+    # @return [Array<OAI::Set>] an array of sets.
+    #
+    # @see OAI::Set
+    def sets(opts = {}, &block)
+      arry = client.list_sets.full.to_a
+      return arry unless block_given?
+      arry.map(&block)
     end
 
     ##
@@ -76,7 +97,9 @@ module Krikri::Harvesters
         key: :oai,
         opts: {
           set: {type: :string, required: false, multiple_ok: true},
-          metadata_prefix: {type: :string, required: true}
+          metadata_prefix: {type: :string, required: false},
+          from: {type: :string, required: false},
+          until: {type: :string, required: false}
         }
       }
     end

--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -1,6 +1,29 @@
 module Krikri::Harvesters
   ##
   # A harvester implementation for OAI-PMH
+  #
+  # Accepts options to pass to OAI client as `:oai => opts`
+  #
+  # @example
+  #
+  #   OAIHarvester.new(:uri => endpoint,
+  #     :oai => { :set => 'my_set', :metadata_prefix => 'oai_dc' }
+  #
+  # Options allowed are:
+  #
+  #   - set: A string or array of strings specifying the sets to harvest.
+  #          If multiple sets are given, they will be lazily requested from
+  #          `OAI::Client#list_records` in turn and combined into a single
+  #          enumerator.
+  #   - skip_set: A string or array of strings specifying the sets to skip.
+  #               If both `set` and `skip_set` are given, sets specified as
+  #               skip are excluded from the harvest. Otherwise, all sets
+  #               returned by `#set` except those skipped will be harvested.
+  #   - metadata_prefix: A string specifying the metadata prefix. e.g. 'oai_dc'.
+  #   - from: The begin date for the harvest.
+  #   - until: The end date for the harvest.
+  #
+  # @see http://www.rubydoc.info/gems/oai/OAI/Client
   class OAIHarvester
     include Krikri::Harvester
     attr_accessor :client
@@ -32,9 +55,13 @@ module Krikri::Harvesters
     #
     #     record_ids.take(1000)
     #
+    # @param opts [Hash] opts to pass to OAI::Client
+    # @see #expected_opts
     def record_ids(opts = {})
-      opts = opts.merge(@opts)
-      client.list_identifiers(opts).full.lazy.flat_map(&:identifier)
+      opts = @opts.merge(opts)
+      request_with_sets(opts) do |set_opts|
+        client.list_identifiers(set_opts).full.lazy.flat_map(&:identifier)
+      end
     end
 
     # Count on record_ids will request all ids and load them into memory
@@ -51,12 +78,15 @@ module Krikri::Harvesters
     #
     #     records.take(1000)
     #
+    # @param opts [Hash] opts to pass to OAI::Client
+    # @see #expected_opts
     def records(opts = {})
-      opts = opts.merge(@opts)
-      client.list_records(opts).full.lazy.flat_map do |rec|
-        @record_class.build(mint_id(rec.header.identifier),
-                            record_xml(rec))
-
+      opts = @opts.merge(opts)
+      request_with_sets(opts) do |set_opts|
+        client.list_records(set_opts).full.lazy.flat_map do |rec|
+          @record_class.build(mint_id(rec.header.identifier),
+                              record_xml(rec))
+        end
       end
     end
 
@@ -67,7 +97,7 @@ module Krikri::Harvesters
     # @param opts [Hash] options to pass to the OAI client
     def get_record(identifier, opts = {})
       opts[:identifier] = identifier
-      opts = opts.merge(@opts)
+      opts = @opts.merge(opts)
       @record_class.build(mint_id(identifier),
                           record_xml(client.get_record(opts).record))
     end
@@ -91,12 +121,16 @@ module Krikri::Harvesters
     end
 
     ##
+    # @return [Hash] A hash documenting the allowable options to pass to
+    #   initializers.
+    #
     # @see Krikri::Harvester::expected_opts
     def self.expected_opts
       {
         key: :oai,
         opts: {
           set: {type: :string, required: false, multiple_ok: true},
+          skip_set: {type: :string, required: false, multiple_ok: true},
           metadata_prefix: {type: :string, required: false},
           from: {type: :string, required: false},
           until: {type: :string, required: false}
@@ -104,7 +138,39 @@ module Krikri::Harvesters
       }
     end
 
+    ##
+    # Concatinates two enumerators
+    # @todo find a better home for this. Reopen Enumerable? or use the
+    #    `Enumerating` gem: https://github.com/mdub/enumerating
+    def concat_enum(*enums)
+      Enumerator.new do |yielder|
+        enums.each do |enum|
+          enum.each { |i| yielder << i }
+        end
+      end
+    end
+
     private
+
+    ##
+    # Runs the request in the given block against the sets specified in `opts`.
+    # Results are concatenated into a single enumerator
+    def request_with_sets(opts, &block)
+      sets = Array(opts.delete(:set))
+      if opts[:skip_set]
+        sets = self.sets(&:spec) if sets.empty?
+        skips = Array(opts.delete(:skip_set))
+        sets.reject! { |s| skips.include? s }
+      end
+      sets = [nil] if sets.empty?
+
+      set_enums = sets.map do |set|
+        set_opts = opts.dup
+        set_opts[:set] = set unless set.nil?
+        yield(set_opts) if block_given?
+      end
+      concat_enum(*set_enums).lazy
+    end
 
     def record_xml(rec)
       doc = Nokogiri::XML::Builder.new do |xml|

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -47,15 +47,8 @@ describe Krikri::Harvesters::OAIHarvester do
                    :headers => {})
 
       # ListRecords -- Multiple record OAI Request (w/ resumption)
-      stub_request(:get,
-                   'http://example.org/endpoint?metadataPrefix=oai_dc&verb='\
-                   'ListRecords')
-        .with(:headers => {
-                'Accept' => '*/*',
-                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
-              })
-        .to_return(:status => 200,
-                   :body => '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T23:05:33Z</responseDate><request verb="ListRecords" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><ListRecords><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+      response_body = <<EOM
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T23:05:33Z</responseDate><request verb="ListRecords" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><ListRecords><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
    <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
    <dc:creator>Bart Besamusca</dc:creator>
    <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000010</dc:identifier>
@@ -96,7 +89,74 @@ describe Krikri::Harvesters::OAIHarvester do
    <dc:contributor>Bart Besamusca</dc:contributor>
    <dc:type>model</dc:type>
    <dc:language>eng</dc:language>
-</oai_dc:dc></metadata></record><resumptionToken cursor="1">MToxMHwyOnwzOnw0Onw1Om9haV9kYw==</resumptionToken></ListRecords></OAI-PMH>',
+</oai_dc:dc></metadata></record><resumptionToken cursor="1">MToxMHwyOnwzOnw0Onw1Om9haV9kYw==</resumptionToken></ListRecords></OAI-PMH>
+EOM
+      stub_request(:get,
+                   'http://example.org/endpoint?metadataPrefix=oai_dc&verb='\
+                   'ListRecords')
+        .with(:headers => {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
+              })
+        .to_return(:status => 200,
+                   :body => response_body,
+                   :headers => {})
+
+      # with set
+      response_body = <<EOM
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="static/oai2.xsl"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2014-10-27T23:05:33Z</responseDate><request verb="ListRecords" metadataPrefix="oai_dc">http://oaipmh.huygens.knaw.nl/</request><ListRecords><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 446-E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000010</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000011</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction</setSpec><setSpec>arthurianfiction:manuscript</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 5018-D</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000011</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000012</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction</setSpec><setSpec>arthurianfiction:manuscript</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 445-D</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000012</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata><about>
+<oaiProvenance:provenance xmlns:oaiProvenance="http://www.openarchives.org/OAI/2.0/provenance" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/provenance http://www.openarchives.org/OAI/2.0/provenance.xsd">
+<oaiProvenance:originDescription harvestDate="2015-01-07" altered="true">
+<oaiProvenance:baseURL>http://cdm16694.contentdm.oclc.org/oai/oai.php</oaiProvenance:baseURL>
+<oaiProvenance:identifier>oai:cdm16694.contentdm.oclc.org:R6A001/1</oaiProvenance:identifier>
+<oaiProvenance:datestamp>2015-01-07</oaiProvenance:datestamp>
+<oaiProvenance:metadataNamespace>http://www.openarchives.org/OAI/2.0/</oaiProvenance:metadataNamespace>
+</oaiProvenance:originDescription>
+</oaiProvenance:provenance>
+</about></record><record><header><identifier>oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000013</identifier><datestamp>2012-07-13T14:27:31Z</datestamp><setSpec>arthurianfiction:manuscript</setSpec><setSpec>arthurianfiction</setSpec></header><metadata><oai_dc:dc xmlns:cmdi="http://www.clarin.eu/cmd/" xmlns:database="http://www.oclc.org/pears/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1345561703673/xsd">
+   <dc:title>Aberystwyth, National Library of Wales, 5667 E</dc:title>
+   <dc:creator>Bart Besamusca</dc:creator>
+   <dc:identifier>https://service.arthurianfiction.org/manuscript/MAN0000000013</dc:identifier>
+   <dc:date>2012-07-13T14:27:31Z</dc:date>
+   <dc:contributor>Bart Besamusca</dc:contributor>
+   <dc:type>model</dc:type>
+   <dc:language>eng</dc:language>
+</oai_dc:dc></metadata></record><resumptionToken cursor="1">MToxMHwyOnwzOnw0Onw1Om9haV9kYw==</resumptionToken></ListRecords></OAI-PMH>
+EOM
+
+      stub_request(:get,
+                   'http://example.org/endpoint?metadataPrefix=mods&set=moomin&' \
+                   'verb=ListRecords')
+        .with(:headers => {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
+              })
+        .to_return(:status => 200,
+                   :body => response_body,
                    :headers => {})
 
       # ListRecords -- Multiple record OAI Request (resumed)
@@ -218,12 +278,35 @@ EOM
             .and_return(result)
           subject.send(method)
         end
+
         it 'adds options passed into request' do
           expect(subject.client).to receive(request_type)
             .with(:metadata_prefix => args[:oai][:metadata_prefix],
                   :set => request_opts[:set])
             .and_return(result)
           subject.send(method, request_opts)
+        end
+
+        context 'with multiple sets' do
+          before { args[:oai][:set] = ['moomin', 'moomin'] }
+          it 'skips sets when specific sets are selected' do
+            opts = args[:oai].dup
+            opts.delete(:set)
+            expect(subject.client).to receive(request_type).with(opts)
+                                       .and_return(result)
+            subject.send(method, { :skip_set => 'moomin' })
+          end
+
+          it 'skips sets from full list when none given' do
+            args[:oai].delete(:set)
+            opts = args[:oai].dup
+            opts[:set] = 'valid'
+
+            allow(subject).to receive(:sets).and_return(['valid', 'moomin'])
+            expect(subject.client).to receive(request_type).with(opts)
+                                       .and_return(result)
+            subject.send(method, { :skip_set => 'moomin' })
+          end
         end
       end
 
@@ -233,6 +316,12 @@ EOM
 
         let(:request_type) { :list_records }
         let(:method) { :records }
+
+        it 'combines sets' do
+          args[:oai][:set] = ['moomin', 'moomin']
+          single_set = subject.records(:set => 'moomin').to_a
+          expect(subject.records.to_a).to eq single_set.concat(single_set)
+        end
       end
 
       describe 'record_ids' do
@@ -286,6 +375,20 @@ EOM
         activity = Krikri::Activity.first
         opts = JSON.parse(activity.opts, symbolize_names: true)
         expect(opts).to eq(args)
+      end
+    end
+
+    describe 'concat_enum' do
+
+      it 'concatenates enums' do
+        expect(subject.concat_enum((1..10), (100..110)).to_a)
+          .to eq (1..10).to_a.concat((100..110).to_a)
+      end
+
+      it 'works with lazy' do
+        enum = double
+        expect(enum).not_to receive :each
+        subject.concat_enum((1..10), enum).lazy.take(10)
       end
     end
 

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -152,6 +152,52 @@ describe Krikri::Harvesters::OAIHarvester do
       end
     end
 
+    describe '#sets' do
+      before do
+        response_body = <<EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2015-02-21T17:07:46Z</responseDate>
+  <request verb="ListSets">http://fedora.digitalcommonwealth.org/oaiprovider/</request>
+<ListSets>
+<set>
+  <setSpec>commonwealth-oai:1r66j283x</setSpec>
+  <setName>History of the Academy</setName>
+</set>
+<set>
+  <setSpec>commonwealth-oai:1r66j2871</setSpec>
+  <setName>List of Vessels Belonging to the District of Gloucester</setName>
+</set>
+<set>
+  <setSpec>commonwealth-oai:wp988k074</setSpec>
+  <setName>NOBLE Collection</setName>
+</set>
+</ListSets>
+</OAI-PMH>
+EOM
+        stub_request(:get, "http://example.org/endpoint?verb=ListSets").
+          with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}).
+          to_return(:status => 200,
+                    :body => response_body,
+                    :headers => {})
+      end
+
+      it 'returns sets' do
+        expect(subject.sets).to contain_exactly(an_instance_of(OAI::Set),
+                                                an_instance_of(OAI::Set),
+                                                an_instance_of(OAI::Set))
+      end
+
+      it 'passes block to sets' do
+        expect(subject.sets(&:spec)).to contain_exactly(an_instance_of(String),
+                                                       an_instance_of(String),
+                                                       an_instance_of(String))
+      end
+    end
+
     describe 'options' do
       let(:result) { double }
       let(:args) do


### PR DESCRIPTION
 - Adds `OAIHarvester#sets` to list sets.
 - Adds ability to specify multiple sets to harvest by passing a list to the `:set` option on `#records` and `#record_ids`.
 - Adds ability to blacklist sets in `#records` and `#record_ids` requests.