### PR TITLE
Fix/provider model

### DIFF
--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -134,9 +134,9 @@ module Krikri
     # @param [Hash] user_parameters a hash of user-supplied parameters.
     def records_by_provider(solr_params, user_params)
       if @provider_id.present?
-        provider = Krikri::Provider.find(@provider_id)
+        rdf_subject = Krikri::Provider.base_uri + @provider_id
         solr_params[:fq] ||= []
-        solr_params[:fq] << "provider_id:\"#{provider.rdf_subject}\""
+        solr_params[:fq] << "provider_id:\"#{rdf_subject}\""
       end
     end
 

--- a/app/helpers/krikri/application_helper.rb
+++ b/app/helpers/krikri/application_helper.rb
@@ -15,7 +15,7 @@ module Krikri
     # @return [String]
     def provider_name(provider)
       provider = Krikri::Provider.find(provider) if provider.is_a? String
-      provider.present? ? provider.provider_name : "All Providers"
+      provider.present? ? provider.name : 'All Providers'
     end
 
     ##

--- a/app/models/krikri/provider.rb
+++ b/app/models/krikri/provider.rb
@@ -1,80 +1,173 @@
 module Krikri
   ##
-  # This models provider data from the {Krikri::Repository}.
+  # Provider is an ActiveModel object. It represents a provider that has been
+  # indexed in Solr.
   #
-  # @todo create an appropriate `ActiveTriples::PersistenceStrategy' for
-  #   handling providers as data from a repository alongside LDP data.
-  # @see ActiveTriples::Resource
-  class Provider < DPLA::MAP::Agent
-    configure :base_uri => Krikri::Settings.prov.provider_base
+  # This is a read-only object. It does not write new providers to Solr, nor
+  # does it update or delete providers.
+  #
+  # A DPLA::MAP::Agent object can be constructed from an instance of this
+  # ActiveModel object using the :agent method. The DPLA::MAP::Agent object
+  # interacts with Marmotta, rather than Solr.
+  #
+  #   @example Krikri::Provider.find(rdf_subject: 'http://blah.com/123').agent
+  #     => [DPLA::MAP::Agent]
+  #
+  class Provider
+    include ActiveModel::Validations
+    include ActiveModel::Conversion
+    extend ActiveModel::Naming
+
+    ##
+    # @!attribute :rdf_subject [String] the URI identifying the provider
+    #   @example: "http://blah.com/contributor/123"
+    #
+    # @!attribute :id [String] the stub id
+    #   @example: "123"
+    #
+    # @!attribute :name [String] the human-redable name of the provider
+    #
+    # @!attribute :agent [DPLA::MAP::Agent] an ActiveTriples representation of
+    # the provider, read from Marmotta.
+    attr_accessor :rdf_subject, :name
+    attr_reader :agent, :id
+
+    ##
+    # Initializes a Provider object.
+    #
+    # @param attributes [Hash]
+    # If the params Hash contains a valid value for :rdf_subject, the model can
+    # extrapolate all other attributes.
+    #
+    # @example
+    #   Krikri::Provider.new({ rdf_subject: 'http:://blah.com/contributor/123',
+    #                          name: 'Moomin Valley Historical Society' })
+    #
+    # @raise [NoMethodError] if the params Hash includes a key that does not
+    # match listed attr_accessors
+    #
+    # @return [<Krikri::Provider>]
+    def initialize(attributes = {})
+      attributes.each do |name, value|
+        send("#{name}=", value)
+      end
+    end
 
     ##
     # Gives a list of all providers, ignoring those with no URI (bnodes).
+    #
+    # Providers will be initialized with both an :rdf_subject and a :name,
+    # if both exist in the Solr index.
     #
     # @return [Array<Krikri::Provider>]
     def self.all
       query_params = { :rows => 0,
                        :id => '*:*',
-                       'facet.field' => 'provider_id' }
+                       :facet => true,
+                       'facet.pivot' => 'provider_id,provider_name' }
       response = Krikri::SolrResponseBuilder.new(query_params).response
