### PR TITLE
Update Crosswalk mapping for preview/object change

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -85,7 +85,7 @@ module Krikri
           view.respond_to?(:rdf_subject) ? view.rdf_subject.to_s : nil
         end
 
-        set_value(hash, :object, @parent.object, true) do |view|
+        set_value(hash, :object, @parent.preview, true) do |view|
           view.respond_to?(:rdf_subject) ? view.rdf_subject.to_s : nil
         end
 


### PR DESCRIPTION
`edm:object` was used in MAPv3.x to mean `edm:preview`. That's fixed in 4.0; this fixes it in the mapping.