### PR TITLE
Add boolean or expressions to Krikri::Parser::Value subclasses

### DIFF
--- a/lib/krikri/parsers/json_parser.rb
+++ b/lib/krikri/parsers/json_parser.rb
@@ -44,6 +44,11 @@ module Krikri
 
       private
 
+      ##
+      # @see Krikri::Parser#get_child_nodes
+      #
+      # @param name_exp [String]  Object property name
+      # @return [Krikri::Parser::ValueArray]
       def get_child_nodes(name)
         if @node[name].is_a?(Array)
           vals = @node[name].map { |node| self.class.new(node) }

--- a/lib/krikri/parsers/xml_parser.rb
+++ b/lib/krikri/parsers/xml_parser.rb
@@ -61,9 +61,16 @@ module Krikri
 
       private
 
+      ##
+      # @see Krikri::Parser#get_child_nodes
+      #
+      # @param name_exp [String]  Element name
+      # @return [Krikri::Parser::ValueArray]
       def get_child_nodes(name)
-        Krikri::Parser::ValueArray.new(@node.xpath("#{@node.path}/#{name}", @namespaces)
-          .map { |node| self.class.new(node, @namespaces) })
+        Krikri::Parser::ValueArray.new(
+          @node.xpath("#{@node.path}/#{name}", @namespaces)
+            .map { |node| self.class.new(node, @namespaces) }
+        )
       end
 
       def attribute(name)

--- a/spec/lib/krikri/parsers/json_parser_spec.rb
+++ b/spec/lib/krikri/parsers/json_parser_spec.rb
@@ -27,4 +27,13 @@ describe Krikri::JsonParser::Value do
   let(:record) { build(:json_record) }
 
   it_behaves_like 'a parser value'
+
+  it 'allows boolean "or" with "|" in the field name' do
+    expect(subject['notdefined|subject'].values).to eq ["Moomin Papa"]
+  end
+
+  it 'returns the value from the first defined name, given a "|"' do
+    # "subject" comes last in the document, but first in the "|" expression:
+    expect(subject['subject|title'].values).to eq ["Moomin Papa"]
+  end
 end

--- a/spec/lib/krikri/parsers/xml_parser_spec.rb
+++ b/spec/lib/krikri/parsers/xml_parser_spec.rb
@@ -19,4 +19,19 @@ describe Krikri::XmlParser::Value do
 
   it_behaves_like 'a parser value'
   it_behaves_like 'a parser value that has attributes'
+
+  context 'with a root path' do
+    subject { Krikri::XmlParser.new(record, '//oai_dc:dc').root }
+
+    it 'allows boolean "or" with "|" in the field name' do
+      expect(subject['dc:notdefined|dc:type'].values).to eq ["model"]
+    end
+
+    it 'returns the value from the first defined name, given a "|"' do
+      # "dc:type" comes last in the document, but comes first in the "|"
+      # expression:
+      expect(subject['dc:type|dc:title'].values)
+        .to eq ["model"]
+    end
+  end
 end


### PR DESCRIPTION
Add the ability to interpret boolean "or" expressions in the names passed to `Krikri::XmlParser#get_child_nodes` and `Krikri::JsonParser#get_child_nodes`, by way of `Krikri::Parser::ValueArray#field` and `#fields`.

This is necessary so that we can do the following sort of thing in our mappings:
```
    providedLabel record.field('description', 'item|itemAv|fileUnit',
                               'physicalOccurrenceArray',
                               'itemPhysicalOccurrence|' \
                                 'itemAvPhysicalOccurrence|' \
                                 'fileUnitPhysicalOccurrence',
                               'referenceUnitArray', 'referenceUnit',
                               'name')
```
Both `XmlParser` and `JsonParser` have been modified so that usage is consistent between the two.

