### PR TITLE
Allow Krikri::Indexer#run to receive an (unused) activity_uri

### DIFF
--- a/lib/krikri/job.rb
+++ b/lib/krikri/job.rb
@@ -28,6 +28,7 @@ module Krikri
     # @param activity_uri  the URI of the activity responsible for
     #   generating the resources. Set this to (e.g.) prov:wasGeneratedBy
     def self.run(agent, activity_uri = nil)
+      return agent.run unless activity_uri && agent.method(:run).arity != 0
       agent.run(activity_uri)
     end
   end

--- a/lib/krikri/software_agent.rb
+++ b/lib/krikri/software_agent.rb
@@ -26,14 +26,23 @@ module Krikri
     ##
     # Return an agent name suitable for saving in an Activity.
     # This is the name of the most-derived class upon which this is invoked.
+    #
+    # @return [String]
     # @see Krikri::Activity
     def agent_name
       self.class.agent_name
     end
 
     ##
-    # @abstract Perform this agent's work
-    # @return [Boolean]
+    # @abstract Perform this agent's work. The method may accept an
+    #   `activity_uri` to record as the Activity in provenance metadata.
+    #   If so, the implementation must be optional and handle `nil` values by
+    #   declining to record provenance
+    #
+    # @return [Boolean] `true` if the run has succeeded; otherwise `false`
+    #
+    # @see Krirkri::Activity
+    # @see Krikri::Job.run
     def run
       fail NotImplementedError
     end

--- a/spec/lib/krikri/job_spec.rb
+++ b/spec/lib/krikri/job_spec.rb
@@ -32,8 +32,16 @@ describe Krikri::Job do
       described_class.run(agent, activity_uri)
     end
 
-    it 'defaults activity to nil' do
-      expect(agent).to receive(:run).with(nil).and_return(true)
+    it 'passes with no args if no activity given' do
+      expect(agent).to receive(:run).with(no_args).and_return(true)
+      described_class.run(agent)
+    end
+
+    it 'passes with no args if no agent accepts no args' do
+      arity_zero = Proc.new {}
+      allow(agent).to receive(:method).with(:run).and_return(arity_zero)
+
+      expect(agent).to receive(:run).with(no_args).and_return(true)
       described_class.run(agent)
     end
   end

--- a/spec/support/shared_examples/software_agent.rb
+++ b/spec/support/shared_examples/software_agent.rb
@@ -28,6 +28,12 @@ shared_examples 'a software agent' do |args|
     it { expect(subject.agent_name).to be_a String }
   end
 
+  describe '#run' do
+    it 'accepts one or no arguments' do
+      expect(subject.method(:run).arity).to satisfy { |v| v == -1 || v == 0 }
+    end
+  end
+
   describe '#enqueue' do
     let(:queue_name) { described_class.queue_name.to_s }
 


### PR DESCRIPTION
Despite `Krikri::Indexer` using `Krikri::EntityConsumer` to identify the activity for which to index records, `Krikri::Indexer#run` still needs an `activity_uri` parameter to meet the expectations of the interface
for `Krikri::Job#self.run`.