-      response.facets.first.items.map do |item|
-        provider = new(item.value)
-        provider.node? ? nil : provider
+
+      response.facet_pivot['provider_id,provider_name'].map do |facet|
+        rdf_subject = facet['value']
+        name = facet['pivot'].present? ? facet['pivot'].first['value'] : nil
+        provider = new({ :rdf_subject => rdf_subject, :name => name })
+        provider.valid_rdf_subject? ? provider : nil
       end.compact
     end
 
     ##
-    # @param id [#to_s] the identifier (local name or URI) of the provider
-    #   to find
+    # Finds a provider in Solr that matches the given ID, ignoring bnodes.
+    #
+    # @param [String] :id or :rdf_subject
     #
     # @return [Krikri::Provider]
-    # @todo Use {ActiveTriples}/{RDF::Repository} to populate the object
     def self.find(id)
-      return nil if id.nil?
-      provider = new(id)
-      provider.reload
-      return nil if provider.empty?
-      provider
+      rdf_subject = id.start_with?(base_uri) ? id : base_uri + id
+      query_params = { :rows => 1,
+                       :q => rdf_subject,
+                       :qf => 'provider_id',
+                       :fl => 'provider_id provider_name' }
+      response = Krikri::SolrResponseBuilder.new(query_params).response
+      return nil unless response.docs.count > 0
+      new({ :rdf_subject => rdf_subject,
+            :name => response.docs.first['provider_name'].first })
     end
 
     ##
-    # Loads the provider's data from the repository.
-    #
-    # @return [Krikri::Provider] self
-    def reload
-      query = Krikri::Repository.query_client.select.distinct.where([self, :p, :o])
-      query.each_solution do |solution|
-        set_value(solution.p, solution.o)
-      end
-
-      self
+    # Get the base of the :rdf_subject for any provider
+    # @return [String] ending in "/"
+    def self.base_uri
+      base_uri = Krikri::Settings.prov.provider_base
+      base_uri.end_with?('/') ? base_uri : base_uri << '/'
     end
 
-    ##
-    # A list of records of type ore:Aggregation associated with this provider
-    #
-    # @return [Array<DPLA::MAP::Aggregation>] the Aggregations with this
-    #   provider
-    def records
-      query = Krikri::Repository.query_client.select
-              .where([:record, RDF::EDM.provider, self],
-                     [:record, RDF.type, RDF::ORE.Aggregation])
-
-      query.execute.map do |solution|
-        DPLA::MAP::Aggregation.new(solution.record)
-      end
-    end
-
-    ##
-    # @return [String] the local name (last uri segment) for the provider
     def id
-      node? ? nil : rdf_subject.to_s.gsub(base_uri.to_s, '')
+      @id ||= local_name
+    end
+
+    def name
+      @name ||= initialize_name
+    end
+
+    def agent
+      @agent ||= initialize_agent
     end
 
     ##
-    # @return [String] the name of the provider
-    def provider_name
-      label.first || providedLabel.first || id
+    # Tests for providers that have valid a :rdf_subject (not a bnode).
+    # A valid :rdf_subject does not necessarily match and :rdf_subject in the
+    # Solr index, but it has the correct URI format.
+    def valid_rdf_subject?
+      return false unless rdf_subject.present?
+      rdf_subject.start_with?(self.class.base_uri) ? true : false
+    end
+
+    ##
+    # Required ActiveModel method.
+    def persisted?
+      false
+    end
+
+    private
+
+    ##
+    # Gives the last path fragment for :rdf_subject in HTML escaped form,
+    # ignoring :rdf_subjects, ignoring bnodes.
+    #
+    # @example
+    #   Given: rdf_subject == 'http://my_domain/blah/0123'
+    #   local_name == '0123'
+    #
+    # @return [String]
+    def local_name
+      return nil unless valid_rdf_subject?
+      rdf_subject.split('/').last.html_safe
+    end
+
+    ##
+    # Gives the :provider_name associated with a provider's :rdf_subject
+    # (ie. :provider_id) in Solr, ignoring bnodes.
+    #
+    # @return [String]
+    def initialize_name
+      return nil unless valid_rdf_subject?
+      query_params = { :rows => 1,
+                       :q => rdf_subject,
+                       :qf => 'provider_id',
+                       :fl => 'provider_name' }
+      response = Krikri::SolrResponseBuilder.new(query_params).response
+      return nil unless response.docs.count > 0
+      response.docs.first['provider_name'].first
+    end
+
+    ##
+    # Creates DPLA::MAP::Agent object from the :rdf_subject and :name, ignoring
+    # bnodes.
+    #
+    # @return [DPLA::MAP::Agent]
+    def initialize_agent
+      return nil unless valid_rdf_subject?
+      DPLA::MAP::Agent.new(rdf_subject).tap { |agent| agent.label = name }
     end
   end
 end

