### PR TITLE
Add Enricher, a SoftwareAgent that runs enrichments

### DIFF
--- a/lib/krikri/enricher.rb
+++ b/lib/krikri/enricher.rb
@@ -1,0 +1,158 @@
+module Krikri
+  ##
+  # A SoftwareAgent that runs enrichment processes.
+  #
+  # @example
+  #
+  #   To enrich records that were mapped by the mapping activity with ID 3:
+  #
+  #   # Define which enrichments are run, and thier parameters:
+  #   chain = {
+  #     'Krikri::Enrichments::StripHtml' => {
+  #       input_fields: [{sourceResource: :title}]
+  #     },
+  #     'Krikri::Enrichments::StripWhitespace' => {
+  #       input_fields: [{sourceResource: :title}]
+  #     }
+  #   }
+  #   Krikri::Enricher.enqueue({
+  #     generator_uri: 'http://ldp.local.dp.la/ldp/activity/3',
+  #     chain: chain
+  #   })
+  #
+  # @see Krikri::SoftwareAgent#enqueue
+  # @see Krikri::Enrichment
+  #
+  class Enricher
+    include SoftwareAgent
+
+    attr_reader :chain, :generator_uri
+
+    def self.queue_name
+      :enrichment
+    end
+
+    ##
+    # Create a new Enricher, given a hash of options:
+    #   generator_uri:  the LDP URI of the Activity that generated the mapped
+    #      records that this one will enrich.
+    #   chain:  a hash specifying the input_fields and output_fields, as
+    #      illustrated above, which will be passed to the Enrichment.
+    #
+    # @see Krikri::Enrichment
+    # @param opts [Hash] a hash of options
+    def initialize(opts = {})
+      @generator_uri = RDF::URI(opts.fetch(:generator_uri))
+      @chain = deep_sym(opts.fetch(:chain) { {} })
+    end
+
+    ##
+    # Run the enrichmnt.
+    #
+    # Take each record that was affected by the activity defined by our
+    # instantiation, and apply each enrichment from the enrichment chain.
+    #
+    def run(activity_uri = nil)
+      log :info, 'enricher is running'
+      # see TODO below
+      target_aggregations.each do |agg|
+        begin
+          chain_enrichments!(agg)
+          agg << RDF::Statement(agg, RDF::PROV.wasGeneratedBy, activity_uri) if
+            activity_uri
+          agg.save
+        rescue => e
+          log :error, "Enrichment error: #{e.message}\n#{e.backtrace}"
+        end
+      end
+      log :info, 'enricher is done'
+    end
+
+    # TODO:  remove this when the current topic branch that introduces the
+    # EntityConsumer mixin has been merged.
+    def target_aggregations
+      query = Krikri::ProvenanceQueryClient.find_by_activity(generator_uri)
+      query.execute.lazy.flat_map do |solution|
+        agg = DPLA::MAP::Aggregation.new(solution.record.to_s)
+        agg.get
+        agg
+      end
+    end
+
+    ##
+    # Given an aggregation, take each enrichment specified by the `chain'
+    # given in our instantiation, and apply that enrichment, with the given
+    # options, modifying the aggregation in-place.
+    #
+    def chain_enrichments!(agg)
+      chain.keys.each do |e|
+        enrichment = e.to_s.constantize.new
+        if enrichment.is_a? Krikri::FieldEnrichment
+          agg = do_field_enrichment(agg, enrichment, chain[e])
+        else
+          agg = do_basic_enrichment(agg, enrichment, chain[e])
+        end
+      end
+    end
+
+    private
+
+    ##
+    # Perform a default enrichment, using Enrichment#enrichment or a derived
+    # class that expects the same arguments.
+    #
+    # @param agg [DPLA::MAP::Aggregation]
+    # @param enrichment [Krikri::Enrichment]
+    # @param options [Hash]
+    #
+    # @see Krikri::Enrichment
+    #
+    def do_basic_enrichment(agg, enrichment, options)
+      enrichment.enrich(
+        agg, options[:input_fields], options[:output_fields]
+      )
+    end
+
+    ##
+    # Perform a FieldEnrichment enrichment on the given aggregation.
+    #
+    # With FieldEnrichment#enrich, the input_fields option parameter is passed
+    # as a variable arguments list
+    #
+    # @param agg [DPLA::MAP::Aggregation]
+    # @param enrichment [Krikri::FieldEnrichment]
+    # @param options [Hash]  Hash with :input_fields containing variable
+    #                        arguments list
+    #
+    # @see Krikri::FieldEnrichment
+    #
+    def do_field_enrichment(agg, enrichment, options)
+      enrichment.enrich(agg, *options[:input_fields])
+    end
+
+    ##
+    # Transform the given hash recursively by turning all of its string keys
+    # and values into symbols.
+    #
+    # Symbols are expected in the enrichment classes, and we will usually be
+    # dealing with values that have been deserialized from JSON.
+    #
+    def deep_sym(obj)
+      if obj.is_a? Hash
+        return obj.inject({}) do |memo, (k, v)|
+          memo[k.to_sym] = deep_sym(v)
+          memo
+        end
+      elsif obj.is_a? Array
+        return obj.inject([]) do |memo, el|
+          memo << deep_sym(el)
+          memo
+        end
+      elsif obj.respond_to? :to_sym
+        return obj.to_sym
+      else
+        return nil
+      end
+    end
+  end
+end

