### PR TITLE
Adds solr commit to solr bulk add processes

### DIFF
--- a/lib/krikri/search_index.rb
+++ b/lib/krikri/search_index.rb
@@ -156,9 +156,11 @@ module Krikri
     ##
     # @see Krikri::SearchIndex#update_from_activity
     def update_from_activity(activity)
-      fail "#{activity} is not an Activity" \
-        unless activity.class == Krikri::Activity
-      bulk_update_from_activity(activity)
+      fail "#{activity} is not an Activity" unless 
+        activity.class == Krikri::Activity
+      result = bulk_update_from_activity(activity)
+      solr.commit
+      result
     end
 
     ##

--- a/spec/lib/krikri/search_index_spec.rb
+++ b/spec/lib/krikri/search_index_spec.rb
@@ -158,10 +158,14 @@ describe Krikri::QASearchIndex do
     # See provenance_query_client.rb ('provenance queries' shared context)
     let(:generator_uri) { 'http://localhost:8983/marmotta/ldp/activity/3' }
 
-    it 'updates records affected by an activity' do
-      expect do
-        subject.update_from_activity(activity)
-      end.to_not raise_error
+    it 'sends bulk add requests' do
+      expect(subject).to receive(:bulk_add).at_least(1).times
+      subject.update_from_activity(activity)
+    end
+
+    it 'calls commit' do
+      expect(subject.solr).to receive(:commit)
+      subject.update_from_activity(activity)
     end
   end
 end


### PR DESCRIPTION
The QA index perviously required a manual commit following indexing jobs. `#update_from_activity` continues to return the same, but calls `solr#commit` after running its bulk adds.