### PR TITLE
Add test coverage with simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ marmotta
 
 ./spec/internal
 dump.rdb
+
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 
 group :test do
   gem "codeclimate-test-reporter", require: false
+  gem 'simplecov', require: false
 end
 
 file = File.expand_path('Gemfile',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV['COVERAGE'] == 'yes'
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 


### PR DESCRIPTION
Here's a quick little addition for test coverage.

I added this quickly and it seems to work well enough; gives html reports in `./coverage`

It shouldn't run in ci tests.