--- a/app/models/krikri/qa_report.rb
+++ b/app/models/krikri/qa_report.rb
@@ -136,7 +136,7 @@ module Krikri
     # @todo figure out a better relations pattern between {ActiveRecord} objects
     #   and {ActiveTriples}
     def build_provider
-      Krikri::Provider.find(provider)
+      Krikri::Provider.new(:rdf_subject => provider).agent
     end
 
     private

--- a/app/models/krikri/validation_report.rb
+++ b/app/models/krikri/validation_report.rb
@@ -63,9 +63,11 @@ module Krikri
 
     private
 
+    ##
+    # Get the full URI identifier for the provider
     def provider_uri
       return unless provider_id.present?
-      Krikri::Provider.new(provider_id).rdf_subject
+      Krikri::Provider.base_uri + provider_id
     end
   end
 end

--- a/app/views/krikri/providers/index.html.erb
+++ b/app/views/krikri/providers/index.html.erb
@@ -9,7 +9,7 @@
   <ul>
   <% @providers.each do |provider| %>
     <li>
-      <%= link_to provider_name(provider), { controller: 'providers',
+      <%= link_to provider.name, { controller: 'providers',
         action: 'show', id: provider.id } %>
     </li>
   <% end %>

--- a/lib/tasks/krikri.rake
+++ b/lib/tasks/krikri.rake
@@ -27,12 +27,13 @@ namespace :krikri do
       original_record = build(:oai_dc_record)
       original_record.save unless original_record.exists?
 
-      provider = Krikri::Provider.new('123')
-      provider.label = 'Moomin valley Historical Society'
+      provider_uri = Krikri::Provider.base_uri + '123'
+      provider = Krikri::Provider.new(:rdf_subject => provider_uri).agent
+      provider.label = 'Moomin Valley Historical Society'
 
-      agg = build(:aggregation)
-      agg.originalRecord = original_record.rdf_source
-      agg.provider = provider
+      agg = build(:aggregation,
+                  :originalRecord => original_record.rdf_source,
+                  :provider => provider)
 
       agg.mint_id!('krikri_sample')
 
@@ -47,11 +48,15 @@ namespace :krikri do
       original_record = build(:json_record)
       original_record.save unless original_record.exists?
 
+      provider_uri = Krikri::Provider.base_uri + '456'
+      provider = Krikri::Provider.new(:rdf_subject => provider_uri).agent
+      provider.label = 'Snork Maiden Archives'
+
       agg = build(:aggregation,
                   :originalRecord => ActiveTriples::Resource
                                       .new(original_record.rdf_subject),
-                  :sourceResource => build(:source_resource, title: nil)
-            )
+                  :sourceResource => build(:source_resource, title: nil),
+                  :provider => provider)
 
       agg.mint_id!('krikri_sample_invalid')
 

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -5,10 +5,11 @@ describe Krikri::ProvidersController, :type => :controller do
   routes { Krikri::Engine.routes }
 
   describe 'GET #show' do
+    include_context 'with indexed item'
     login_user
 
     it 'sets provider variable' do
-      expect { get :show, id: 'moomin' }
+      expect { get :show, id: provider.id }
         .to change { assigns[:current_provider] }
              .to an_instance_of(Krikri::Provider)
     end

--- a/spec/factories/krikri_provider.rb
+++ b/spec/factories/krikri_provider.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :krikri_provider, class: Krikri::Provider do
-    label 'Moomin Valley Historical Society'
-    rdf_subject 'MoominValleyHistoricalSociety'
-
-    initialize_with { new(rdf_subject) }
+    name 'Moomin Valley Historical Society'
+    rdf_subject "#{Krikri::Provider.base_uri}123"
   end
 end

--- a/spec/helpers/krikri/application_helper_spec.rb
+++ b/spec/helpers/krikri/application_helper_spec.rb
@@ -28,13 +28,13 @@ describe Krikri::ApplicationHelper, :type => :helper do
     let(:name) { double('name') }
 
     it 'finds provider for id if string is given' do
