### PR TITLE
Add migration to change Krikri::Activity.opts from :string to :text

### DIFF
--- a/db/migrate/20150309160112_change_opts_in_krikri_activities.rb
+++ b/db/migrate/20150309160112_change_opts_in_krikri_activities.rb
@@ -1,0 +1,5 @@
+class ChangeOptsInKrikriActivities < ActiveRecord::Migration
+  def change
+    change_column :krikri_activities, :opts, :text
+  end
+end

--- a/spec/factories/krikri_activities.rb
+++ b/spec/factories/krikri_activities.rb
@@ -4,6 +4,14 @@ FactoryGirl.define do
     opts '{"uri": "http://example.org/endpoint"}'
   end
 
+  factory :krikri_activity_with_long_opts, parent: :krikri_activity do
+    opts '{"uri": "http://example.org/endpoint",' \
+      '"oai": {"metadata_prefix": "mods", "set": ["SSDPLABrynMawr",' \
+      '"SSDPLACornell","SSDPLAUCSD","SSDPLAWashington","SSDelwareAtlas",' \
+      '"SSDelwareGeorge","SSDelwareHistoric","SSDelwareIncorporated1968",' \
+      '"SSDelwareIncorporated1959"]}}'
+  end
+
   factory :krikri_harvest_activity, parent: :krikri_activity do
     agent 'Krikri::Harvesters::OAIHarvester'
     opts '{"uri": "http://example.org/endpoint", ' \

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -14,6 +14,14 @@ end
 describe Krikri::Activity, type: :model do
   subject { create(:krikri_activity) }
 
+  describe '#save' do
+    subject { build(:krikri_activity_with_long_opts) }
+
+    it 'saves long :opts values successfully' do
+      expect { subject.save }.not_to raise_error
+    end
+  end
+
   describe '#rdf_subject' do
     it 'is a URI' do
       expect(subject.rdf_subject).to be_a RDF::URI


### PR DESCRIPTION
Embiggens the `:opts` JSON blob used to pass options, to ensure cromulent option
storage and behavior for `Krikri::Activity` objects.