### PR TITLE
Extend Timeout and Keep Alive for SPARQL::Client

### DIFF
--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -75,6 +75,11 @@ module Krikri
     initializer :rdf_repository do
       Krikri::Repository =
         RDF::Marmotta.new(Krikri::Settings['marmotta']['base'])
+
+      Krikri::Repository.query_client.instance_eval do
+        @http.keep_alive = 360
+        @http.read_timeout = 360
+      end
     end
 
     initializer :blacklight_settings do


### PR DESCRIPTION
Some of our more intensive SPARQL Queries for reports take on the order of two minutes for Marmotta to query and build the response. This keeps `SPARQL::Client` from timing out on these queries.