### PR TITLE
Add `#map` to DSL Parser::ValueArray methods

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -133,7 +133,7 @@ module Krikri
     class ValueArray
       include Enumerable
 
-      delegate :[], :each, :empty?, :map, :to_a, :to_ary,
+      delegate :[], :each, :empty?, :to_a, :to_ary,
       :to => :@array
 
       def initialize(array = [])
@@ -169,7 +169,7 @@ module Krikri
       # @return [Array] literal values from the objects in this array.
       # @see Parser::Value#value
       def values
-        map(&:value)
+        @array.map(&:value)
       end
 
       ##
@@ -214,6 +214,15 @@ module Krikri
       # @return [ValueArray]
       def flatten(*args, &block)
         self.class.new(@array.flatten(*args, &block))
+      end
+
+      ##
+      # Wraps the result of Array#map in a ValueArray
+      #
+      # @see Array#map
+      # @return [ValueArray]
+      def map(*args, &block)
+        self.class.new(@array.map(*args, &block))
       end
 
       ##

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -26,7 +26,7 @@ describe Krikri::Mapper do
       mapped = Krikri::Mapper.map(:integration, record).first
 
       expect(mapped.sourceResource.first.creator.first.providedLabel)
-        .to eq record.root['dc:creator'].map(&:value)
+        .to eq record.root['dc:creator'].to_a.map(&:value)
 
       expect(mapped.sourceResource.first.identifier)
         .to eq Array(record.header.first['xmlns:identifier'].first.value)

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -183,6 +183,16 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#map' do
+    it 'calls block on all' do
+      expect { |b| subject.map(&b) }.to yield_successive_args(*subject.to_a)
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.map {}).to be_a described_class
+    end
+  end
+
   describe '#reject' do
     it 'creates new array not containing rejected values' do
       expect(subject.reject { |v| v.value == 'value_1'})


### PR DESCRIPTION
This allows you to call `#map` on DSL values to implement transforms.