### PR TITLE
remove scroll from side-by-side records

### DIFF
--- a/app/views/krikri/records/show.html.erb
+++ b/app/views/krikri/records/show.html.erb
@@ -14,12 +14,12 @@
   <div class='row'>
     <div class='col-md-6 col-sm-6'>
       <h3>Enriched Record</h3>
-      <pre class='pre-scrollable'><%= render_enriched_record(@document) %></pre>
+      <pre><%= render_enriched_record(@document) %></pre>
     </div>
 
     <div class='col-md-6 col-sm-6'>
       <h3>Original Record</h3>
-      <pre class='pre-scrollable'><%= render_original_record(@document) %></pre>
+      <pre><%= render_original_record(@document) %></pre>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This removes the scrolling feature for individual records on the side-by-side record comparison.