### PR TITLE
Feature/skip deleted

### DIFF
--- a/lib/krikri/harvesters/basic_save_behavior.rb
+++ b/lib/krikri/harvesters/basic_save_behavior.rb
@@ -1,0 +1,9 @@
+module Krikri::Harvesters
+  ##
+  # Harvest behavior that call a simple save on a record
+  class BasicSaveBehavior < HarvestBehavior
+    def process_record
+      record.save(activity_uri)
+    end
+  end
+end

--- a/lib/krikri/harvesters/harvest_behavior.rb
+++ b/lib/krikri/harvesters/harvest_behavior.rb
@@ -1,0 +1,40 @@
+module Krikri::Harvesters
+  ##
+  # Defines an interface for handling records during the harvest process.
+  # Subclasses specify behavior by implementing `#process_record`.
+  #
+  # Behaviors should be implemented idempotently so they can be safely
+  # retried on errors.
+  #
+  # @example
+  #   behavior = MyHarvestBehavior.new(record, activity_uri)
+  #   behavior.process_record
+  #
+  # @example
+  #   MyHarvestBehavior.process_record(record, activity_uri)
+  #
+  # @see Krirki::Harvester#run
+  class HarvestBehavior
+    # @!attribute activity_uri [r]
+    #   a URI identifying the activity responsible for invoking the behavior
+    # @!attribute record [r]
+    #   the record to process with this behavior
+    attr_reader :activity_uri, :record
+
+    def initialize(record, activity_uri)
+      @record = record
+      @activity_uri = activity_uri
+    end
+
+    ##
+    # Creates a new instance of this behavior with the given arguments
+    # and calls `#process_record`.
+    #
+    # @param activity_uri
+    # @param record
+    # @see self#record, self#activity_uri for parameter usage
+    def self.process_record(record, activity_uri)
+      new(record, activity_uri).process_record
+    end
+  end
+end

--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -35,6 +35,7 @@ module Krikri::Harvesters
     # @see OAI::Client
     # @see #expected_opts
     def initialize(opts = {})
+      opts[:harvest_behavior] ||= OAISkipDeletedBehavior
       super
       @opts = opts.fetch(:oai, {})
 

--- a/lib/krikri/harvesters/oai_skip_deleted_behavior.rb
+++ b/lib/krikri/harvesters/oai_skip_deleted_behavior.rb
@@ -1,0 +1,20 @@
+module Krikri::Harvesters
+  ##
+  # Harvest behavior that skips OAI records marked as deleted
+  class OAISkipDeletedBehavior < BasicSaveBehavior
+    def process_record
+      return if deleted?(record)
+      super
+    end
+
+    private
+
+    def deleted?(record)
+      header = Nokogiri::XML(record.content).xpath('//xmlns:header')
+      return false if header.empty?
+      status = header.first['status']
+      return true if status.to_s.downcase.include? 'deleted'
+      false
+    end
+  end
+end

--- a/spec/factories/krikri_original_record.rb
+++ b/spec/factories/krikri_original_record.rb
@@ -33,6 +33,28 @@ FactoryGirl.define do
 EOS
   end
 
+  factory :oai_deleted_record, parent: :krikri_original_record do
+    content <<-EOS.strip_heredoc
+<?xml version="1.0" encoding="UTF-8" ?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+         http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2015-03-02T15:56:51Z</responseDate>
+  <request verb="ListRecords" metadataPrefix="oai_dc">https://digital.library.in.gov/OAI/Server</request>
+    <ListRecords>
+      <record>
+        <header status="deleted">
+          <identifier>oai:digital.library.in.gov:ACPL_coll14-1</identifier>
+          <datestamp>1969-12-31T19:00:00Z</datestamp>
+        </header>
+      </record>
+    </ListRecords>
+  </request>
+</OAI-PMH>
+EOS
+  end
+
   factory :cdm_qdc_record, parent: :krikri_original_record do
     content <<-EOS.strip_heredoc
 <?xml version="1.0" encoding="UTF-8"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2015-01-26T19:32:57Z</responseDate><request verb="ListRecords" resumptionToken="p15799coll82:40000:oclc-cdm-allsets:0000-00-00:9999-99-99:oai_qdc" metadataPrefix="oai_qdc">http://digitallibrary.usc.edu/oai/oai.php</request><ListRecords><record><header><identifier>oai:digitallibrary.usc.edu:p15799coll117/0</identifier><datestamp>2012-11-07</datestamp><setSpec>p15799coll117</setSpec></header>

--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -25,13 +25,30 @@ describe Krikri::Harvester do
   end
 
   describe '#run' do