--- a/lib/krikri/enricher.rb
+++ b/lib/krikri/enricher.rb
@@ -58,9 +58,7 @@ module Krikri
       target_aggregations.each do |agg|
         begin
           chain_enrichments!(agg)
-          agg << RDF::Statement(agg, RDF::PROV.wasGeneratedBy, activity_uri) if
-            activity_uri
-          agg.save
+          activity_uri ? agg.save_with_provenance(activity_uri) : agg.save
         rescue => e
           log :error, "Enrichment error: #{e.message}\n#{e.backtrace}"
         end

--- a/lib/krikri/enrichment.rb
+++ b/lib/krikri/enrichment.rb
@@ -3,8 +3,6 @@ module Krikri
   # Mixin module for enriching a set of input_fields and setting the resulting
   # values to a set of output fields.
   module Enrichment
-    extend SoftwareAgent
-
     ##
     # The main enrichment method; passes specified input fields to
     # #enrich_values, which must return an array of values with length equal to

--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -109,9 +109,7 @@ module Krikri
         Krikri::Mapper.map(name, records).each do |rec|
           begin
             rec.mint_id! if rec.node?
-            rec << RDF::Statement(rec, RDF::PROV.wasGeneratedBy, activity_uri) if
-              activity_uri
-            rec.save
+            activity_uri ? rec.save_with_provenance(activity_uri) : rec.save
           rescue => e
             Rails.logger.error("Error saving record: #{rec.rdf_subject}\n" \
                                "#{e.message}\n#{e.backtrace}")

--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -6,11 +6,21 @@ module Krikri
 
     module_function
 
+    ##
+    # Finds all entities generated or revised by the activity whose URI is
+    # given.
+    #
+    # @param activity_uri [#to_uri] the URI of the activity to search
+    #
+    # @return [RDF::SPARQL::Query] a query object that, when executed, will
+    #   give solutions containing the URIs for the resources in `#record`.
     def find_by_activity(activity_uri)
       raise ArgumentError, 'activity_uri must be an RDF::URI' unless
         activity_uri.respond_to? :to_uri
       SPARQL_CLIENT.select(:record)
-        .where([:record, RDF::PROV.wasGeneratedBy, activity_uri])
+        .where([:record,
+                [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy],
+                activity_uri])
     end
   end
 end

--- a/spec/lib/krikri/enricher_spec.rb
+++ b/spec/lib/krikri/enricher_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe Krikri::Enricher do
+
+  subject do
+    described_class.new generator_uri: mapping_activity_uri,
+                        chain: chain
+  end
+
+  shared_context 'common' do
+    let(:chain) do
+      {
+        :'Krikri::Enrichments::StripHtml' => {
+          input_fields: [{sourceResource: :title}]
+        },
+        :'Krikri::Enrichments::StripWhitespace' => {
+          input_fields: [{sourceResource: :title}]
+        }
+      }
+    end
+    let(:mapping_activity_uri) do
+      (RDF::URI(Krikri::Settings['marmotta']['ldp']) /
+        Krikri::Settings['prov']['activity'] / '3').to_s
+    end
+  end
+
+  describe '#initialize' do
+    context 'with a chain argument that has been parsed from JSON' do
+      # Activity records will contain the serialized chain hash, which is
+      # passed in the call to Krikri::Enricher.enqueue.
+      include_context 'common'
+
+      subject do
+        described_class.new generator_uri: mapping_activity_uri,
+                            chain: JSON.parse(json_chain)
+      end
+
+      let(:json_chain) do
+        <<-EOS.gsub /\s+/, ' '
+        {
+          "Krikri::Enrichments::StripHtml": {
+            "input_fields":[{"sourceResource":"title"}]
+          },
+          "Krikri::Enrichments::StripWhitespace": {
+            "input_fields":[{"sourceResource":"title"}]
+          }
+        }
+EOS
+      end
+
+      it 'has a valid chain when it has been parsed from JSON' do
+        expect(subject.chain).to eq(chain)
+      end
+    end
+  end
+
+  describe '#run' do
+    let(:agg_double) { instance_double(DPLA::MAP::Aggregation) }
+    let(:aggs) { [agg_double, agg_double.clone, agg_double.clone] }
+
+    context 'with errors thrown' do
+      include_context 'common'
+
+      before do
+        aggs.each do |agg|
+          allow(agg).to receive(:save).and_raise(StandardError.new)
+        end
+
+        allow(subject).to receive(:target_aggregations)
+                                    .and_return(aggs)
+      end
+
+      it 'logs errors' do
+        expect(Krikri::SoftwareAgent::Logger)
+          .to receive(:error)
+          .with(start_with('Enrichment error'))
+          .exactly(3).times
+
+        subject.run
+      end
+    end
+  end
+
+  describe '#chain_enrichments!' do
+    context 'with a chain of enrichments' do
+      include_context 'common'
+      let(:aggregation) { build(:aggregation) }
+
+      before do
+        # This title needs two enrichments applied, whitespace stripping and
+        # HTML stripping.
+        aggregation.sourceResource.first.title = ['<i>nice and clean</i> ']
+      end
+      it 'runs enrichments in the chain, on the generated aggregations' do
+        subject.chain_enrichments!(aggregation)
+        expect(aggregation.sourceResource.first.title)
+          .to eq(['nice and clean'])
+      end
+    end
+  end
+
+end

