### PR TITLE
Fix broken build on enrichments

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec-rails", '~> 3.2.0'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'

--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -46,7 +46,7 @@ module Krikri::Enrichments
   # @see DPLA::MAP::Controlled::Language
   # @see http://www.lexvo.org/
   class LanguageToLexvo
-    include Krikri::FieldEnrichment
+    include Audumbla::FieldEnrichment
 
     TERMS = DPLA::MAP::Controlled::Language.list_terms.freeze
     QNAMES = TERMS.map { |t| t.qname[1] }.freeze

--- a/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
+++ b/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
@@ -18,7 +18,7 @@ module Krikri::Enrichments
   #   results.map(&:exactMatch)
   #   # => [[#<ActiveTriple::Resource:...>], []]
   #
-  # @see Krikri::FieldEnrichment
+  # @see Audumbla::FieldEnrichment
   class SplitProvidedLabelAtDelimiter
     include Audumbla::FieldEnrichment
 
@@ -30,7 +30,7 @@ module Krikri::Enrichments
 
     ##
     # @param value [Object] the value to split
-    # @see Krikri::FieldEnrichment
+    # @see Audumbla::FieldEnrichment
     def enrich_value(value)
       return value unless value.is_a?(ActiveTriples::Resource) &&
                           value.respond_to?(:providedLabel)


### PR DESCRIPTION
The order of the last few merges ended up breaking the build. In the process of resolving this, I discovered that RSpec 3.3 also breaks the build, but I think that will have to wait for @no-reply to look at.

There's a remaining outstanding issue where we're seeing the following error:

```
undefined method `type' for .focus:Sass::Selector::Class (NoMethodError)
```

...which was first discovered by @markbreedlove. 