### PR TITLE
Handle empty/non-existent root nodes on XmlParser

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -135,7 +135,7 @@ module Krikri
             rec.mint_id! if rec.node?
             activity_uri ? rec.save_with_provenance(activity_uri) : rec.save
           rescue => e
-            Rails.logger.error("Error saving record: #{rec.rdf_subject}\n" \
+            Rails.logger.error("Error saving record: #{rec.try(:rdf_subject)}\n" \
                                "#{e.message}\n#{e.backtrace}")
           end
         end

--- a/lib/krikri/parsers/xml_parser.rb
+++ b/lib/krikri/parsers/xml_parser.rb
@@ -14,7 +14,9 @@ module Krikri
     def initialize(record, root_path = '/', ns = {})
       xml = Nokogiri::XML(record.to_s)
       ns = namespaces_from_xml(xml).merge(ns)
-      @root = Value.new(xml.at_xpath(root_path, ns), ns)
+      root_node = xml.at_xpath(root_path, ns) 
+      raise EmptyRootNodeError if root_node.nil?
+      @root = Value.new(root_node, ns)
       super(record)
     end
 
@@ -81,5 +83,11 @@ module Krikri
         Krikri::Parser::ValueArray.new(@node.children.select(&:text?))
       end
     end
+    
+    ##
+    # An error class for empty Value nodes.
+    #
+    # This is raised if a root value does not exist.
+    class EmptyRootNodeError < ArgumentError; end
   end
 end

--- a/spec/lib/krikri/mapper_agent_spec.rb
+++ b/spec/lib/krikri/mapper_agent_spec.rb
@@ -63,13 +63,19 @@ describe Krikri::Mapper::Agent do
     end
 
     context 'with errors thrown' do
-      before do
+      it 'logs errors' do
+        allow(agg_record_double).to receive(:node?).and_raise(StandardError.new)
+        allow(Krikri::Mapper).to receive(:map).and_return(generated_records)
+
+        expect(Rails.logger).to receive(:error).exactly(3).times
+        subject.run(activity_uri)
+      end
+
+      it 'logs errors with #rdf_subject' do
         allow(agg_record_double).to receive(:node?).and_raise(StandardError.new)
         allow(agg_record_double).to receive(:rdf_subject).and_return('123')
         allow(Krikri::Mapper).to receive(:map).and_return(generated_records)
-      end
 
-      it 'logs errors' do
         expect(Rails.logger).to receive(:error)
                                  .with(start_with('Error saving record: 123'))
                                  .exactly(3).times

--- a/spec/lib/krikri/parsers/xml_parser_spec.rb
+++ b/spec/lib/krikri/parsers/xml_parser_spec.rb
@@ -11,6 +11,14 @@ describe Krikri::XmlParser do
 
     it_behaves_like 'a parser'
   end
+
+  context 'with no root path' do
+    subject { Krikri::XmlParser.new(record, '//oai_dc:fake_root') }
+
+    it 'raises an error' do
+      expect { subject }.to raise_error described_class::EmptyRootNodeError
+    end
+  end
 end
 
 describe Krikri::XmlParser::Value do


### PR DESCRIPTION
If a non-existent path is given as the root node for a record, parsing failed with `NoMethodError` on an `#xml?` call to `nil`. This makes the parser throw a sensible error instead.

This should take care of error handling for the current ESDN mapping. It's an incremental improvement on error handling in mapping in general.

While we're in here, I'm open to suggestions about what to output as error context when `rec` is `nil`. `e.message` and `e.backtrace` may be enough.