### PR TITLE
use local names for item ids in routes

### DIFF
--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -80,5 +80,19 @@ module Krikri
 
       config.solr_document_model = Krikri::SearchIndexDocument
     end
+
+    ##
+    # Construct a valid item URI from a local name, and use it to fetch a single
+    # document from the search index.
+    # Override method in Blacklight::SolrHelper.
+    # TODO: This method is depreciated in Blacklight v5.10.
+    # TODO: Write appropriate test for this functionality after it is updated
+    # with Blacklight v5.10.
+    # @param String id is a local name.
+    def get_solr_response_for_doc_id(id=nil, extra_controller_params={})
+      id_uri = Krikri::Settings.marmotta.item_container << '/' << id
+      solr_response = solr_repository.find(id_uri, extra_controller_params)
+      [solr_response, solr_response.documents.first]
+    end
   end
 end

--- a/app/models/krikri/search_index_document.rb
+++ b/app/models/krikri/search_index_document.rb
@@ -5,6 +5,16 @@ module Krikri
   class SearchIndexDocument < SolrDocument
 
     ##
+    # Use local name instead of full item id URI in route.  For example, a
+    # document with the id 'http://dp.la/marmotta/ldp/items/123ab' will have an
+    # id param of '123ab'.  This is necessary because routes that contain '.' 
+    # are not valid.
+    # @return String
+    def to_param
+      self[self.class.unique_key].match(/[\/]([^\/]*)\z/)[1]
+    end
+
+    ##
     # Get the aggregation, populated with data from Marmotta, which corresponds
     # to this SearchIndexDocument
     # @return [DPLA::MAP::Aggregation, nil]

--- a/spec/models/search_index_document_spec.rb
+++ b/spec/models/search_index_document_spec.rb
@@ -10,6 +10,14 @@ describe Krikri::SearchIndexDocument, type: :model do
     expect(subject).to be_a SolrDocument
   end
 
+  describe '#to_param' do
+    it 'uses local name instead of full item uri for routes' do
+      item_uri = 'http://dp.la/marmotta/ldp/items/123ab'
+      doc = Krikri::SearchIndexDocument.new(id: item_uri)
+      expect(doc.to_param).to eq('123ab')
+    end
+  end
+
   describe '#aggregation' do
 
     it 'creates a DPLA::MAP::Aggregation with its id' do


### PR DESCRIPTION
This fixes a bug in which items with dots in their ids create invalid routes.  Instead of using the full id uri, routes instead use local names.