### PR TITLE
Log requests on OAI Harvests

### DIFF
--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -42,6 +42,7 @@ module Krikri::Harvesters
       http_conn = Faraday.new do |conn|
         conn.request :retry, :max => 3
         conn.response :follow_redirects, :limit => 5
+        conn.response :logger, Rails.logger
         conn.adapter :net_http
       end
 

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -195,6 +195,14 @@ EOM
       expect { subject.records.first }.to raise_error
     end
 
+    it 'logs failed requests' do
+      allow_any_instance_of(Faraday::Adapter::NetHttp)
+        .to receive(:perform_request).and_raise(Net::ReadTimeout.new)
+      
+      expect(Rails.logger).to receive(:info).at_least(4).times
+      expect { subject.records.first }.to raise_error
+    end
+
     describe 'resumption' do
       let(:resumed_uri) do
         'http://example.org/endpoint?resumptionToken='\


### PR DESCRIPTION
Sets up the Faraday client that makes OAI requests to log requests; this makes it possible to spot retried requests.