### PR TITLE
Support multivalued node fields in solr index

### DIFF
--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -506,72 +506,72 @@ v         currently supported on types that are sorted internally as strings
 
    <field name="type" type="string" indexed="false" stored="false" multiValued="true" />
 
-   <field name="dataProvider_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="dataProvider_type" type="string" indexed="false" stored="false" />
-   <field name="dataProvider_name" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="dataProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="dataProvider_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="dataProvider_type" type="string" indexed="false" stored="false" multiValued="true" />
+   <field name="dataProvider_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="dataProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="hasView_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="hasView_type" type="string" indexed="false" stored="false" />
+   <field name="hasView_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="hasView_format" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="hasView_rights" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="hasView_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="intermediateProvider_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="intermediateProvider_type" type="string" indexed="false" stored="false" />
-   <field name="intermediateProvider_name" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="intermediateProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="intermediateProvider_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="intermediateProvider_type" type="string" indexed="false" stored="false" multiValued="true" />
+   <field name="intermediateProvider_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="intermediateProvider_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="isShownAt_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="isShownAt_type" type="string" indexed="false" stored="false" />
+   <field name="isShownAt_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="isShownAt_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="isShownAt_format" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="isShownAt_rights" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="isShownAt_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="isShownAt_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="object_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="object_type" type="string" indexed="false" stored="false" />
+   <field name="object_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="object_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="object_format" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="object_rights" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="object_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="object_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="originalRecord" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="originalRecord" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="preview_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="preview_type" type="string" indexed="false" stored="false" />
+   <field name="preview_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="preview_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="preview_format" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="preview_rights" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="preview_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="preview_rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="provider_id" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="provider_type" type="string" indexed="false" stored="false" />
-   <field name="provider_name" type="string" indexed="true" stored="true" multiValued="false" />
-   <field name="provider_providedLabel" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="provider_id" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="provider_type" type="string" indexed="false" stored="false" multiValued="true" />
+   <field name="provider_name" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="provider_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="rightsStatement_id" type="string" indexed="true" stored="true" multiValued="false" />
+   <field name="rightsStatement_id" type="string" indexed="true" stored="true" multiValued="true" />
 
-   <field name="sourceResource_id" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="sourceResource_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_id" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="sourceResource_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_alternative" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_collection_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_collection_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_collection_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_collection_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_collection_title" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_collection_description" type="text" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_contributor_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_contributor_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_contributor_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_contributor_name" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_contributor_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_creator_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_creator_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_creator_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_creator_name" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_creator_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <!-- TODO: Change date_begin and date_end type to "date" assuming they have been correctly formatted -->
    <field name="sourceResource_date_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_date_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_date_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_date_begin" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_date_end" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_date_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
@@ -591,7 +591,7 @@ v         currently supported on types that are sorted internally as strings
    <field name="sourceResource_genre_type" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_publisher_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_publisher_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_publisher_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_publisher_name" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_publisher_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
@@ -602,12 +602,12 @@ v         currently supported on types that are sorted internally as strings
    <field name="sourceResource_rightsHolder" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_rightsHolder_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_rightsHolder_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_rightsHolder_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_rightsHolder_name" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_rightsHolder_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_spatial_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_spatial_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_spatial_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_spatial_exactMatch" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_spatial_countryCode" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_spatial_parentFeature_id" type="string" indexed="true" stored="true" multiValued="true" />
@@ -618,10 +618,10 @@ v         currently supported on types that are sorted internally as strings
    <field name="sourceResource_spatial_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_specType_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_specType_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_specType_type" type="string" indexed="false" stored="false" multiValued="true" />
 
    <field name="sourceResource_subject_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_subject_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_subject_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_subject_name" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_subject_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
@@ -629,7 +629,7 @@ v         currently supported on types that are sorted internally as strings
    <field name="sourceResource_title" type="string" indexed="true" stored="true" multiValued="true" />
 
    <field name="sourceResource_type_id" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="sourceResource_type_type" type="string" indexed="false" stored="false" />
+   <field name="sourceResource_type_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_type_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields

--- a/spec/lib/krikri/search_index_spec.rb
+++ b/spec/lib/krikri/search_index_spec.rb
@@ -102,6 +102,7 @@ describe Krikri::QASearchIndex do
         subject.delete_by_query('id:*')
         subject.commit
         aggregation.set_subject!('http://api.dp.la/item/123')
+        aggregation.provider << build(:krikri_provider, rdf_subject: 'snork')
         subject.add aggregation.to_jsonld['@graph'][0]
         subject.commit
       end


### PR DESCRIPTION
This allows the solr schema to support documents with multiple rdf nodes for a given property (i.e. multiple creators, places, etc...).

The test checks `provider` particularly. We could improve it across the board by adding more data to DPLA::MAP::Aggregation's factory.