### PR TITLE
Add controller/view for Krikri::Activity; add PrettifierHelperBehavior

### DIFF
--- a/app/controllers/krikri/activities_controller.rb
+++ b/app/controllers/krikri/activities_controller.rb
@@ -1,0 +1,10 @@
+module Krikri
+  class ActivitiesController < ApplicationController
+    before_action :authenticate_user!
+    layout 'krikri/application'
+
+    def index
+      @activities = Krikri::Activity.order('id DESC').page params[:page]
+    end
+  end
+end

--- a/app/helpers/krikri/activities_helper.rb
+++ b/app/helpers/krikri/activities_helper.rb
@@ -1,0 +1,5 @@
+module Krikri
+  module ActivitiesHelper
+    include Krikri::PrettifierHelperBehavior
+  end
+end 

--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -20,6 +20,7 @@ module Krikri
     #    @return [DateTime] a datestamp marking the activity's start
 
     validate :agent_must_be_a_software_agent
+    paginates_per 10
 
     def agent_must_be_a_software_agent
       errors.add(:agent, 'does not represent a SoftwareAgent') unless

--- a/app/views/krikri/activities/index.html.erb
+++ b/app/views/krikri/activities/index.html.erb
@@ -1,0 +1,52 @@
+<% content_for :title do %>Activities<% end %>
+
+<div id="main-container" class="container">
+  <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
+  <h1>Activities</h1>
+  <%= paginate @activities, theme: 'twitter-bootstrap-3' %>
+
+  <div class="panel panel-default">
+    <table class="table table-bordered table-striped table-hover">
+      <thead>
+        <tr>
+          <th>
+            ID
+          </th>
+          <th>
+            Agent
+          </th>
+          <th>
+            Start Time
+          </th>
+          <th>
+            End Time
+          </th>
+          <th>
+            Options
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @activities.each do |activity| %>
+          <tr data-item-id=<%= "#{activity.id}" %> class="item">
+            <td>
+              <%= activity.id %>
+            </td>
+            <td>
+              <%= activity.agent %>
+            </td>
+            <td>
+              <%= activity.start_time %>
+            </td>
+            <td>
+              <%= activity.end_time %>
+            </td>
+            <td>
+               <pre class="pre-scrollable"><%= prettify_json_string(activity.opts) %></pre>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Krikri::Engine.routes.draw do
   resources :institutions do
     resources :harvest_sources, shallow: true
   end
+  resources :activities, only: [:index]
   mount Resque::Server.new, at: '/resque'
 end

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |s|
   s.add_dependency "resque", "~>1.0"
   s.add_dependency "analysand", "4.0.0"
   s.add_dependency "yajl-ruby"
+  s.add_dependency "kaminari", "~>0.16"
+  s.add_dependency "bootstrap-kaminari-views"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'

--- a/lib/krikri/prettifier_helper_behavior.rb
+++ b/lib/krikri/prettifier_helper_behavior.rb
@@ -1,0 +1,19 @@
+module Krikri
+  module PrettifierHelperBehavior
+    def prettify_json_string(string)
+      begin
+        return JSON.pretty_generate(JSON.parse(string))
+      rescue JSON::ParserError
+        return string
+      end
+    end
+
+    def prettify_xml_string(string)
+      if Nokogiri.XML(string).errors.empty?
+        doc = Nokogiri.XML(string) { |c| c.noblanks }
+        return doc.to_xml(indent: 2)
+      end
+      string
+    end
+  end
+end

--- a/lib/krikri/search_results_helper_behavior.rb
+++ b/lib/krikri/search_results_helper_behavior.rb
@@ -2,6 +2,7 @@ module Krikri
   # This module helps controllers that display results from a querying the
   # search index.
   module SearchResultsHelperBehavior
+    include Krikri::PrettifierHelperBehavior
 
     # Override method in Blacklight::CatalogHelperBehavior.
     def render_thumbnail_tag(document, image_options = {}, url_options = {})
@@ -75,22 +76,6 @@ module Krikri
     def prettify_string(string, mime_type)
       string = prettify_json_string(string) if mime_type.include? 'json'
       string = prettify_xml_string(string) if mime_type.include? 'xml'
-      string
-    end
-
-    def prettify_json_string(string)
-      begin
-        return JSON.pretty_generate(JSON.parse(string))
-      rescue JSON::ParserError
-        return string
-      end
-    end
-
-    def prettify_xml_string(string)
-      if Nokogiri.XML(string).errors.empty?
-        doc = Nokogiri.XML(string) { |c| c.noblanks }
-        return doc.to_xml(indent: 2)
-      end
       string
     end
 

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'database_cleaner'
+
+module Krikri
+  RSpec.describe Krikri::ActivitiesController, :type => :controller do
+    routes { Krikri::Engine.routes }
+    let(:activity) { create(:krikri_activity) }
+
+    before(:all) do
+      DatabaseCleaner.clean_with(:truncation)
+    end
+
+    describe "GET #index" do
+      login_user
+
+      it 'assigns all activities to @activities' do
+        get :index
+        expect(assigns(:activities)).to eq([activity])
+      end
+
+      it 'renders the :index view' do
+        get :index
+        expect(response).to render_template('krikri/activities/index')
+      end
+
+      it 'returns http success' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This was a self-serving thing I built out to make it easier for me to find and inspect instances of `Krikri::Activity` as I wrote the SPARQL queries for QA.

This also moves two methods from `Krikri::SearchResultsHelperBehavior` into a new
module, `Krikri::PrettifierHelperBehavior`.