-      allow(provider).to receive(:provider_name).and_return(name)
+      allow(provider).to receive(:name).and_return(name)
       expect(Krikri::Provider).to receive(:find).and_return(provider)
       expect(helper.provider_name('provider')).to eq name
     end
 
     it 'gives provider name' do
-      allow(provider).to receive(:provider_name).and_return(name)
+      allow(provider).to receive(:name).and_return(name)
       expect(helper.provider_name(provider)).to eq name
     end
 

--- a/spec/lib/krikri/search_index_spec.rb
+++ b/spec/lib/krikri/search_index_spec.rb
@@ -117,6 +117,7 @@ describe Krikri::QASearchIndex do
         subject.commit
         aggregation.set_subject!('http://api.dp.la/item/123')
         aggregation.provider << build(:krikri_provider, rdf_subject: 'snork')
+          .agent
         subject.add aggregation.to_jsonld['@graph'][0]
         subject.commit
       end

--- a/spec/models/qa_report_spec.rb
+++ b/spec/models/qa_report_spec.rb
@@ -4,9 +4,11 @@ describe Krikri::QAReport do
 
   subject { described_class.new(:provider => provider.id.to_s) }
 
+  let(:provider_base) { Krikri::Provider.base_uri }
+
   let(:provider) do
     agent = build(:agent)
-    agent.set_subject! 'http://example.org/moomin'
+    agent.set_subject!(provider_base + 'moomin')
     agent
   end
 
@@ -50,8 +52,8 @@ describe Krikri::QAReport do
   end
 
   describe '#build_provider' do
-    it 'gives a provider' do
-      expect(subject.build_provider).to be_a Krikri::Provider
+    it 'gives a DPLA::MAP::Agent' do
+      expect(subject.build_provider).to be_a DPLA::MAP::Agent
     end
 
     it 'gives provider with correct uri' do

--- a/spec/models/validation_report_spec.rb
+++ b/spec/models/validation_report_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Krikri::ValidationReport do
-  describe `#all` do
+  describe '#all' do
     it 'returns facet for each required field' do
       count = described_class::REQUIRED_FIELDS.count
       facet_field_const = Blacklight::SolrResponse::Facets::FacetField
@@ -23,7 +23,7 @@ describe Krikri::ValidationReport do
     end
   end
 
-  describe `#find` do
+  describe '#find' do
     it 'gives a blacklight solr response' do
       expect(subject.find('sourceResource_title'))
         .to be_a Blacklight::SolrResponse

--- a/spec/support/shared_contexts/indexed_item.rb
+++ b/spec/support/shared_contexts/indexed_item.rb
@@ -15,17 +15,15 @@ shared_context 'with indexed item' do
   let(:records) { [agg] }
 
   let(:agg) do
-    a = build(:aggregation)
-    a.provider = provider
-    a.set_subject! 'moomin'
-    a
+    provider_agent = provider.agent
+    provider_agent.label = provider.name
+
+    aggregation = build(:aggregation, provider: provider_agent)
+    aggregation.set_subject! 'moomin'
+    aggregation
   end
 
-  let(:provider) do
-    build(:krikri_provider,
-          rdf_subject: 'moomin_valley',
-          label: 'moomin valley')
-  end
+  let(:provider) { build(:krikri_provider) }
 end
 
 shared_context 'with missing values' do
@@ -33,14 +31,22 @@ shared_context 'with missing values' do
     let(:records) { [agg, empty, empty_new_provider] }
 
     let(:empty) do
-      aggregation = build(:aggregation, provider: provider, sourceResource: nil)
+      provider_agent = provider.agent
+      provider_agent.label = provider.name
+
+      aggregation = build(:aggregation, 
+                          provider: provider_agent, 
+                          sourceResource: nil)
       aggregation.set_subject! 'empty'
       aggregation
     end
 
     let(:empty_new_provider) do
+      provider_agent = build(:krikri_provider, 
+                             rdf_subject: 'http://example.com/fake').agent
+
       aggregation = build(:aggregation,
-                          provider: RDF::URI('http://example.com/fake'),
+                          provider: provider_agent,
                           sourceResource: nil)
       aggregation.set_subject! 'empty_new_provider'
       aggregation

