### PR TITLE
Improve error handling for Krikri::Mapper:Agent#run

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -133,8 +133,13 @@ module Krikri
             rec.mint_id! if rec.node?
             activity_uri ? rec.save_with_provenance(activity_uri) : rec.save
           rescue => e
-            Rails.logger.error("Error saving record: #{rec.rdf_subject}\n" \
-                               "#{e.message}\n#{e.backtrace}")
+            if rec
+              Rails.logger.error("Error saving record: #{rec.rdf_subject}\n"\
+                                 "#{e.message}\n#{e.backtrace}")
+            else
+              Rails.logger.error("Error saving record: received nil record\n"\
+                                 "#{e.message}\n#{e.backtrace}")
+            end
           end
         end
       end


### PR DESCRIPTION
Occasionally, a mapping job will fail if it tries to save a record that is `nil`. The error logger handling itself fails, since it tries to call the `rdf_subject`method on an instance of `NilClass`.

This addresses an issue when I was testing my changes for #136. Not quite as high priority, and probably needs better tests and more discussion.