### PR TITLE
Add enrichment to create prefLabels from provided

### DIFF
--- a/lib/krikri/enrichments/create_pref_label_from_provided.rb
+++ b/lib/krikri/enrichments/create_pref_label_from_provided.rb
@@ -1,0 +1,58 @@
+module Krikri::Enrichments
+  ##
+  # Given an field that accepts both `providedLabel` and `prefLabel`, copies 
+  # the first `providedLabel` into `prefLabel` unless one is already present.
+  #
+  # Only the first `providedLabel` is copied, avoiding conflicts with SKOS's 
+  # limit of one `skos:prefLabel` per language tag.
+  #
+  # Fields are ignored and returned as-is if:
+  #   - they are not `ActiveTriples::Resource`
+  #   - they do not respond to `#providedLabel`
+  #   - they already have a `prefLabel`
+  #   - there are no `providedLabel`s present
+  # 
+  # @example enriching a resource with a providedLabel
+  #   label_enricher = CreatePrefLabelFromProvided.new
+  #
+  #   resource.providedLabel = 'moomin'
+  #   label_enricher.enrich_value(resource)
+  #   resource.dump :ttl
+  #   # [
+  #   #   a <http://www.europeana.eu/schemas/edm/Agent>;
+  #   #   <http://dp.la/about/map/providedLabel> "moomin";
+  #   #   <http://www.w3.org/2004/02/skos/core#prefLabel> "moomin"
+  #   # ] .
+  #   
+  # @see http://www.w3.org/2012/09/odrl/semantic/draft/doco/skos_prefLabel.html
+  #   for information about skos:prefLabel
+  # @see Audumbla::FieldEnrichment
+  class CreatePrefLabelFromProvided
+    include Audumbla::FieldEnrichment
+
+    ##
+    # @param value [Object] the value to split
+    # @see Audumbla::FieldEnrichment#enrich_value
+    def enrich_value(value)
+      return value unless value.is_a?(ActiveTriples::Resource) &&
+                          value.respond_to?(:providedLabel)
+      add_pref_label(value)
+    end
+
+    private
+    
+    ##
+    # Returns the same value originally given. If a `skos:prefLabel` is not 
+    # present, one is derived from the first `providedLabel` (if any).
+    #
+    # @param [ActiveTriples::Resource] value  the resource to enrich
+    # @return [ActiveTriples::Resource] the original value, after adding a 
+    #   prefLabel
+    def add_pref_label(value)
+      return value if value.providedLabel.empty?
+      return value unless value.get_values(RDF::SKOS.prefLabel).empty?
+      value.set_value(RDF::SKOS.prefLabel, value.providedLabel.first)
+      value
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/create_pref_label_from_provided_spec.rb
+++ b/spec/lib/krikri/enrichments/create_pref_label_from_provided_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::CreatePrefLabelFromProvided do
+  it_behaves_like 'a field enrichment'
+
+  describe '#enrich_value' do
+    let(:resource) { DPLA::MAP::Agent.new }
+
+    it 'skips non-Resource' do
+      date = Date.today
+      expect(subject.enrich_value(date)).to eq date
+    end
+
+    it 'skips values that do not respond to providedLabel' do
+      resource = ActiveTriples::Resource.new
+      expect { subject.enrich_value(resource) }
+        .not_to change { resource.get_values(RDF::SKOS.prefLabel) }.from([])
+    end
+
+    it 'skips values that have no providedLabel' do
+      expect { subject.enrich_value(resource) }
+        .not_to change { resource.label }.from([])
+    end
+
+    it 'skips values that aready have a prefLabel' do
+      resource.providedLabel = 'moomin'
+      resource.label = 'moomintroll'
+      expect { subject.enrich_value(resource) }
+        .not_to change { resource.label }
+                 .from(a_collection_containing_exactly('moomintroll'))
+    end
+
+    it 'copies providedLabel to prefLabel' do
+      resource.label = nil
+      resource.providedLabel = 'moomintroll'
+      subject.enrich_value(resource)
+      expect(resource.label).to contain_exactly 'moomintroll'
+      expect(resource.providedLabel).to contain_exactly 'moomintroll'
+    end
+
+    it 'copies first providedLabel to prefLabel' do
+      resource.label = nil
+      resource.providedLabel << 'moomintroll'
+      resource.providedLabel << 'snorkmaiden'
+      subject.enrich_value(resource)
+
+      expect(resource.label).to contain_exactly 'moomintroll'
+      expect(resource.providedLabel)
+        .to contain_exactly('moomintroll', 'snorkmaiden')
+    end
+  end
+end


### PR DESCRIPTION
For most providers, we want to copy providedLabels into prefLabel prior
to running enrichments which will alter the label. This keeps the
providedLabels as a true representation of the original data.

Fields are ignored and returned as-is if:
   - they are not `ActiveTriples::Resource`
   - they do not respond to `#providedLabel`
   - they already have a `prefLabel`
   - there are no 'providedLabel`s present