--- a/spec/support/shared_examples/active_model_lint.rb
+++ b/spec/support/shared_examples/active_model_lint.rb
@@ -1,0 +1,14 @@
+shared_examples 'ActiveModel' do
+  include ActiveModel::Lint::Tests
+
+  # to_s is to support ruby-1.9
+  ActiveModel::Lint::Tests.public_instance_methods.map{|m| m.to_s}.grep(/^test/).each do |m|
+    example m.gsub('_',' ') do
+      send m
+    end
+  end
+
+  def model
+    subject
+  end
+end

--- a/spec/views/krikri/providers/index.html.erb_spec.rb
+++ b/spec/views/krikri/providers/index.html.erb_spec.rb
@@ -8,10 +8,10 @@ describe 'krikri/providers/index.html.erb', type: :view do
   end
 
   let(:providers) do
-    [build(:krikri_provider, rdf_subject: 123),
+    [build(:krikri_provider, rdf_subject: '123'),
      build(:krikri_provider,
            rdf_subject: 'TooTickyLibrary',
-           label: 'Too-Ticky')]
+           name: 'Too-Ticky')]
   end
 
   it 'renders each provider' do

--- a/spec/views/krikri/providers/show.html.erb_spec.rb
+++ b/spec/views/krikri/providers/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'krikri/providers/show.html.erb', type: :view do
 
   it 'displays provider name' do
     render
-    expect(rendered).to include provider.label.first.to_s
+    expect(rendered).to include provider.name
   end
 
   it 'links to records' do

--- a/spec/views/krikri/reports/index.html.erb_spec.rb
+++ b/spec/views/krikri/reports/index.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'krikri/reports/index.html.erb', type: :view do
 
   it 'displays provider name' do
     render
-    expect(rendered).to include provider.label.first
+    expect(rendered).to include provider.name
   end
 
   it 'renders validation reports' do


### PR DESCRIPTION
This changes the `Krikri::Provider` model so that it populates with data from a small number of calls to Solr, rather than a large number of calls to Marmotta.  It should reduce page load times in the QA interface, especially in views that need to generate a list of all providers.

`Krikri::Provider` is changed from a `DPLA::MAP::Agent` object (which is an `ActiveTriples` object) to an `ActiveModel` object.  `ActiveModel` is much like `ActiveRecord` - it plays nicely with `ActionPack`and includes some model features.  However, `ActiveModel` abstracts away database interactions, allowing us to populate it with data from other sources like Solr.  An `ActiveModel` object is constructed by including and extending certain modules, and by including key methods (ie. `persisted?`).  We might consider using `ActiveModel` elsewhere in the code - for example, `Krikri::ValidationReport` seems a good candidate to be made into an `ActiveModel` object.  For more info on `ActiveModel`, see http://api.rubyonrails.org/classes/ActiveModel/Model.html or http://railscasts.com/episodes/219-active-model  

If you want to interact with with a provider as a `DPLA::MAP::Agent`, you can still do so; `Krikri::Provider` has an instance method, `#agent`, that returns the provider as a `DPLA::MAP::Agent` object.  You can even get said `DPLA::MAP::Agent` object without hitting Solr at all, provided you know the provider's `:rdf_subject` (aka it's full URI identifier).  Most of `Krikri::Provider`'s attributes are lazy-loaded so that time and memory can be expended on things like network calls only when necessary.

Another feature `Krikri::Provider` is that the `#all` and `#find` methods each make only one call to Solr, and then instantiate instances of `Krikri:Provider` with provider's `:rdf_subject` _and_ `:name`.  Before this change, generating each `:name` required its own separate network call, so this should also reduce page load times.

This PR required many changes to the code (especially specs) that use `Krikri::Provider`.  The changes are of three basic types:
1. Creating a `DPLA::MAP::Agent` object if needed
2. Adjusting for new attribute accessors (for example, using `#name` instead of `#label` to get the provider's name
3. Eliminating unnecessary network calls (for example, refraining from using `#find` if you don't really need to search Solr)

Page load time can still be improved with changes to the current model of tracking `@current_provider`s in the user interface, but that is outside the scope of this PR.