### PR TITLE
Rewrite validation reports model/controller; add tests

### DIFF
--- a/app/controllers/krikri/reports_controller.rb
+++ b/app/controllers/krikri/reports_controller.rb
@@ -10,9 +10,9 @@ module Krikri
     # for the specified provider.
     def index
       @current_provider = params[:provider]
-      @validation_reports = Krikri::ValidationReport.new.all do
-        self.provider_id = @current_provider
-      end
+      report = Krikri::ValidationReport.new
+      report.provider_id = @current_provider
+      @validation_reports = report.all
 
       if @current_provider
         @qa_reports = Array(Krikri::QAReport.find_by(provider: @current_provider))

--- a/app/controllers/krikri/validation_reports_controller.rb
+++ b/app/controllers/krikri/validation_reports_controller.rb
@@ -17,16 +17,29 @@ module Krikri
     # ApplicationController.  It uses krikri's application layout:
     layout 'krikri/application'
 
+    ##
+    # Render the show view
+    #
+    # This differs from {Blacklight::CatalogController}'s normal handling of the
+    # index and show views, Giving a paginated list of response documents
+    # instead of showing a single document.
+    #
+    # @todo: consider bringing this in line with Blacklight's approach
     def show
       @current_provider = params[:provider]
-      page = params[:page]
-      per_page = params[:per_page]
-      @response = ValidationReport.new.find(params[:id]) do
-        self.provider_id = @current_provider
-        self.start = page
-        self.rows = per_page
-      end
+
+      @response = build_report.find(params[:id])
       @documents = @response.documents
+    end
+
+    private
+
+    def build_report
+      report = ValidationReport.new
+      report.provider_id = @current_provider
+      report.page = params[:page]
+      report.rows = params[:per_page]
+      report
     end
   end
 end

--- a/app/models/krikri/validation_report.rb
+++ b/app/models/krikri/validation_report.rb
@@ -1,23 +1,25 @@
 module Krikri
   class ValidationReport
-    attr_accessor :provider_id, :start, :rows
+    attr_accessor :provider_id, :page, :rows
 
     REQUIRED_FIELDS = ['dataProvider_name', 'isShownAt_id', 'preview_id',
                        'sourceResource_rights', 'sourceResource_title',
                        'sourceResource_type_id']
 
     ##
-    # @param &block may contain provider_id
-    #   Sample use:
-    #     ValidationReport.new.all do
-    #       self.provider_id = '0123'
-    #     end
+    # @example
+    #   ValidationReport.new.all
+    #   => [#<Blacklight::SolrResponse::Facets::FacetField:0x007fce32f46fe8 ...]
     #