--- a/spec/lib/krikri/job_spec.rb
+++ b/spec/lib/krikri/job_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Krikri::Job do
+  let(:agent) { double('agent') }
+
+  describe '.perform' do
+    let(:activity_id) { 1 }
+    let(:activity) { double('activity') }
+
+    before do
+      allow(Krikri::Activity).to receive(:find).with(activity_id)
+                                  .and_return(activity)
+    end
+
+    it 'calls #run on activity by id' do
+      expect(activity).to receive(:run).and_return(true)
+      described_class.perform(activity_id)
+    end
+
+    it 'passes its run method to block' do
+      uri = double('uri')
+      expect(activity).to receive(:run).and_yield(agent, uri)
+      expect(described_class).to receive(:run).with(agent, uri)
+      described_class.perform(activity_id)
+    end
+  end
+
+  describe '.run' do
+    it 'calls #run on agent' do
+      activity_uri = double('uri')
+      expect(agent).to receive(:run).with(activity_uri).and_return(true)
+      described_class.run(agent, activity_uri)
+    end
+
+    it 'defaults activity to nil' do
+      expect(agent).to receive(:run).with(nil).and_return(true)
+      described_class.run(agent)
+    end
+  end
+end

--- a/spec/lib/krikri/mapper_agent_spec.rb
+++ b/spec/lib/krikri/mapper_agent_spec.rb
@@ -24,6 +24,7 @@ describe Krikri::Mapper::Agent do
       allow(record_double).to receive(:node?).and_return(true)
       allow(record_double).to receive(:mint_id!)
       allow(record_double).to receive(:save)
+      allow(record_double).to receive(:save_with_provenance)
     end
 
     context 'with errors thrown' do
@@ -52,13 +53,16 @@ describe Krikri::Mapper::Agent do
         subject.run
       end
 
-      it 'sets generator' do
+      it 'saves each record' do
+        records.each do |record|
+          expect(record).to receive(:save)
+        end
+        subject.run
+      end
+
+      it 'saves with provenance' do
         records.each do |rec|
-          statement = double
-          allow(RDF).to receive(:Statement)
-                         .with(rec, RDF::PROV.wasGeneratedBy, activity_uri)
-                         .and_return(statement)
-          expect(rec).to receive(:<<).with(statement)
+          expect(rec).to receive(:save_with_provenance).with(activity_uri)
         end
         subject.run(activity_uri)
       end

--- a/spec/support/shared_examples/rdf_source.rb
+++ b/spec/support/shared_examples/rdf_source.rb
@@ -46,6 +46,28 @@ shared_examples 'an LDP RDFSource' do
     end
   end
 
+  describe '#save_with_provenance' do
+    include_context 'with RDF subject'
+
+    let(:activity_uri) { RDF::URI 'http://example.org/act' }
+
+    it 'adds generated provenance triple' do
+      subject.save_with_provenance(activity_uri)
+      expect(subject.query([subject, RDF::PROV.wasGeneratedBy, activity_uri]))
+        .not_to be_empty
+    end
+
+    context 'when saved' do
+      before { subject.save }
+
+      it 'adds provenance triple' do
+        subject.save_with_provenance(activity_uri)
+        expect(subject.query([subject, RDF::DPLA.wasRevisedBy, activity_uri]))
+          .not_to be_empty
+      end
+    end
+  end
+
   describe '#get' do
     context 'without subject' do
       include_examples 'LDP rdf_subject errors', :get, error_msg


### PR DESCRIPTION
One Enricher run chains together multiple enrichments that get run on each record that was generated by a mapping activity.  The enrichments are specified in the options hash that is passed to `Enricher.enqueue`.
