### PR TITLE
Split geographic coordinate strings

### DIFF
--- a/lib/krikri/enrichments/split_coordinates.rb
+++ b/lib/krikri/enrichments/split_coordinates.rb
@@ -1,0 +1,73 @@
+module Krikri::Enrichments
+  ##
+  # Splits a string given in `lat' or `long' in an edm:Place object and
+  # assigns `lat' and `long' with the split values.
+  #
+  # @example
+  #
+  #   Where val is a DPLA::MAP::Place,
+  #   and val.lat == '40.7127,74.0059',
+  #   assign val.lat = '40.7127' and val.long = '74.0059'
+  #
+  #   If long is filled in instead of lat, the values will be assigned in the
+  #   reverse order, with lat taking '74.0059' and long taking '40.7127'.
+  #
+  class SplitCoordinates
+    include Krikri::FieldEnrichment
+
+    ##
+    # Enrich a `DPLA::MAP::Place' object by splitting the string given
+    # in its `lat' or `long'.
+    #
+    # @param place [DPLA::MAP::Place]
+    # @return [DPLA::MAP::Place]
+    #
+    def enrich_value(place)
+      return place if !place.is_a? DPLA::MAP::Place
+
+      # place.lat and place.long are arrays of one value if they are assigned.
+
+      return place if place.lat.first && place.long.first  # no split required
+
+      if place.lat.first
+        latlong = coord_values(place.lat.first)
+        assign_latlong!(place, latlong.first, latlong.last)
+      elsif place.long.first
+        latlong = coord_values(place.long.first)
+        assign_latlong!(place, latlong.last, latlong.first)
+      end
+
+      place
+    end
+
+    def assign_latlong!(place, lat, long)
+      # We have to assign these one at a time because we can't do this:
+      # place.lat, place.long = [[nil], [nil]]
+      # ... which results in:
+      #     "value must be an RDF URI, Node, Literal, or a valid datatype.
+      #     See RDF::Literal. You provided nil"
+      # ... although this works fine:
+      # place.lat, place.long = [['10.0'], ['11.1']]
+      place.lat = lat
+      place.long = long
+    end
+
+    ##
+    # Given a String `s', return an array of two elements split on a comma
+    # and any whitespace around the comma.
+    #
+    # If the string does not split into two strings representing decimal
+    # values, then return [nil, nil] because the string does not make sense as
+    # coordinates.
+    #
+    # @param s [String]  String of, hopefully, comma-separated decimals
+    # @return [Array]
+    def coord_values(s)
+      coords = s.split(/ *, */)
+      return [nil, nil] if coords.size != 2
+      coords.map! { |c| c.to_f.to_s == c ? c : nil }   # must be decimal ...
+      return [nil, nil] unless coords[0] && coords[1]  # ... i.e. not nil
+      [coords[0], coords[1]]
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/split_coordinates_spec.rb
+++ b/spec/lib/krikri/enrichments/split_coordinates_spec.rb
@@ -6,9 +6,7 @@ describe Krikri::Enrichments::SplitCoordinates do
   context 'with place object' do
     let(:lat) { nil }
     let(:long) { nil }
-    let(:place) do
-      build(:place, lat: lat, long: long)
-    end
+    let(:place) { build(:place, lat: lat, long: long) }
 
     shared_examples 'latitude and longitude' do |expected_lat, expected_long|
       it 'assigns latitude' do
@@ -16,14 +14,14 @@ describe Krikri::Enrichments::SplitCoordinates do
       end
       it 'assigns longitude' do
         expect(subject.enrich_value(place).long).to eq expected_long
-      end      
+      end
     end
 
     shared_examples 'nonsensical coordinates' do
-      it 'returns empty coordinates' do
+      it 'retains original coordinates' do
         rv = subject.enrich_value(place)
-        expect(rv.lat).to eq []
-        expect(rv.long).to eq []
+        expect(rv.lat).to eq [lat].compact
+        expect(rv.long).to eq [long].compact
       end
     end
 
@@ -53,7 +51,7 @@ describe Krikri::Enrichments::SplitCoordinates do
     end
 
     context 'with a latitude containing non-decimal characters' do
-      let(:lat) {'10.0,10;'}
+      let(:lat) { '10.0,10;' }
       include_examples 'nonsensical coordinates'
     end
   end  # context 'with place object'

--- a/spec/lib/krikri/enrichments/split_coordinates_spec.rb
+++ b/spec/lib/krikri/enrichments/split_coordinates_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::SplitCoordinates do
+  it_behaves_like 'a field enrichment'
+
+  context 'with place object' do
+    let(:lat) { nil }
+    let(:long) { nil }
+    let(:place) do
+      build(:place, lat: lat, long: long)
+    end
+
+    shared_examples 'latitude and longitude' do |expected_lat, expected_long|
+      it 'assigns latitude' do
+        expect(subject.enrich_value(place).lat).to eq expected_lat
+      end
+      it 'assigns longitude' do
+        expect(subject.enrich_value(place).long).to eq expected_long
+      end      
+    end
+
+    shared_examples 'nonsensical coordinates' do
+      it 'returns empty coordinates' do
+        rv = subject.enrich_value(place)
+        expect(rv.lat).to eq []
+        expect(rv.long).to eq []
+      end
+    end
+
+    context 'with latitude first' do
+      let(:lat) { '40.7127,74.0059' }
+      include_examples 'latitude and longitude', ['40.7127'], ['74.0059']
+    end
+
+    context 'with longitude first' do
+      let(:long) { '40.7127,74.0059' }
+      include_examples 'latitude and longitude', ['74.0059'], ['40.7127']
+    end
+
+    context 'with a space character' do
+      let(:lat) { '40.7127, 74.0059' }
+      include_examples 'latitude and longitude', ['40.7127'], ['74.0059']
+    end
+
+    context 'with a latitude that does not split' do
+      let(:lat) { '40.0' }
+      include_examples 'nonsensical coordinates'
+    end
+
+    context 'with a latitude that splits into too many values' do
+      let(:lat) { '1.0,2.0,3.0' }
+      include_examples 'nonsensical coordinates'
+    end
+
+    context 'with a latitude containing non-decimal characters' do
+      let(:lat) {'10.0,10;'}
+      include_examples 'nonsensical coordinates'
+    end
+  end  # context 'with place object'
+
+  context 'with something other than a place object' do
+    it 'returns the given object' do
+      val = 'something'
+      expect(subject.enrich_value(val)).to equal val
+    end
+  end
+end


### PR DESCRIPTION
Split strings given in edm:Place (`DPLA::MAP::Place`) into latitude and longitude.
