### PR TITLE
Fix broken builds from enrichment merges and RSpec/Sass issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,6 @@ else
     gem 'sass-rails', '~> 5.0.0'
     gem 'responders', '~> 2.0'
   else
-    gem 'sass-rails', '~> 4.0.3'
+    gem 'sass-rails', '~> 5.0.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ A Rails engine for metadata aggregation, enhancement, and quality control.
 Installation
 -------------
 
-1. Add the `krikri` gem to your Gemfile.
+1. Add the `krikri` gem to your Gemfile. If you're using Rails 4.1, you will
+   manually need to set the gem version for `sass-rails` as follows:
+   `gem 'sass-rails', '~> 5.0.0'`
 
 2. Run `bundle exec rails g krikri:install`
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,10 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 require 'engine_cart/rake_task'
+# Skip Sprockets-related dependencies since we need to manually install
+# sass-rails ~> 5.0.0
+EngineCart.rails_options = '--skip-sprockets'
+
 require 'jettywrapper'
 
 import 'lib/tasks/jetty.rake'

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec-rails", '~> 3.2.0'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "analysand", "4.0.0"
   s.add_dependency "yajl-ruby"
   s.add_dependency "elasticsearch", "~>0.4.0"
+  s.add_dependency "sass-rails", "~> 5.0.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -19,6 +19,17 @@ module Krikri
     end
 
     ##
+    # Explicitly add sass-rails and uglifier, since the new app generated
+    # by engine_cart skips the sprockets-related dependencies. This is because
+    # Rails 4.1 uses sass-rails ~> 4.0.3, which for some reason surfaced
+    # this bug suddenly: https://github.com/sass/sass/issues/1656
+    def reenable_sprockets
+      gem 'sass-rails', '~> 5.0.0'
+      gem 'uglifier', '>= 1.3.0'
+      gsub_file 'config/application.rb', /^\# require ['"]sprockets\/railtie['"]$/, 'require "sprockets/railtie"'
+    end
+
+    ##
     # Add solr configuration
     def configure_solr
       copy_file 'schema.xml', 'solr_conf/schema.xml', :force => true

--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -46,7 +46,7 @@ module Krikri::Enrichments
   # @see DPLA::MAP::Controlled::Language
   # @see http://www.lexvo.org/
   class LanguageToLexvo
-    include Krikri::FieldEnrichment
+    include Audumbla::FieldEnrichment
 
     TERMS = DPLA::MAP::Controlled::Language.list_terms.freeze
     QNAMES = TERMS.map { |t| t.qname[1] }.freeze

--- a/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
+++ b/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
@@ -18,7 +18,7 @@ module Krikri::Enrichments
   #   results.map(&:exactMatch)
   #   # => [[#<ActiveTriple::Resource:...>], []]
   #
-  # @see Krikri::FieldEnrichment
+  # @see Audumbla::FieldEnrichment
   class SplitProvidedLabelAtDelimiter
     include Audumbla::FieldEnrichment
 
@@ -30,7 +30,7 @@ module Krikri::Enrichments
 
     ##
     # @param value [Object] the value to split
-    # @see Krikri::FieldEnrichment
+    # @see Audumbla::FieldEnrichment
     def enrich_value(value)
       return value unless value.is_a?(ActiveTriples::Resource) &&
                           value.respond_to?(:providedLabel)


### PR DESCRIPTION
This addresses the following issues:

* The order of the last few merges ended up breaking the build (when we merged the Audumbla abstraction before merging the language-to-Lexvo enrichment).
* Since the last release of Krikri/Heidrun, RSpec 3.3 was released, and running the specs under it breaks the build. I'm not sure why but I think that will have to wait for @no-reply to look at, because I'm guessing it's an issue with `rdf-spec` or `active_triples`. 
* This also addresses the `undefined method 'type' for .focus:Sass::Selector::Class (NoMethodError)` failure when precompiling the assets or running the specs for the `HarvestSourcesController`. The changes feel a bit excessive, but the next most feasible workaround would be to upgrade Krikri to Rails 4.2.

Closes #168.