### PR TITLE
Fix broken builds from enrichment merges and dependency resolution issues 

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec-rails", '~> 3.2.0'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -38,6 +38,20 @@ Gem::Specification.new do |s|
   s.add_dependency "yajl-ruby"
   s.add_dependency "elasticsearch", "~>0.4.0"
 
+  ##
+  # FIXME on Rails 4.2 upgrade: pin bootstrap-sass to 3.3.4.1
+  #
+  # This relates to sass/sass#1656. bootstrap-sass 3.3.5 introduced a
+  # regression which causes the Blacklight default CSS to fail its build.
+  # A quick fix could be to require sass-rails 5.0.x, but that introduces
+  # some slight dependency resolution problems under Rails 4.1 since Rails 4.1
+  # apps use sass-rails ~> 4.0.3 by default. The better fix will be to upgrade
+  # Krikri to Rails 4.2, but that will require further testing. This change
+  # has to be in the gemspec, and not the Gemfile for Krikri or the
+  # application in which it is hosted, as the dependencies won't resolve
+  # properly.
+  s.add_dependency "bootstrap-sass", "3.3.4.1"
+
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'
   s.add_development_dependency "rspec-rails", '~> 3.2.0'

--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -46,7 +46,7 @@ module Krikri::Enrichments
   # @see DPLA::MAP::Controlled::Language
   # @see http://www.lexvo.org/
   class LanguageToLexvo
-    include Krikri::FieldEnrichment
+    include Audumbla::FieldEnrichment
 
     TERMS = DPLA::MAP::Controlled::Language.list_terms.freeze
     QNAMES = TERMS.map { |t| t.qname[1] }.freeze

--- a/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
+++ b/lib/krikri/enrichments/split_provided_label_at_delimiter.rb
@@ -18,7 +18,7 @@ module Krikri::Enrichments
   #   results.map(&:exactMatch)
   #   # => [[#<ActiveTriple::Resource:...>], []]
   #
-  # @see Krikri::FieldEnrichment
+  # @see Audumbla::FieldEnrichment
   class SplitProvidedLabelAtDelimiter
     include Audumbla::FieldEnrichment
 
@@ -30,7 +30,7 @@ module Krikri::Enrichments
 
     ##
     # @param value [Object] the value to split
-    # @see Krikri::FieldEnrichment
+    # @see Audumbla::FieldEnrichment
     def enrich_value(value)
       return value unless value.is_a?(ActiveTriples::Resource) &&
                           value.respond_to?(:providedLabel)


### PR DESCRIPTION
This addresses the following issues:

* The order of the last few merges ended up breaking the build (when we merged the Audumbla abstraction before merging the language-to-Lexvo enrichment).
* Since the last release of Krikri/Heidrun, RSpec 3.3 was released, and running the specs under it breaks the build. I'm not sure why but I think that will have to wait for @no-reply to look at, because I'm guessing it's an issue with `rdf-spec` or `active_triples`. 
* This also addresses the `undefined method 'type' for .focus:Sass::Selector::Class (NoMethodError)` failure when precompiling the assets or running the specs for the `HarvestSourcesController`. `bootstrap-sass` introduced a small regression related to dependency resolution in version 3.3.5. The best nett step would be to upgrade Krikri to Rails 4.2 and remove the version pin on `bootstrap-sass`.

Supersedes and closes #169.