-    let(:records) { [double, double] }
+    let(:records) { [double('record'), double('record2')] }
 
     before do
       allow(subject).to receive(:records).and_return(records)
     end
 
-    context 'when save fails' do
+    context 'with non-default behavior' do
+      subject { klass.include(Krikri::Harvester).new(opts) }
+      let(:opts) do
+        { :uri => 'urn:fake_uri',
+          :harvest_behavior => 'Krikri::Harvesters::OAISkipDeletedBehavior' }
+      end
+
+      it 'sends record to behavior for processing' do
+        activity_uri = double('activity uri')
+        records.each do |rec|
+          expect(Krikri::Harvesters::OAISkipDeletedBehavior)
+            .to receive(:process_record).with(rec, activity_uri).and_return(true)
+        end
+        subject.run(activity_uri)
+      end
+    end
+
+    context 'when behavior fails' do
       it 'logs error' do
         records.each do |rec|
           allow(rec).to receive(:save)

--- a/spec/lib/krikri/harvesters/basic_save_behavior_spec.rb
+++ b/spec/lib/krikri/harvesters/basic_save_behavior_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Krikri::Harvesters::BasicSaveBehavior do
+  it_behaves_like 'a harvest behavior'
+
+  subject { described_class.new(record, activity_uri) }
+  let(:record) { double('record') }
+  let(:activity_uri) { double('activity URI') }
+
+  describe '#process_record' do
+    it 'calls save with activity_uri on the record' do
+      expect(record).to receive(:save).with(activity_uri)
+      subject.process_record
+    end
+  end
+end

--- a/spec/lib/krikri/harvesters/harvest_behavior_spec.rb
+++ b/spec/lib/krikri/harvesters/harvest_behavior_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Krikri::Harvesters::HarvestBehavior do
+  it_behaves_like 'a harvest behavior'
+end

--- a/spec/lib/krikri/harvesters/oai_skip_deleted_behavior_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_skip_deleted_behavior_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Krikri::Harvesters::OAISkipDeletedBehavior do
+  it_behaves_like 'a harvest behavior'
+
+  subject { described_class.new(record, activity_uri) }
+  let(:record) { build(:oai_dc_record) }
+  let(:activity_uri) { double('activity URI') }
+
+  describe '#process_record' do
+    context 'with deleted record' do
+      let(:record) { build(:oai_deleted_record) }
+
+      it 'skips record' do
+        expect(record).not_to receive(:save)
+        subject.process_record
+      end
+    end
+
+    it 'saves record' do
+      expect(record).to receive(:save).with(activity_uri)
+      subject.process_record
+    end
+  end
+end

--- a/spec/support/shared_examples/harvest_behavior.rb
+++ b/spec/support/shared_examples/harvest_behavior.rb
@@ -1,0 +1,21 @@
+
+shared_examples 'a harvest behavior' do
+  subject { described_class.new(record, activity_uri) }
+  let(:record) { double('record') }
+  let(:activity_uri) { double('activity URI') }
+
+  it { is_expected.to have_attributes(:record => record) }
+  it { is_expected.to have_attributes(:activity_uri => activity_uri) }
+
+  describe '.process_record' do
+    it 'passes args and call to instance' do
+      instance = double('behavior instance')
+
+      expect(described_class).to receive(:new).with(record, activity_uri)
+                                  .and_return(instance)
+      expect(instance).to receive(:process_record)
+
+      described_class.process_record(record, activity_uri)
+    end
+  end
+end

--- a/spec/support/shared_examples/harvester.rb
+++ b/spec/support/shared_examples/harvester.rb
@@ -102,14 +102,16 @@ shared_examples 'a harvester' do
   describe '#run' do
     before do
       allow(harvester).to receive(:records)
-        .and_return [double('Original Record 1'), double('Record 2')]
+                           .and_return [double('Original Record 1'),
+                                        double('Record 2')]
     end
 
     let(:activity_uri) { RDF::URI('http://example.org/prov/activity/1') }
 
-    it 'saves the OriginalRecords' do
+    it 'processes the OriginalRecords' do
       harvester.records.each do |r|
-        expect(r).to receive(:save).with(activity_uri)
+        expect(harvester).to receive(:process_record).with(r, activity_uri)
+                             .and_return(true)
       end
       harvester.run(activity_uri)
     end


### PR DESCRIPTION
- Add harvest behavior objects to harvester. This makes it possible to introduce new record processing behavior by injecting them into the harvesters.
- Create skip deleted behavior for OAI, make it the default behavior for OAI harvesters.
