### PR TITLE
Krikri::Provider#reload query should use a DISTINCT clause

### DIFF
--- a/app/helpers/krikri/application_helper.rb
+++ b/app/helpers/krikri/application_helper.rb
@@ -3,7 +3,11 @@ module Krikri
     ##
     # @return [Array<Blacklight::SolrResponse::Facets::FacetItem>]
     def available_providers
-      Krikri::Provider.all(&:reload)
+      Rails.cache.fetch('krikri/application_helper/available_providers',
+                        expires_in: 1.hour,
+                        race_condition_ttl: 3.minutes) do
+        Krikri::Provider.all(&:reload)
+      end
     end
 
     ##

--- a/app/models/krikri/provider.rb
+++ b/app/models/krikri/provider.rb
@@ -42,7 +42,7 @@ module Krikri
     #
     # @return [Krikri::Provider] self
     def reload
-      query = Krikri::Repository.query_client.select.where([self, :p, :o])
+      query = Krikri::Repository.query_client.select.distinct.where([self, :p, :o])
       query.each_solution do |solution|
         set_value(solution.p, solution.o)
       end

--- a/app/views/krikri/providers/index.html.erb
+++ b/app/views/krikri/providers/index.html.erb
@@ -10,7 +10,7 @@
   <% @providers.each do |provider| %>
     <li>
       <%= link_to provider_name(provider), { controller: 'providers',
-        action: 'show', id: provider.id } %> (<%= provider.records.count %> records)
+        action: 'show', id: provider.id } %>
     </li>
   <% end %>
   </ul>

--- a/spec/helpers/krikri/application_helper_spec.rb
+++ b/spec/helpers/krikri/application_helper_spec.rb
@@ -2,9 +2,24 @@ require 'spec_helper'
 
 describe Krikri::ApplicationHelper, :type => :helper do
   describe '#available_providers' do
+    before { Rails.cache.clear }
+    after { Rails.cache.clear }
+
     it 'gets available providers' do
       allow(Krikri::Provider).to receive(:all).and_return([:all_providers])
       expect(helper.available_providers).to eq [:all_providers]
+    end
+
+    it 'caches providers' do
+      providers = helper.available_providers
+
+      expect(Krikri::Provider).not_to receive(:all)
+      helper.available_providers
+    end
+
+    it 'returns same providers after cache' do
+      providers = helper.available_providers
+      expect(helper.available_providers).to eq providers
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,4 +1,11 @@
 require 'spec_helper'
+require 'rdf/isomorphic'
+
+module RDF
+  module Isomorphic
+    alias_method :==, :isomorphic_with?
+  end
+end
 
 describe Krikri::Provider do
   let(:local_name) { '123' }


### PR DESCRIPTION
`Krikri::Provider#reload` builds out the triples associated with the provider through a SPARQL query. When there are more than a small number (say, 100) of mapped records in your repository, it takes
a very long time for it to build out the provider given that `#reload` calls `set_value` multiple times: one for each of the sum of the number of solutions for each mapped record associated with that provider.