### PR TITLE
Adds an enrichment to copy non-DCMI type values

### DIFF
--- a/lib/krikri/enrichments/move_non_dcmi_type.rb
+++ b/lib/krikri/enrichments/move_non_dcmi_type.rb
@@ -1,0 +1,17 @@
+module Krikri::Enrichments
+  ##
+  # Copies non-DCMI Type values from the input fields to the output fields.
+  # If
+  class MoveNonDcmiType
+    include Krikri::Enrichment
+
+    ##
+    # @param value [Object] the value to enrich
+    #
+    # @return [Object, nil] the existing value, if it is NOT a DCMI Type value
+    def enrich_value(value)
+      return nil if value.is_a? DPLA::MAP::Controlled::DCMIType
+      value
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/move_non_dcmi_type_spec.rb
+++ b/spec/lib/krikri/enrichments/move_non_dcmi_type_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::MoveNonDcmiType do
+  it_behaves_like 'a generic enrichment'
+
+  it 'returns strings as found' do
+    string = 'moomin'
+    expect(subject.enrich_value(string)).to eq string
+  end
+
+  it 'returns typed data as found' do
+    date = Date.today
+    expect(subject.enrich_value(date)).to eq date
+  end
+
+  it 'returns Resources as found' do
+    resource = ActiveTriples::Resource.new
+    expect(subject.enrich_value(resource)).to eq resource
+  end
+
+  it 'returns nil for DCMI Type values' do
+    resource = DPLA::MAP::Controlled::DCMIType.new
+    expect(subject.enrich_value(resource)).to be_nil
+  end
+end


### PR DESCRIPTION
Copies non-DCMI Type values to a new field via a 'generic' enrichment. This allows, e.g. moving values from `dctype` to `dcformat` before clearing the invalid values from `dctype`.