### PR TITLE
Adds a `#last_value` to `ParserValueArray`

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -210,6 +210,18 @@ module Krikri
       end
 
       ##
+      # Retrieves the last element of a ValueArray. Uses an optional argument
+      # to specify how many items to return. By design, it behaves similarly
+      # to Array#last, but it intentionally doesn't override it.
+      #
+      # @return [ValueArray] a Krikri::Parser::ValueArray for last n elements
+      def last_value(*args)
+        return self.class.new(@array.last(*args)) unless args.empty?
+        self.class.new([@array.last].compact)
+      end
+
+
+      ##
       # @see Array#concat
       # @return [ValueArray]
       def flatten(*args, &block)

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -160,6 +160,29 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#last_value' do
+    it 'returns a single item ValueArray without an argument' do
+      expect(subject.last_value).to contain_exactly values.last
+    end
+
+    it 'returns only requested items when called with an argument' do
+      expect(subject.last_value(2)).to contain_exactly(*values[-2..-1])
+      expect(subject.last_value(2).count).to eq(2)
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.last_value).to be_a described_class
+    end
+
+    context 'with empty field' do
+      let(:values) { [] }
+
+      it 'returns an empty ValueArray' do
+        expect(subject.last_value).to be_empty
+      end
+    end
+  end
+
   describe '#concat' do
     it 'gives union of two arrays' do
       vals = subject.to_a.dup


### PR DESCRIPTION
This behaves similarly to `#first_value`, in that it avoids overriding `#first` on the underlying (delegated) `Array`, but gives access to a `ParserValueArray` with only the requested values`.