### PR TITLE
Use Ruby OAI's new `#_source` method to access XML

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "therubyracer"
   s.add_dependency "edtf"
   s.add_dependency "text"
-  s.add_dependency "oai"
+  s.add_dependency "oai", '~>0.4.0'
   s.add_dependency "jsonpath"
   s.add_dependency "devise", "~>3.4.1"
   s.add_dependency "resque", "~>1.0"

--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -183,26 +183,16 @@ module Krikri::Harvesters
 
     ##
     # Transforms an OAI::Record to xml suitable for saving with the
-    # OriginalRecord
+    # OriginalRecord. It's necessary to build a new document and add the 
+    # namespace manually to normalize record output between `ListRecords` and
+    # `GetRecord` requests.
     #
     # @param rec [OAI::Record]
     # @return [String] an xml string
     def record_xml(rec)
-      doc = Nokogiri::XML::Builder.new do |xml|
-        xml.record('xmlns' => 'http://www.openarchives.org/OAI/2.0/') {
-          xml.header {
-            xml.identifier rec.header.identifier
-            xml.datestamp  rec.header.datestamp
-            rec.header.set_spec.each do |set|
-              xml.set_spec set.text
-            end
-          }
-          xml << rec.metadata.to_s unless rec.metadata.nil?
-          xml << rec.about.to_s unless rec.about.nil?
-        }
-      end
-      doc.doc.at_css('header')['status'] = rec.header.status if
-        rec.header.status
+      doc = Nokogiri.XML(rec._source.to_s)
+      doc.root
+        .add_namespace_definition(nil, 'http://www.openarchives.org/OAI/2.0/')
       doc.to_xml
     end
   end

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -188,6 +188,20 @@ EOM
                    :headers => {})
     end
 
+    it 'produces valid xml' do
+      expect do
+        Nokogiri::XML(subject.records.first.content) do |config|
+          config.options = Nokogiri::XML::ParseOptions::STRICT
+        end
+      end.not_to raise_error
+    end
+
+    it 'produces has oai namespace and header' do
+      expect(Nokogiri::XML(subject.records.first.content)
+              .xpath('//xmlns:header'))
+        .not_to be_empty
+    end
+
     it 'retries timed out requests' do
       expect_any_instance_of(Faraday::Adapter::NetHttp)
         .to receive(:perform_request).at_least(4).times
@@ -400,25 +414,6 @@ EOM
         activity = Krikri::Activity.first
         opts = JSON.parse(activity.opts, symbolize_names: true)
         expect(opts).to eq(args)
-      end
-    end
-
-    describe '#record_xml' do
-      let(:oai_record) { OAI::Record.new('') }
-
-      it 'produces valid xml' do
-        expect do
-          Nokogiri::XML(subject.send(:record_xml, oai_record)) do |config|
-            config.options = Nokogiri::XML::ParseOptions::STRICT
-          end
-        end.not_to raise_error
-      end
-
-      it 'sets header status' do
-        allow(oai_record.header).to receive(:status).and_return('deleted')
-        node = Nokogiri::XML(subject.send(:record_xml, oai_record))
-               .at_css('header')
-        expect(node['status']).to eq 'deleted'
       end
     end
 


### PR DESCRIPTION
Rather than building a new XML document from scratch, it's now possible to use the REXML Element in the returned `OAI::Record` directly. This is the case from `ruby-oai` 0.4.0 on.