### PR TITLE
Add `ConvertToSentenceCase` enrichment

### DIFF
--- a/lib/krikri/enrichments/convert_to_sentence_case.rb
+++ b/lib/krikri/enrichments/convert_to_sentence_case.rb
@@ -1,0 +1,20 @@
+module Krikri::Enrichments
+  ##
+  # Converts a string to sentence case.
+  #
+  # @example
+  #
+  #   string = 'this is a sentence about Moomins. this is another about Snorks.'
+  #   Krikri::Enrichments::ConvertToSentenceCase.enrich_value(string)
+  #   # => 'This is a sentence about moomins. This is another about snorks.'
+  class ConvertToSentenceCase
+    include Krikri::FieldEnrichment
+
+    def enrich_value(value)
+      return value unless value.is_a? String
+      value.gsub(/([a-z])((?:[^.?!]|\.(?=[a-z]))*)/i) do
+        $1.upcase + $2.downcase.rstrip
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/convert_to_sentence_case_spec.rb
+++ b/spec/lib/krikri/enrichments/convert_to_sentence_case_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::ConvertToSentenceCase do
+  it_behaves_like 'a field enrichment'
+
+  values = [{ :string => 'converts to sentence case',
+              :start => 'moomin. snORKmaiden! HATTIFATTENERS? the Groak.',
+              :end => 'Moomin. Snorkmaiden! Hattifatteners? The groak.'
+            },
+            { :string => 'leaves other fields unaltered',
+              :start => 'Blah blah blah',
+              :end => 'Blah blah blah'
+            }]
+
+  it_behaves_like 'a string enrichment', values
+end


### PR DESCRIPTION
Converts a string to sentence case, removing capital letters in the sentences.