### PR TITLE
check for existence of provider_name

### DIFF
--- a/app/models/krikri/provider.rb
+++ b/app/models/krikri/provider.rb
@@ -154,10 +154,11 @@ module Krikri
       query_params = { :rows => 1,
                        :q => rdf_subject,
                        :qf => 'provider_id',
-                       :fl => 'provider_name' }
+                       :fl => 'provider_name provider_id' }
       response = Krikri::SolrResponseBuilder.new(query_params).response
       return nil unless response.docs.count > 0
-      response.docs.first['provider_name'].first
+      response.docs.first['provider_name'].respond_to?(:first) ?
+        response.docs.first['provider_name'].first : rdf_subject
     end
 
     ##

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -122,14 +122,24 @@ describe Krikri::Provider do
   end
 
   describe '#name' do
-    include_context 'indexed in Solr'
 
-    it 'returns an :name corresponding to the indexed :rdf_subject' do
-      expect(described_class.new({ rdf_subject: rdf_subject }).name).to eq name
+    context 'with item' do
+      include_context 'indexed in Solr'
+
+      it 'returns an :name corresponding to the indexed :rdf_subject' do
+        expect(described_class.new({ rdf_subject: rdf_subject }).name).to eq name
+      end
+
+      it 'returns nil without valid :rdf_subject' do
+        expect(described_class.new.name).to eq nil
+      end
     end
 
-    it 'returns nil without valid :rdf_subject' do
-      expect(described_class.new.name).to eq nil
+    it 'returns :rdf_subject without indexed :provider_name' do
+      allow_any_instance_of(Blacklight::SolrResponse).to receive(:docs)
+        .and_return([{ 'provider_id' => [rdf_subject] }])
+      expect(described_class.new({ rdf_subject: rdf_subject }).name)
+        .to eq rdf_subject
     end
   end
 


### PR DESCRIPTION
This fixes an error that was causing the QA interface to crash if it tried to call `Krikri::Provider.name` on an indexed provider that was missing a value for `provider_name`.  