### PR TITLE
Add `Activity#to_s` for easier activity display

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -85,6 +85,8 @@ module Krikri
       RDF::URI(Krikri::Settings['marmotta']['ldp']) /
         Krikri::Settings['prov']['activity'] / id.to_s
     end
+    alias_method :to_term, :rdf_subject
+    
 
     ##
     # @return [String] a string reprerestation of the activity

--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -79,9 +79,17 @@ module Krikri
       JSON.parse(opts, symbolize_names: true)
     end
 
+    ##
+    # @return [RDF::URI] the uri for this activity
     def rdf_subject
       RDF::URI(Krikri::Settings['marmotta']['ldp']) /
         Krikri::Settings['prov']['activity'] / id.to_s
+    end
+
+    ##
+    # @return [String] a string reprerestation of the activity
+    def to_s
+      inspect.to_s
     end
 
     ##
@@ -109,6 +117,5 @@ module Krikri
     def entities
       agent_instance.entity_behavior.entities(self)
     end
-
   end
 end

--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -16,11 +16,11 @@ module Krikri
     #   give solutions containing the URIs for the resources in `#record`.
     def find_by_activity(activity_uri)
       raise ArgumentError, 'activity_uri must be an RDF::URI' unless
-        activity_uri.respond_to? :to_uri
+        activity_uri.respond_to? :to_term
       SPARQL_CLIENT.select(:record)
         .where([:record,
                 [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy],
-                activity_uri])
+                activity_uri.to_term])
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -32,6 +32,12 @@ describe Krikri::Activity, type: :model do
     end
   end
 
+  describe '#to_term' do
+    it 'gives the subject' do
+      expect(subject.to_term).to eq subject.rdf_subject
+    end
+  end
+
   describe '#to_s' do
     it 'outputs the object properties' do
       expect(subject.to_s).to eq subject.inspect.to_s

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -32,6 +32,12 @@ describe Krikri::Activity, type: :model do
     end
   end
 
+  describe '#to_s' do
+    it 'outputs the object properties' do
+      expect(subject.to_s).to eq subject.inspect.to_s
+    end
+  end
+
   describe '#start_time' do
     before do
       subject.set_start_time
@@ -148,7 +154,6 @@ describe Krikri::Activity, type: :model do
     end
   end
 
-
   describe '#entity_uris' do
     include_context 'provenance queries'
     include_context 'entities query'
@@ -163,7 +168,5 @@ describe Krikri::Activity, type: :model do
       # 'result uri' is what the mocked query solution's record should contain.
       expect(subject.entity_uris.first).to match 'result uri'
     end
-
   end
-
 end


### PR DESCRIPTION
Punts `#to_s` to `#inspect` to simplify activity discovery, e.g.:

      puts Krikri::Activities.all
      # the output is now equivalent to:
      # `puts Krikri::Activities.all.map(&:inspect)`

This was bothering me, now it shouldn't anymore.