### PR TITLE
Feature/punctuation cleanup

### DIFF
--- a/lib/krikri/enrichments/strip_ending_punctuation.rb
+++ b/lib/krikri/enrichments/strip_ending_punctuation.rb
@@ -1,0 +1,21 @@
+module Krikri::Enrichments
+  ##
+  # Strip ending punctuation
+  #
+  #   StripEndingPunctuation.new
+  #     .enrich_value("moomin!...!;,.",)
+  #   # => "moomin"
+  #
+  # Leaves quotation marks and closing parentheses & brackets. Also
+  # leaves periods when they follow a one or two letter abbreviation.
+  class StripEndingPunctuation
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      value.gsub!(/[^\p{Alnum}\'\"\)\]\}]*$/, '') unless
+        value.match /\s*[a-z]{1,2}\.$/i
+      value
+    end
+  end
+end

--- a/lib/krikri/enrichments/strip_leading_colons.rb
+++ b/lib/krikri/enrichments/strip_leading_colons.rb
@@ -1,0 +1,15 @@
+module Krikri::Enrichments
+  ##
+  # Strip leading colons
+  #
+  #   StripLeadingColons.new.enrich_value(";:\tmoominpa()pa;;;")
+  #   # => "\tmoominpa()pa;;;"
+  class StripLeadingColons
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      value.gsub(/^[\;\:]*/, '')
+    end
+  end
+end

--- a/lib/krikri/enrichments/strip_leading_punctuation.rb
+++ b/lib/krikri/enrichments/strip_leading_punctuation.rb
@@ -1,0 +1,18 @@
+module Krikri::Enrichments
+  ##
+  # Strip leading punctuation
+  #
+  #   StripLeadingPunctuation.new
+  #     .enrich_value("([!.;:\tmoominpapa;:;:; moominmama! ...\n")
+  #   # => "\tmoominpapa;:;:; moominmama! ...\n"
+  #
+  # Leaves quotation marks.
+  class StripLeadingPunctuation
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      value.gsub(/^[^\p{Alnum}\'\"\s]*/, '')
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/strip_ending_punctuation_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_ending_punctuation_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::StripEndingPunctuation do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'removes punctuation from end of field',
+              :start => "moomin!...!;,.",
+              :end => "moomin"
+            },
+            { :string => 'keeps initials',
+              :start => "Smith, Smithy Q.",
+              :end => "Smith, Smithy Q."
+            },
+            { :string => 'keeps closing parentheses',
+              :start => "(Smith)",
+              :end => "(Smith)"
+            },
+            { :string => 'keeps two letter abbreviations',
+              :start => "66 cm.",
+              :end => "66 cm."
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => "moominpapa;:;:; moominmama",
+              :end => "moominpapa;:;:; moominmama"
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end

--- a/spec/lib/krikri/enrichments/strip_leading_colons_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_leading_colons_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::StripLeadingColons do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'removes (semi)colons from beginning of field',
+              :start => ";:\tmoominpa()pa;;;",
+              :end => "\tmoominpa()pa;;;"
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => ";:\tmoominpapa;:;:; moominmama! ...\n",
+              :end => "\tmoominpapa;:;:; moominmama! ...\n"
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end

--- a/spec/lib/krikri/enrichments/strip_leading_punctuation_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_leading_punctuation_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::StripLeadingPunctuation do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'removes punctuation from beginning of field',
+              :start => "([!.;:\tmoominpapa;:;:; moominmama! ...\n",
+              :end => "\tmoominpapa;:;:; moominmama! ...\n"
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => "'moominpapa;:;:; moominmama! ...\n'",
+              :end => "'moominpapa;:;:; moominmama! ...\n'"
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end


### PR DESCRIPTION
Adds several enrichments to cleanup punctuation.

The aim is to be able to conform (at least) to the following:

Titles
--- 
 - Strip out any leading colons or semi-colons. 
 - Strip out any ending punctuation, excluding parentheses but including periods. If we could make some exceptions to the stripping of trailing periods that would be great. For example, we wouldn't strip trailing periods from subject or formats where:
   - A value ends with a space-single letter-period combination ("Smith, John Q." not "Smith, John Q") OR 
   - A value ends with a space-two letters-period combination ("Johnson, Steven, Jr." not "Johnson, Steven Jr"; "oil painting, 64 x 64 in." not "oil painting, 64 x 64 in")
   - All other punctuation within the text should stay as is.

Descriptions
---
 - Strip out any leading colons or semi-colons. 

Subjects, Formats, Creators
---
 - Strip out any leading punctuation except quotation marks.
- Strip out any ending punctuation, excluding parentheses but including periods. If we could make some exceptions to the stripping of trailing periods that would be great. For example, we wouldn't strip trailing periods from subject or formats where:
   - A value ends with a space-single letter-period combination ("Smith, John Q." not "Smith, John Q") OR 
   - A value ends with a space-two letters-period combination ("Johnson, Steven, Jr." not "Johnson, Steven Jr"; "oil painting, 64 x 64 in." not "oil painting, 64 x 64 in")

Date
---
 - Strip out trailing punctuation in this field, except for square brackets, when we're displaying the ProvidedLabel (or whatever it's called).