### PR TITLE
Change index fields for records

### DIFF
--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -51,7 +51,7 @@ module Krikri
       # :show may be set to false if you don't want the facet to be drawn in the
       # facet bar
 
-      config.add_facet_field 'sourceResource_type_providedLabel',
+      config.add_facet_field 'sourceResource_type_name',
                              label: 'Type',
                              limit: 20
       config.add_facet_field 'sourceResource_format',
@@ -83,13 +83,26 @@ module Krikri
 
       # solr fields to be displayed in the index (search results) view
       #   The ordering of the field names is the order of the display
-      config.add_index_field 'sourceResource_title', label: 'Title'
-      config.add_index_field 'sourceResource_description', label: 'Description'
-      config.add_index_field 'sourceResource_date_providedLabel', label: 'Date'
-      config.add_index_field 'sourceResource_type_providedLabel', label: 'Type'
-      config.add_index_field 'sourceResource_format', label: 'Format'
-      config.add_index_field 'sourceResource_rights', label: 'Rights'
-      config.add_index_field 'dataProvider_providedLabel', label: 'Data Provider'
+      config.add_index_field 'sourceResource_title', 
+                             label: 'Title'
+      config.add_index_field 'sourceResource_creator_providedLabel', 
+                             label: 'Creator'
+      config.add_index_field 'sourceResource_date_providedLabel', 
+                             label: 'Date'
+      config.add_index_field 'sourceResource_description', 
+                             label: 'Description'
+      config.add_index_field 'sourceResource_type_name', 
+                             label: 'Type'
+      config.add_index_field 'sourceResource_format', 
+                             label: 'Format'
+      config.add_index_field 'sourceResource_subject_providedLabel',
+                             label: 'Subject'
+      config.add_index_field 'sourceResource_rights', 
+                             label: 'Rights'
+      config.add_index_field 'sourceResource_collection_title',
+                             label: 'Collection'
+      config.add_index_field 'dataProvider_providedLabel', 
+                             label: 'Data Provider'
 
       config.index.thumbnail_field = :preview_id
 

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -631,6 +631,7 @@ v         currently supported on types that are sorted internally as strings
    <field name="sourceResource_type_id" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="sourceResource_type_type" type="string" indexed="false" stored="false" multiValued="true" />
    <field name="sourceResource_type_providedLabel" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="sourceResource_type_name" type="string" indexed="true" stored="true" multiValued="true" />
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
@@ -735,6 +736,7 @@ v         currently supported on types that are sorted internally as strings
   <copyField source="sourceResource_subject_providedLabel" dest="text" />
   <copyField source="sourceResource_temporal" dest="text" />
   <copyField source="sourceResource_title" dest="text" />
+  <copyField source="sourceResource_type_name" dest="text" />
 
    <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same

--- a/solr_conf/solrconfig.xml
+++ b/solr_conf/solrconfig.xml
@@ -99,7 +99,7 @@
          sourceResource_spatial_providedLabel
          sourceResource_subject_providedLabel
          sourceResource_title
-         sourceResource_type_id
+         sourceResource_type_name
          text
        </str>
 
@@ -114,7 +114,7 @@
          sourceResource_spatial_providedLabel
          sourceResource_subject_providedLabel
          sourceResource_title
-         sourceResource_type_id
+         sourceResource_type_name
          text
        </str>
        
@@ -134,7 +134,7 @@
          sourceResource_spatial_providedLabel,
          sourceResource_subject_providedLabel,
          sourceResource_title,
-         sourceResource_type_id
+         sourceResource_type_name
        </str>
 
        <str name="facet">true</str>


### PR DESCRIPTION
This adds 'Creator', 'Subject', and 'Collection' to the index fields for a record on the search results page.  It also reorders the fields.  It changes the source field for 'Type' from `sourceResource.type.id` to `sourceResource.type.name`. 

To test locally, generate a test app and start jetty.  You may need to stop, clean, and config jetty first:
`bundle exec rake jetty:stop`
`bundle exec rake jetty:clean`
`bundle exec rake jetty:config`
`bundle exec rake jetty:start`

Index a sample record with a value for `sourceResource.type.name`.  In your rails console:
`include FactoryGirl::Syntax::Methods`
`require 'dpla/map/factories'`
`agg = build(:aggregation)`
`agg.mint_id!('krikri_sample')`
`indexer = Krikri::QASearchIndex.new`
`graph = agg.to_jsonld['@graph'].first`
`graph['sourceResource']['type']['name'] = "Image"`
`indexer.add graph`
`indexer.commit`