### PR TITLE
Have CouchdbHarvester make batch requests

### DIFF
--- a/spec/lib/krikri/harvesters/couchdb_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/couchdb_harvester_spec.rb
@@ -28,9 +28,9 @@ describe Krikri::Harvesters::CouchdbHarvester do
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","key":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","value":{"rev":"11-b3e9a75b56599a78cb875ffb5c508c2b"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","_rev":"11-b3e9a75b56599a78cb875ffb5c508c2b","object":"bfecb6c11db808ca6603cd13def5f9bf"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","key":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","value":{"rev":"11-c9ebbeb8064280e674ea79c0b16c59d6"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","_rev":"11-c9ebbeb8064280e674ea79c0b16c59d6","object":"d2e3b4d91fba4f77df6fb8fab46f3375"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}},
-{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
-{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
-{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"}}
+{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-5f16aec70767aa294b07ad4396bc56af"},"doc":{"_id":"_design/all_provider_docs","_rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
+{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"},"doc":{"_id":"_design/auth","_rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
+{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"},"doc":{"_id":"_design/export_database","_rev":"1-82e865010760bbe7760acd013a0913ba"}}
 ]}
 EOS
   end
@@ -57,9 +57,9 @@ EOS
     <<-EOS.strip_heredoc
 {"total_rows":8,"offset":0,"rows":[
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}},
-{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
-{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
-{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"}}
+{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-5f16aec70767aa294b07ad4396bc56af"},"doc":{"_id":"_design/all_provider_docs","_rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
+{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"},"doc":{"_id":"_design/auth","_rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
+{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"},"doc":{"_id":"_design/export_database","_rev":"1-82e865010760bbe7760acd013a0913ba"}}
 ]}
 EOS
   end
@@ -171,7 +171,6 @@ EOS
 
         end
         it 'sends request with correct default options' do
-          p 'sends request ...'
           records = subject.send(ex_opts[:method])
           records.first if ex_opts[:method] == :records  # start enumerator
           expect(subject.client).to have_received(:view)

--- a/spec/lib/krikri/harvesters/couchdb_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/couchdb_harvester_spec.rb
@@ -5,7 +5,7 @@ require 'pry'
 describe Krikri::Harvesters::CouchdbHarvester do
 
   let(:args) { { uri: 'http://example.org:5984/couchdb' } }
-  # Generic Analysand view response for all records.  Note that we're using a
+  # Generic Analysand view responses for all records.  Note that we're using a
   # ViewResponse when it could be a StreamingViewResponse in some cases.  The
   # interfaces of these classes is the same, so it keeps these tests cleaner to
   # stick to ViewResponse.
@@ -13,28 +13,34 @@ describe Krikri::Harvesters::CouchdbHarvester do
   # Analysand view responses for paginated requests that are used in `#records'
   let(:view_response_page_1) { double(Analysand::ViewResponse) }
   let(:view_response_page_2) { double(Analysand::ViewResponse) }
+  # Analysand view responses for `#count'
+  let(:view_response_totalrows) { double(Analysand::ViewResponse) }
+  let(:view_response_ddcount) { double(Analysand::ViewResponse) }
 
   # The HTTP response bodies from the view responses above, plus the options
   # passed in the corresponding client.view calls
   #
   let(:view_response_body) do
     <<-EOS.strip_heredoc
-{"total_rows":5,"offset":0,"rows":[
+{"total_rows":8,"offset":0,"rows":[
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","key":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","value":{"rev":"11-e68fd829f55b85dec51d044fe4711530"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","_rev":"11-e68fd829f55b85dec51d044fe4711530","object":"e6d7a72d8e957175a46965f104b9bb52"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","key":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","value":{"rev":"11-fec45c2c32bf6b468d8d6413796ff85b"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","_rev":"11-fec45c2c32bf6b468d8d6413796ff85b","object":"744cc17058614440ae6c3722aaacb4c3"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","key":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","value":{"rev":"11-b3e9a75b56599a78cb875ffb5c508c2b"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","_rev":"11-b3e9a75b56599a78cb875ffb5c508c2b","object":"bfecb6c11db808ca6603cd13def5f9bf"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","key":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","value":{"rev":"11-c9ebbeb8064280e674ea79c0b16c59d6"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt038nc34r","_rev":"11-c9ebbeb8064280e674ea79c0b16c59d6","object":"d2e3b4d91fba4f77df6fb8fab46f3375"}},
-{"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}}
+{"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}},
+{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
+{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
+{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"}}
 ]}
 EOS
   end
 
   let(:view_opts_page_1) do
-    {include_docs: true, stream: false, limit: 4, startkey: '0'}
+    { include_docs: true, stream: false, limit: 4 }
   end
   let(:view_response_body_page_1) do
     <<-EOS.strip_heredoc
-{"total_rows":4,"offset":0,"rows":[
+{"total_rows":8,"offset":0,"rows":[
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","key":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","value":{"rev":"11-e68fd829f55b85dec51d044fe4711530"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt009nc254","_rev":"11-e68fd829f55b85dec51d044fe4711530","object":"e6d7a72d8e957175a46965f104b9bb52"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","key":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","value":{"rev":"11-fec45c2c32bf6b468d8d6413796ff85b"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0199p9ph","_rev":"11-fec45c2c32bf6b468d8d6413796ff85b","object":"744cc17058614440ae6c3722aaacb4c3"}},
 {"id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","key":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","value":{"rev":"11-b3e9a75b56599a78cb875ffb5c508c2b"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt029016nn","_rev":"11-b3e9a75b56599a78cb875ffb5c508c2b","object":"bfecb6c11db808ca6603cd13def5f9bf"}},
@@ -49,15 +55,32 @@ EOS
   end
   let(:view_response_body_page_2) do
     <<-EOS.strip_heredoc
-{"total_rows":1,"offset":0,"rows":[
-{"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}}
+{"total_rows":8,"offset":0,"rows":[
+{"id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","key":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","value":{"rev":"11-7fbb604516852656d30f37bbe1f09d5f"},"doc":{"_id":"10046--http://ark.cdlib.org/ark:/13030/kt0489p9km","_rev":"11-7fbb604516852656d30f37bbe1f09d5f","object":"0162e70cde3d9d77ba8cbe9e146beda4"}},
+{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
+{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
+{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"}}
 ]}
 EOS
   end
 
   let(:view_opts_common_stream) { { include_docs: false, stream: true } }
   let(:view_opts_common_nostream) do
-    { include_docs: true, stream: false, limit: 10, startkey: '0'}
+    { include_docs: true, stream: false, limit: 10 }
+  end
+
+  let(:view_opts_designdoc_count) do
+    { include_docs: false, stream: false,
+      startkey: '_design', endkey: '_design0' }
+  end
+  let(:view_response_body_designdoc_count) do
+    <<-EOS.strip_heredoc
+{"total_rows":8,"offset":5,"rows":[
+{"id":"_design/all_provider_docs","key":"_design/all_provider_docs","value":{"rev":"1-9347ba9fffa89bdd76092466a0e83d71"}},
+{"id":"_design/auth","key":"_design/auth","value":{"rev":"1-1beca9b6e893c434a7d4fc19d9468d9b"}},
+{"id":"_design/export_database","key":"_design/export_database","value":{"rev":"1-82e865010760bbe7760acd013a0913ba"}}
+]}
+EOS
   end
 
   let(:document_response) do
@@ -71,19 +94,38 @@ EOS
   let(:parsed_response) { JSON.parse(view_response_body) }
   let(:parsed_response_page_1) { JSON.parse(view_response_body_page_1) }
   let(:parsed_response_page_2) { JSON.parse(view_response_body_page_2) }
+  let(:parsed_response_designdoc_count) do
+    JSON.parse(view_response_body_designdoc_count)
+  end
+  let(:parsed_response_no_dd) do
+    rv = parsed_response
+    rv['rows'] = parsed_response['rows'].select do |r|
+      !r['id'].start_with?('_design')
+    end
+    rv
+  end
 
   before do
-    allow(view_response).to receive(:docs)
-      .and_return(parsed_response['rows'].map { |r| r['doc'] })
+    allow(view_response).to receive(:rows)
+      .and_return(parsed_response['rows'])
     allow(view_response).to receive(:keys)
       .and_return(parsed_response['rows'].map { |r| r['key'] })
     allow(view_response).to receive(:total_rows)
       .and_return(parsed_response['total_rows'])
 
-    allow(view_response_page_1).to receive(:docs)
-      .and_return(parsed_response_page_1['rows'].map { |r| r['doc'] })
-    allow(view_response_page_2).to receive(:docs)
-      .and_return(parsed_response_page_2['rows'].map { |r| r['doc'] })
+    allow(view_response_page_1).to receive(:rows)
+      .and_return(parsed_response_page_1['rows'])
+    allow(view_response_page_1).to receive(:total_rows)
+      .and_return(parsed_response_page_1['total_rows'])
+    allow(view_response_page_2).to receive(:rows)
+      .and_return(parsed_response_page_2['rows'])
+    allow(view_response_page_2).to receive(:total_rows)
+      .and_return(parsed_response_page_2['total_rows'])
+
+    allow(view_response_ddcount).to receive(:keys)
+      .and_return(parsed_response_designdoc_count['rows'].map { |r| r['key'] })
+    allow(view_response_ddcount).to receive(:total_rows)
+      .and_return(parsed_response_designdoc_count['total_rows'])
   end
 
   subject { described_class.new(args) }
@@ -122,10 +164,14 @@ EOS
       shared_examples 'send options' do |ex_opts|
         before do
           allow(subject.client).to receive(:view).and_return view_response
-          allow(view_response).to receive(:keys).and_return []
-          allow(view_response).to receive(:total_rows).and_return 0
+          allow(view_response).to receive(:keys)
+            .and_return(parsed_response['rows'].map { |r| r['key'] })
+          allow(view_response).to receive(:total_rows)
+           .and_return(parsed_response['total_rows'])
+
         end
         it 'sends request with correct default options' do
+          p 'sends request ...'
           records = subject.send(ex_opts[:method])
           records.first if ex_opts[:method] == :records  # start enumerator
           expect(subject.client).to have_received(:view)
@@ -141,11 +187,21 @@ EOS
       end
 
       describe '#count' do
-        default_request_opts = {limit: 0, include_docs: false, stream: true}
+        default_request_opts = {
+          include_docs: false, stream: false,
+          startkey: '_design', endkey: '_design0'
+        }
         include_examples 'send options', method: :count,
-                                         m_opts: {view: 'foo/bar'},
+                                         m_opts: { view: 'foo/bar' },
                                          r_opts: default_request_opts,
                                          default_r_opts: default_request_opts
+
+        it 'returns the correct count' do
+          expect(subject.client).to receive(:view)
+            .with(instance_of(String), view_opts_designdoc_count)
+            .and_return(view_response_ddcount)
+          expect(subject.count).to eq 5
+        end
       end
 
       describe '#records' do
@@ -155,13 +211,13 @@ EOS
         end
 
         default_request_opts = {
-          include_docs: true, stream: false, limit: 10, startkey: '0'
+          include_docs: true, stream: false, limit: 10
         }
         request_opts = {
-          include_docs: true, stream: false, limit: 5, startkey: '0'
+          include_docs: true, stream: false, limit: 5
         }
         include_examples 'send options', method: :records,
-                                         m_opts: {view: 'foo/bar', limit: 5},
+                                         m_opts: { view: 'foo/bar', limit: 5 },
                                          r_opts: request_opts,
                                          default_r_opts: default_request_opts
 
@@ -175,6 +231,7 @@ EOS
           expect(subject.client).to receive(:view)
             .with(instance_of(String), view_opts_page_2)
             .and_return(view_response_page_2)
+
           recs = subject.records(limit: 4)
           expect(recs.count).to eq 5
         end
@@ -183,9 +240,23 @@ EOS
       describe '#record_ids' do
         default_request_opts = { :include_docs=>false, :stream=>true }
         include_examples 'send options', method: :record_ids,
-                                         m_opts: {view: 'foo/bar'},
+                                         m_opts: { view: 'foo/bar' },
                                          r_opts: default_request_opts,
                                          default_r_opts: default_request_opts
+
+        it 'returns record ids without design documents' do
+          expect(subject.client).to receive(:view)
+            .with(instance_of(String), view_opts_common_stream)
+            .and_return(view_response)
+          allow(view_response).to receive(:keys)
+            .and_return(parsed_response['rows'].map { |r| r['key'] })
+          expected_ids = parsed_response_no_dd['rows'].map { |r| r['id'] }
+          # The actual IDs will be returned as an emumerator, so create an
+          # array for the sake of comparison.
+          actual_ids = []
+          subject.record_ids.each { |id| actual_ids << id }
+          expect(actual_ids).to eq expected_ids
+        end
       end
     end
 


### PR DESCRIPTION
Have `CouchdbHarvester` issue requests to CouchDB in paginated fashion, instead of using a stream.  Removes reliance by `#records` upon `Analysand::StreamingViewResponse`, which was having problems with certain UTF-8 characters.

Fix `CouchdbHarvester#record`, `#record_ids`, and `#count` methods to  exclude CouchDB design documents.
