### PR TITLE
Fixup validation report views

### DIFF
--- a/app/controllers/krikri/validation_reports_controller.rb
+++ b/app/controllers/krikri/validation_reports_controller.rb
@@ -18,11 +18,11 @@ module Krikri
     layout 'krikri/application'
 
     def show
-      provider_id = params[:provider]
+      @current_provider = params[:provider]
       page = params[:page]
       per_page = params[:per_page]
       @response = ValidationReport.new.find(params[:id]) do
-        self.provider_id = provider_id
+        self.provider_id = @current_provider
         self.start = page
         self.rows = per_page
       end

--- a/app/views/krikri/validation_reports/_validation_report.html.erb
+++ b/app/views/krikri/validation_reports/_validation_report.html.erb
@@ -7,15 +7,19 @@
         <dt>ID:</dt>
         <dd>
           <%= link_to doc.id, :controller => 'records', :action => 'show',
-          :id => doc.id, :provider => @current_provider, :method => :get %>
+          :id => local_name(doc.id), :provider => @current_provider, :method => :get %>
         </dd>
         <% if doc['sourceResource_title'].present? %>
           <dt>Title:</dt>
-          <dd><%= doc['sourceResource_title'] %></dd>
+          <% doc['sourceResource_title'].each do |title| %>
+            <dd><%= title %></dd>
+          <% end %>
         <% end %>
         <% if doc['isShownAt_id'].present? %>
           <dt>Is Shown At:</dt>
-          <dd><%= link_to doc['isShownAt_id'], doc['isShownAt_id'] %></dd>
+          <% doc['isShownAt_id'].each do |is_shown_at| %>
+            <dd><%= link_to is_shown_at, is_shown_at %></dd>
+          <% end %>
         <% end %>
       </dl>
     </div>

--- a/spec/controllers/validation_reports_controller_spec.rb
+++ b/spec/controllers/validation_reports_controller_spec.rb
@@ -11,5 +11,10 @@ describe Krikri::ValidationReportsController, :type => :controller do
       get :show, id: 'sourceResource_title', provider: 'nypl'
       expect(response).to render_template('krikri/validation_reports/show')
     end
+
+    it 'sets current provider' do
+      expect { get :show, id: 'sourceResource_title', provider: 'nypl' }
+        .to change { assigns(:current_provider) }.to('nypl')
+    end
   end
 end


### PR DESCRIPTION
1. Iterate through each field returned in validation reports, now that title and isShownAt are multivalued in Solr
1. Link to compare view using `local_name(doc.id)`
1. Pass `@current_provider` as to the validation report view