### PR TITLE
Add a genre filter enrichment

### DIFF
--- a/lib/krikri/enrichments/genre_filter.rb
+++ b/lib/krikri/enrichments/genre_filter.rb
@@ -3,7 +3,6 @@ module Krikri::Enrichments
   # Enrichment to remove non-genre fields from
   #
   #   StripHtml.new.enrich_value('Book') => 'Book'
-  #   StripHtml.new.enrich_value('book') => 'book'
   #   StripHtml.new.enrich_value('not a book') => nil
   #
   # Allowed genre terms are:

--- a/lib/krikri/enrichments/genre_filter.rb
+++ b/lib/krikri/enrichments/genre_filter.rb
@@ -1,0 +1,46 @@
+module Krikri::Enrichments
+  ##
+  # Enrichment to remove non-genre fields from
+  #
+  #   StripHtml.new.enrich_value('Book') => 'Book'
+  #   StripHtml.new.enrich_value('book') => 'book'
+  #   StripHtml.new.enrich_value('not a book') => nil
+  #
+  # Allowed genre terms are:
+  #
+  #  - Book
+  #  - Film/Video
+  #  - Manuscript
+  #  - Maps
+  #  - Music
+  #  - Musical Score
+  #  - Newspapers
+  #  - Nonmusic
+  #  - Photograph/Pictorial Works
+  #  - Serial
+  #
+  # Removes all non-string values
+  class GenreFilter
+    include Krikri::FieldEnrichment
+
+    TERMS = ['Book',
+             'Film/Video',
+             'Manuscript',
+             'Maps',
+             'Music',
+             'Musical Score',
+             'Newspapers',
+             'Nonmusic',
+             'Photograph/Pictorial Works',
+             'Serial']
+
+    def enrich_value(value)
+      return nil unless value.is_a? String
+      term = TERMS.select do |t|
+        t.downcase.gsub(/[^a-zA-Z]/, '') ==
+          value.downcase.gsub(/[^a-zA-Z]/, '')
+      end
+      term.empty? ? nil : term.first
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/genre_filter_spec.rb
+++ b/spec/lib/krikri/enrichments/genre_filter_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::GenreFilter do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'removes non-genre terms',
+              :start => 'Not A Term',
+              :end => nil
+            },
+            { :string => 'retains genre terms',
+              :start => 'Book',
+              :end => 'Book'
+            },
+            { :string => 'normalizes string form',
+              :start => "\n bO  O-k!   \t",
+              :end => 'Book'
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end

--- a/spec/lib/krikri/enrichments/genre_filter_spec.rb
+++ b/spec/lib/krikri/enrichments/genre_filter_spec.rb
@@ -17,4 +17,5 @@ describe Krikri::Enrichments::GenreFilter do
             }]
 
   it_behaves_like 'a string enrichment', values
+  include_examples 'deletes non-strings'
 end

--- a/spec/lib/krikri/enrichments/remove_empty_fields_spec.rb
+++ b/spec/lib/krikri/enrichments/remove_empty_fields_spec.rb
@@ -21,4 +21,5 @@ describe Krikri::Enrichments::RemoveEmptyFields do
             }]
 
   it_behaves_like 'a string enrichment', values
+  include_examples 'skips non-strings'
 end

--- a/spec/lib/krikri/enrichments/strip_html_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_html_spec.rb
@@ -18,4 +18,5 @@ describe Krikri::Enrichments::StripHtml do
             }]
 
   it_behaves_like 'a string enrichment', values
+  include_examples 'skips non-strings'
 end

--- a/spec/lib/krikri/enrichments/strip_punctuation_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_punctuation_spec.rb
@@ -12,4 +12,5 @@ describe Krikri::Enrichments::StripPunctuation do
               :end => "\tmoominpapa moominmama"
             }]
   it_behaves_like 'a string enrichment', values
+  include_examples 'skips non-strings'
 end

--- a/spec/lib/krikri/enrichments/strip_whitespace_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_whitespace_spec.rb
@@ -13,4 +13,5 @@ describe Krikri::Enrichments::StripWhitespace do
             }]
 
   it_behaves_like 'a string enrichment', values
+  include_examples 'skips non-strings'
 end

--- a/spec/support/shared_examples/string_enrichment.rb
+++ b/spec/support/shared_examples/string_enrichment.rb
@@ -1,12 +1,21 @@
 shared_examples 'a string enrichment' do |values|
-  it 'skips non-string values' do
-    date = Date.today
-    expect(subject.enrich_value(date)).to eq date
-  end
-
   values.each do |value|
     it value[:string] do
       expect(subject.enrich_value(value[:start])).to eq value[:end]
     end
+  end
+end
+
+shared_examples 'skips non-strings' do
+  it 'skips non-string values' do
+    date = Date.today
+    expect(subject.enrich_value(date)).to eq date
+  end
+end
+
+shared_examples 'deletes non-strings' do
+  it 'deletes non-string values' do
+    date = Date.today
+    expect(Array(subject.enrich_value(date)).compact).to eq []
   end
 end


### PR DESCRIPTION
Removes values that do not match a given list of genre terms.

Also splits string enrichment shared examples to deal with string enrichments that don't want to ignore non-string values. The shared example which requires that is put into its own group so it can be combined as needed. 