-    # @return [Array<Blacklight::SolrResponse::Facet>]
-    def all(&block)
-      # set values from block
-      instance_eval &block if block_given?
-
+    # @example
+    #   report = ValidationReport.new
+    #   report.provider_id = '0123'
+    #   report.all
+    #   => [#<Blacklight::SolrResponse::Facets::FacetField:0x007fce32f46fe8 ...]
+    #
+    # @return [Array<Blacklight::SolrResponse::Facets::FacetField>] a report for
+    #   missing values in each of the `REQUIRED_FIELDS`
+    def all
       query_params = { :rows => 0,
                        'facet.field' => REQUIRED_FIELDS,
                        'facet.mincount' => 10000000,
@@ -29,25 +31,32 @@ module Krikri
     end
 
     ##
-    # @param id [String]
-    # @param &block may contain provider_id, start, rows
-    #   Sample use:
-    #     ValidationReport.new.find('sourceResource_title') do
-    #       self.provider_id = '0123'
-    #     end
+    # @param id [String] a field to check for missing values
+    #
+    # @example
+    #   ValidationReport.new.find('sourceResource_title')
+    #   => {"responseHeader"=>{"status"=>0, "QTime"=>123},
+    #       "response"=>{"numFound"=>2653, "start"=>0, "docs"=>[...]}}
+    #
+    # @example
+    #   report = ValidationReport.new
+    #   report.provider_id = '0123'
+    #   report.rows = 100
+    #   report.find('sourceResource_title')
     #
     # @raise [RSolr::Error::Http] for non-existant field requests
     # @return [Blacklight::SolrResponse]
-    def find(id, &block)
-      # set values from block
-      instance_eval &block if block_given?
-
-
+    #
+    # @todo possibly make better use of blacklight controllers? This currently
+    #   assumes that the default pagination is 10. Anything else will cause
+    #   trouble.
+    def find(id)
       query_params = { :qt => 'standard', :q => "-#{id}:[* TO *]" }
       query_params[:rows] = @rows.present? ? @rows : '10'
-      query_params[:fq] = "provider_id:\"#{provider_uri}\""
-      query_params[:start] = @start if @start.present? if
+      query_params[:fq] = "provider_id:\"#{provider_uri}\"" if
         provider_id.present?
+      multiplier = @rows ? @rows.to_i : 10
+      query_params[:start] = ((@page.to_i - 1) * multiplier) if @page.present?
 
       Krikri::SolrResponseBuilder.new(query_params).response
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -7,10 +7,13 @@ describe Krikri::ReportsController, :type => :controller do
     login_user
 
     before do
-      allow_any_instance_of(Krikri::ValidationReport)
-        .to receive(:all).and_return(validation_reports)
+      # @todo: Krikri::ValidationReport should be refactored to avoid the need
+      #   for all this mocking.
+      allow(Krikri::ValidationReport).to receive(:new).and_return(report)
+      allow(report).to receive(:provider_id=)
+      allow(report).to receive(:all).and_return(validation_reports)
 
-      allow(Krikri::QAReport).to receive(:find_by).with(provider: 'moomin')
+      allow(Krikri::QAReport).to receive(:find_by).with(provider: provider_id)
                                   .and_return(qa_reports)
     end
 
@@ -20,30 +23,42 @@ describe Krikri::ReportsController, :type => :controller do
 
     let(:qa_reports) { [double('qa report 1'), double('qa report 2')] }
 
+    let(:provider_id) { 'moomin' }
+
+    # @todo: remove me; see other comments
+    let(:report) { instance_double(Krikri::ValidationReport) }
+
     it 'renders the index view' do
       get :index
       expect(response).to render_template('krikri/reports/index')
     end
 
     it 'sets current provider' do
-      expect { get :index, provider: 'moomin' }
-        .to change { assigns(:current_provider) }.to('moomin')
+      expect { get :index, provider: provider_id }
+        .to change { assigns(:current_provider) }.to(provider_id)
     end
 
     it 'populates the validation reports list' do
-      expect { get :index, provider: 'moomin' }
+      expect { get :index, provider: provider_id }
         .to change { assigns(:validation_reports) }.to(validation_reports)
     end
 
+    # @todo: this specifies implementation, due to limitations of the
+    #   Krikri::ValidationReport interface (see above). Refactor me!
+    it 'sets the provider' do
+      expect(report).to receive(:provider_id=).with(provider_id)
+      get :index, provider: provider_id
+    end
+
     it 'populates the QA reports list by provider' do
-      expect { get :index, provider: 'moomin' }
+      expect { get :index, provider: provider_id }
         .to change { assigns(:qa_reports) }.to (qa_reports)
     end
 
     it 'populates the QA reports as an array when a there is a single item' do
-      allow(Krikri::QAReport).to receive(:find_by).with(provider: 'moomin')
+      allow(Krikri::QAReport).to receive(:find_by).with(provider: provider_id)
                                   .and_return(qa_reports.first)
-      expect { get :index, provider: 'moomin' }
+      expect { get :index, provider: provider_id }
         .to change { assigns(:qa_reports) }.to ([qa_reports.first])
     end
 

--- a/spec/controllers/validation_reports_controller_spec.rb
+++ b/spec/controllers/validation_reports_controller_spec.rb
@@ -16,5 +16,61 @@ describe Krikri::ValidationReportsController, :type => :controller do
       expect { get :show, id: 'sourceResource_title', provider: 'nypl' }
         .to change { assigns(:current_provider) }.to('nypl')
     end
+
+    # @todo: these are integration tests, repeating coverage from the
+    #   ValidationReport model specs. The interface of ValidationReports
+    #   makes this hard to test any other way (short of really nasty)
+    #   `allow_any_instance_of` chains.
+    context 'with saved items' do
+      include_context 'with missing values'
+
+      it 'sets documents for all providers' do
+        get :show, id: 'sourceResource_title'
+
+        expect(assigns[:documents].map(&:id))
+          .to contain_exactly(empty.rdf_subject.to_s,
+                              empty_new_provider.rdf_subject.to_s)
+      end
+
+      it 'sets documents by provider' do
+        get :show, id: 'sourceResource_title', provider: provider.id
+
+        expect(assigns[:documents].map(&:id))
+          .to contain_exactly empty.rdf_subject.to_s
+      end
+
+      it 'gives docments with isShownAt' do
+        get :show, id: 'sourceResource_title', provider: provider.id
+
+        expect(assigns[:documents].first['isShownAt_id'])
+          .not_to be_empty
+      end
+
+      describe 'pagination' do
+        it 'finds all matching items' do
+          get :show, id: 'sourceResource_title', per_page: 1
+
+          expect(assigns[:response].count).to eq 2
+        end
+
+        it 'gets current page' do
+          get :show, id: 'sourceResource_title', per_page: 1
+
+          expect(assigns[:response].docs.count).to eq 1
+        end
+
+        it 'sets next page' do
+          get :show, id: 'sourceResource_title', per_page: 1
+
+          expect(assigns[:response].next_page).to eq 2
+        end
+
+        it 'knows when there are no more pages' do
+          get :show, id: 'sourceResource_title', per_page: 1, page: 2
+
+          expect(assigns[:response].next_page).to eq nil
+        end
+      end
+    end
   end
 end

--- a/spec/models/validation_report_spec.rb
+++ b/spec/models/validation_report_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe Krikri::ValidationReport do
-  include_context 'with indexed item'
-
-  # @todo: need more tests for ValidationReport#all
   describe `#all` do
     it 'returns facet for each required field' do
       count = described_class::REQUIRED_FIELDS.count
@@ -12,9 +9,20 @@ describe Krikri::ValidationReport do
 
       expect(subject.all).to contain_exactly(*fields)
     end
+
+    context 'with missing value in record' do
+      include_context 'with missing values'
+
+      it 'returns facets by provider' do
+        subject.provider_id = provider.id
+        hits = subject.all.select { |fct| fct.name == 'sourceResource_title' }
+               .first.items.first.hits
+
+        expect(hits).to eq 1
+      end
+    end
   end
 
-  # @todo: need more tests for ValidationReport#find
   describe `#find` do
     it 'gives a blacklight solr response' do
       expect(subject.find('sourceResource_title'))
@@ -26,24 +34,53 @@ describe Krikri::ValidationReport do
         .to raise_error RSolr::Error::Http
     end
 
-    it 'gets by provider_id' do
-      provider_uri = RDF::URI(Krikri::Settings.prov.provider_base) / '123'
-      params = { :qt => 'standard',
-                 :q => '-sourceResource_title:[* TO *]',
-                 :rows => '10',
-                 :fq => "provider_id:\"#{provider_uri}\"" }
+    context 'with missing values in record' do
+      include_context 'with missing values'
 
+      it 'gets docs for all providers' do
+        docs = subject.find('sourceResource_title').response['docs']
 
-      response = double('solr response')
-      allow(Krikri::SolrResponseBuilder).to receive(:new).with(params)
-                                             .and_return(response)
-      allow(response).to receive(:response).and_return(:result)
-
-      result = subject.find('sourceResource_title') do
-        self.provider_id = '123'
+        expect(docs.map { |d| d['id'] })
+          .to contain_exactly(empty.rdf_subject.to_s,
+                              empty_new_provider.rdf_subject.to_s)
       end
 
-      expect(result).to eq :result
+      it 'allows limiting of rows per page' do
+        subject.rows = 1
+        expect(subject.find('sourceResource_title').docs.count).to eq 1
+      end
+
+      it 'allows pagination' do
+        subject.rows = '1'
+        page_one_docs = subject.find('sourceResource_title').docs
+        subject.page = '2'
+        expect(subject.find('sourceResource_title').docs)
+          .not_to eq page_one_docs
+      end
+
+      it 'paginates based on a default number of rows' do
+        page_one_docs = subject.find('sourceResource_title').docs
+        subject.page = '4'
+        expect(subject.find('sourceResource_title').response['start'])
+          .to eq 30
+      end
+
+      context 'with provider set' do
+        before { subject.provider_id = provider.id }
+
+        it 'gets by provider_id' do
+          expect(subject.find('sourceResource_title').response['numFound'])
+            .to eq 1
+        end
+
+        it 'gets docs by provider_id' do
+          subject.provider_id = provider.id
+          docs = subject.find('sourceResource_title').response['docs']
+
+          expect(docs.map { |d| d['id'] })
+            .to contain_exactly empty.rdf_subject.to_s
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_contexts/indexed_item.rb
+++ b/spec/support/shared_contexts/indexed_item.rb
@@ -4,13 +4,15 @@ shared_context 'with indexed item' do
   before do
     clear_search_index
     indexer = Krikri::QASearchIndex.new
-    indexer.add agg.to_jsonld['@graph'].first
+    records.each { |rec| indexer.add rec.to_jsonld['@graph'].first }
     indexer.commit
   end
 
   after do
     clear_search_index
   end
+
+  let(:records) { [agg] }
 
   let(:agg) do
     a = build(:aggregation)
@@ -23,5 +25,25 @@ shared_context 'with indexed item' do
     build(:krikri_provider,
           rdf_subject: 'moomin_valley',
           label: 'moomin valley')
+  end
+end
+
+shared_context 'with missing values' do
+  include_context 'with indexed item' do
+    let(:records) { [agg, empty, empty_new_provider] }
+
+    let(:empty) do
+      aggregation = build(:aggregation, provider: provider, sourceResource: nil)
+      aggregation.set_subject! 'empty'
+      aggregation
+    end
+
+    let(:empty_new_provider) do
+      aggregation = build(:aggregation,
+                          provider: RDF::URI('http://example.com/fake'),
+                          sourceResource: nil)
+      aggregation.set_subject! 'empty_new_provider'
+      aggregation
+    end
   end
 end


### PR DESCRIPTION
This slightly reworks the `ValidationReports` model, and updates its consumers--adding tests for the functionality along the way.

There are a few places where integration testing/extensive mocking are called out.  These suggest a need for a more extensive rewrite of `ValidationReports` and/or a `ValidationReportBuilder` pattern to free those modules from that internal knowledge.  In the meanwhile, I think this makes everything work. :)  