### PR TITLE
Do not obliterate defaults, QASearchIndex constructor

### DIFF
--- a/lib/krikri/search_index.rb
+++ b/lib/krikri/search_index.rb
@@ -136,8 +136,10 @@ module Krikri
     ##
     # @param opts [Hash] options to pass to RSolr
     # @see RSolr.connect
-    def initialize(opts = Krikri::Settings.solr.to_h)
-      @solr = RSolr.connect(opts)
+    def initialize(opts = {})
+      # Override or append to default Solr options
+      solr_opts = Krikri::Settings.solr.to_h.merge(opts)
+      @solr = RSolr.connect(solr_opts)
       super(opts)
     end
 

--- a/spec/lib/krikri/search_index_spec.rb
+++ b/spec/lib/krikri/search_index_spec.rb
@@ -33,7 +33,7 @@ describe Krikri::QASearchIndex do
   let(:solr) { RSolr.connect }
 
   describe '#initialize' do
-    context 'with args' do
+    context 'with overridden properties' do
       subject { described_class.new(opts) }
       let(:opts) { { url: 'http://my-client-uri/' } }
 
@@ -47,6 +47,20 @@ describe Krikri::QASearchIndex do
       allow(Krikri::Settings)
         .to receive(:solr).and_return(url: uri)
       expect(subject.solr.uri.to_s).to eq uri
+    end
+
+    context 'with extra properties not covered by defaults' do
+      # see https://www.pivotaltracker.com/n/projects/1172184/stories/91822774
+      # Note that `url` is not specified in `opts`:
+      let(:opts) { { extra_prop: 'not covered by defaults' } }
+      subject { described_class.new(opts) }
+
+      it 'preserves defaults by merging extra properties' do
+        uri = 'http://moomin.org/'
+        allow(Krikri::Settings)
+          .to receive(:solr).and_return(url: uri)
+        expect(subject.solr.uri.to_s).to eq uri
+      end
     end
   end
 


### PR DESCRIPTION
Have the `QASearchIndex` constructor preserve default configuration
properties that are not being passed in via the `opts` argument to
`#initialize`.

This allows the Solr URI in Krikri::Settings.solr to be passed to
`RSolr.connect`.

Fixes https://www.pivotaltracker.com/story/show/91822774