### PR TITLE
field value report with csv download

### DIFF
--- a/app/controllers/krikri/field_value_reports_controller.rb
+++ b/app/controllers/krikri/field_value_reports_controller.rb
@@ -1,0 +1,21 @@
+module Krikri
+  ##
+  # Handles HTTP requests for Field Value Reports
+  #
+  # @see Krikri::FieldValueReport
+  class FieldValueReportsController < ApplicationController
+    ##
+    # Renders the show view for the field value report, given by a compound key.
+    # The compound key is comprised by the field value report's field
+    # (represented by the route's id param) and the provider's id.
+
+    def show
+      @field_value_report = Krikri::FieldValueReport.find(params[:id], 
+                                                          params[:provider_id])
+
+      respond_to do |format|
+        format.csv
+      end
+    end
+  end
+end

--- a/app/controllers/krikri/reports_controller.rb
+++ b/app/controllers/krikri/reports_controller.rb
@@ -15,6 +15,7 @@ module Krikri
       @validation_reports = report.all
 
       if @current_provider
+        @provider = Krikri::Provider.find(@current_provider)
         @qa_reports = Array(Krikri::QAReport.find_by(provider: @current_provider))
       else
         @qa_reports = Krikri::QAReport.all

--- a/app/models/krikri/active_model_base.rb
+++ b/app/models/krikri/active_model_base.rb
@@ -1,0 +1,36 @@
+module Krikri
+  ##
+  # ActiveModelBase is a Superclass for ActiveModel objects.
+  class ActiveModelBase
+    include ActiveModel::Conversion
+    include ActiveModel::Dirty
+    include ActiveModel::Validations
+    extend ActiveModel::Naming
+
+    ##
+    # Initializes a Krikri::ActiveModelBase object.
+    #
+    # @param attributes [Hash]
+    #
+    # @raise [NoMethodError] if the params Hash includes a key that does not
+    # match any of the Class's writeable attributes.
+    #
+    # @example
+    #   Given: MyActiveModel is a subclass of ActiveModelBase
+    #   Given: :name is a writeable attribute of MyActiveModel
+    #   MyActiveModel.new({ :name => 'value' })
+    #
+    # @return [Krikri::ActiveModelBase]
+    def initialize(attributes = {})
+      attributes.each do |name, value|
+        send("#{name}=", value)
+      end
+    end
+
+    ##
+    # Required ActiveModel method.
+    def persisted?
+      false
+    end
+  end
+end

--- a/app/models/krikri/field_value_report.rb
+++ b/app/models/krikri/field_value_report.rb
@@ -1,0 +1,124 @@
+module Krikri
+  ##
+  # FieldValueReport gives all unique values for a given field within a
+  # document.  It represents data that has been indexed into Solr.
+  #
+  # This is a read-only object.  FieldValueReports are not persisted.
+  class FieldValueReport < Krikri::ActiveModelBase
+    ##
+    # @!attribute :field [String] the name of the field.
+    #   @example: 'sourceResource_title'
+    #
+    # @!attribute :provider [Krikri::Provider]
+    attr_accessor :field, :provider
+
+    ##
+    # @param field [String] the name of the field being reported on
+    #   @example: 'sourceResource_title'
+    # @param provider_id [String] the id of the provider being reported on
+    # These two params act as a compound key.
+    #
+    # @return [Krikri::FieldValueReport]
+    def self.find(field, provider_id)
+      return nil unless fields.include? field.to_sym
+      provider = Krikri::Provider.find(provider_id)
+      return nil unless provider.present?
+      new({ :field => field,
+            :provider => provider })
+    end
+
+    ##
+    # All of the fields for which a report can be created.
+    def self.fields
+      [:dataProvider_providedLabel,
+       :sourceResource_alternative_providedLabel,
+       :sourceResource_collection_title,
+       :sourceResource_contributor_providedLabel,
+       :sourceResource_creator_providedLabel,
+       :sourceResource_date_providedLabel,
+       :sourceResource_description,
+       :sourceResource_format,
+       :sourceResource_genre_providedLabel,
+       :sourceResource_language_providedLabel,
+       :sourceResource_publisher_providedLabel,
+       :sourceResource_rights,
+       :sourceResource_rightsHolder_providedLabel,
+       :sourceResource_spatial_providedLabel,
+       :sourceResource_subject_providedLabel,
+       :sourceResource_temporal,
+       :sourceResource_title,
+       :sourceResource_type_name]
+    end
+
+    ##
+    # The headers for the report table, and the values to be returned from a
+    # Solr query.
+    def headers
+      [:id, :isShownAt_id, field.to_sym]
+    end
+
+    ##
+    # @param opts [Hash] optional parameters for the solr request
+    #   @example: enumerate_rows(batch_size: 1000)
+    # 
+    # @return Enumerator[<Array>] an enumerator over the rows
+    def enumerate_rows(opts = {})
+      Enumerator.new do |yielder|
+        loop do
+          opts = query_opts(opts)
+          response = Krikri::SolrResponseBuilder.new(opts).response
+          break if response.docs.empty?
+
+          parse_solr_response(response).each do |row|
+            yielder <<  headers.map { |header| row[header] }
+          end
+
+          opts[:start] += opts[:batch_size]
+          break if opts[:start] >= response.total
+        end
+      end
+    end
+
+    private
+
+    ##
+    # @param opts [Hash] additional options for the query params
+    # @return [Hash] parameters for a Solr request
+    def query_opts(opts = {})
+      { :fq => "provider_id:\"#{provider.rdf_subject}\"",
+        :fl => headers,
+        :rows => opts.fetch(:batch_size, 1000).to_i,
+        :start => opts.fetch(:start, 0).to_i }
+    end
+
+    ##
+    # @param [Blacklight::SolrResponse] response
+    # @return [Array<Hash>]
+    #
+    # The return Hashes should include keys for all headers defined in the
+    # :headers method
+    def parse_solr_response(response)
+      rows = []
+
+      response.docs.each do |doc|
+        id = doc['id'].split('/').last
+        isShownAt_id = doc['isShownAt_id'].respond_to?(:first) ?
+          doc['isShownAt_id'].first : '__MISSING__'
+
+        if doc[field].present?
+          doc[field].each do |value|
+            rows << { :id => id,
+                      field.to_sym => value,
+                      :isShownAt_id => isShownAt_id }
+          end
+        else
+          rows << { :id => id,
+                    field.to_sym => '__MISSING__',
+                    :isShownAt_id => isShownAt_id }
+        end
+      end
+
+      rows
+    end
+  end
+end

--- a/app/views/krikri/field_value_reports/show.csv.erb
+++ b/app/views/krikri/field_value_reports/show.csv.erb
@@ -1,0 +1,1 @@
+<%= @field_value_report.headers.to_csv %><% @field_value_report.enumerate_rows.each do |row| %><%= row.to_csv %><% end %>

--- a/app/views/krikri/reports/_field_value_report_list.html.erb
+++ b/app/views/krikri/reports/_field_value_report_list.html.erb
@@ -1,0 +1,14 @@
+<h3>Field Value Reports</h3>
+<% if @provider.present? %>
+  <p>Available as CSV downloads</p>
+  <ul>
+    <% @provider.field_value_reports.each do |report| %>
+      <li>
+        <%= link_to report.field, 
+                    provider_field_value_report_path(id: report.field,
+                                                     provider_id: @provider.id,
+                                                     format: :csv) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/krikri/reports/index.html.erb
+++ b/app/views/krikri/reports/index.html.erb
@@ -6,6 +6,6 @@
   <h1>Reports</h1>
   <h2><%= provider_name(@current_provider) %></h2>
   <%= render "validation_report_list" %>
-
+  <%= render "field_value_report_list" %>
   <%= render "qa_report_list" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Krikri::Engine.routes.draw do
     resources :harvest_sources, shallow: true
   end
 
-  resources :providers, only: [:index, :show]
+  resources :providers, only: [:index, :show] do
+    resources :field_value_reports, only: [:show]
+  end
 
   mount Resque::Server.new, at: '/resque'
 end

--- a/spec/controllers/field_value_reports_controller_spec.rb
+++ b/spec/controllers/field_value_reports_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Krikri::FieldValueReportsController, :type => :controller do
+
+  routes { Krikri::Engine.routes }
+
+  describe 'GET #show' do
+    login_user
+
+    it 'sets field_value_report variable' do
+      field_value_report = [instance_double(Krikri::FieldValueReport)]
+      allow(Krikri::FieldValueReport).to receive(:find)
+        .and_return(field_value_report)
+      expect { get :show, id: 'sourceResource_title', provider_id: '123',
+               format: 'csv' }
+        .to change { assigns[:field_value_report] }.to field_value_report
+    end
+
+    it 'does not render :show view in html' do
+      expect do
+        get :show, id: 'sourceResource_title', provider_id: '123'
+      end.to raise_error(ActionController::UnknownFormat)
+    end
+
+    context 'csv' do
+      include_context 'with indexed item'
+
+      it 'returns a csv document' do
+        get :show, id: 'sourceResource_title', provider_id: '123', format: 'csv'
+        expect(response.content_type).to eq 'text/csv'
+      end
+    end
+  end
+end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -43,6 +43,14 @@ describe Krikri::ReportsController, :type => :controller do
         .to change { assigns(:validation_reports) }.to(validation_reports)
     end
 
+    it 'sets @provider' do
+      provider = double('provider')
+      allow(Krikri::Provider).to receive(:find).with(provider_id)
+        .and_return(provider)
+      expect { get :index, provider: provider_id }
+        .to change { assigns(:provider) }.to(provider)
+    end
+
     # @todo: this specifies implementation, due to limitations of the
     #   Krikri::ValidationReport interface (see above). Refactor me!
     it 'sets the provider' do

--- a/spec/models/active_model_template_spec.rb
+++ b/spec/models/active_model_template_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Krikri::ActiveModelBase do
+  it_behaves_like 'ActiveModel'
+end

--- a/spec/models/field_value_report_spec.rb
+++ b/spec/models/field_value_report_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe Krikri::FieldValueReport do
+  it_behaves_like 'ActiveModel'
+
+  let(:field) { 'sourceResource_title' }
+  let(:provider_base) { Krikri::Settings.prov.provider_base }
+  let(:provider_id) { '123' }
+  let(:report) { described_class.find(field, provider_id) }
+
+  let(:agg) do
+    p = DPLA::MAP::Agent.new(RDF::URI(provider_base) / provider_id)
+    build(:aggregation, :provider => p)
+  end
+
+  shared_context 'item indexed in Solr' do
+    before do
+      clear_search_index
+      indexer = Krikri::QASearchIndex.new
+      indexer.add agg.to_jsonld['@graph'].first
+      indexer.commit
+    end
+
+    after do
+      clear_search_index
+    end
+  end
+
+  describe '#find' do
+    include_context 'item indexed in Solr'
+
+    it 'returns nil if field is invalid' do
+      expect(described_class.find('invalid', provider_id)).to eq nil
+    end
+
+    it 'returns nil if provider not found' do
+      expect(described_class.find(field, 'invalid')).to eq nil
+    end
+
+    it 'returns a FieldValueReport object' do
+      expect(report).to be_a Krikri::FieldValueReport
+    end
+
+    it 'assigns instance variables' do
+      expect(report.field).to eq field
+    end
+  end
+
+  describe '#fields' do
+    it 'returns an Array' do
+      expect(described_class.fields).to be_a Array
+    end
+  end
+
+  describe '#enumerate_rows' do
+    include_context 'item indexed in Solr'
+
+    it 'returns an enumerator' do
+      expect(report.enumerate_rows).to be_a Enumerator
+    end
+
+    it 'contains arrays' do
+      expect(report.enumerate_rows.first).to be_a Array
+    end
+
+    it 'returns correct values' do
+      expect(report.enumerate_rows.first).to include('Stonewall Inn [2]')
+    end
+
+    it 'returns "__MISSING__" for field without value' do
+      r = described_class.find('sourceResource_alternative_providedLabel',
+                               provider_id)
+      expect(r.enumerate_rows.first).to include('__MISSING__')
+    end
+
+    context 'with opts' do
+      it 'sets Solr :rows from :batch_size' do
+        enumerate_rows_opts = { batch_size: 50 }
+        expected_query_opts = { rows: 50 }
+        expect(report.instance_eval{ query_opts(enumerate_rows_opts) })
+          .to include expected_query_opts
+      end
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -127,7 +127,8 @@ describe Krikri::Provider do
       include_context 'indexed in Solr'
 
       it 'returns an :name corresponding to the indexed :rdf_subject' do
-        expect(described_class.new({ rdf_subject: rdf_subject }).name).to eq name
+        expect(described_class.new({ rdf_subject: rdf_subject }).name)
+          .to eq name
       end
 
       it 'returns nil without valid :rdf_subject' do
@@ -163,6 +164,31 @@ describe Krikri::Provider do
 
     it 'returns nil without valid :rdf_subject' do
       expect(described_class.new.agent).to eq nil
+    end
+  end
+
+  describe '#field_value_reports' do
+
+    before(:each) do
+      allow(Krikri::FieldValueReport).to receive(:fields).and_return(['abc'])
+    end
+
+    it 'returns an Array' do
+      expect(described_class.new.field_value_reports).to be_a Array
+    end
+
+    it 'returns FieldValueReports' do
+      expect(described_class.new.field_value_reports.first)
+        .to be_a Krikri::FieldValueReport
+    end
+
+    it 'assigns provider to FieldValueReports' do
+      provider = described_class.new({ rdf_subject: rdf_subject })
+      expect(provider.field_value_reports.first.provider).to eq provider
+    end
+
+    it 'assigns field name to FieldValueReports' do
+      expect(described_class.new.field_value_reports.first.field).to eq 'abc'
     end
   end
 

--- a/spec/views/krikri/reports/index.html.erb_spec.rb
+++ b/spec/views/krikri/reports/index.html.erb_spec.rb
@@ -19,6 +19,11 @@ describe 'krikri/reports/index.html.erb', type: :view do
     expect(rendered).to include 'Validation Reports'
   end
 
+  it 'renders field value reports' do
+    render
+    expect(rendered).to include 'Field Value Reports'
+  end
+
   it 'renders qa reports' do
     render
     expect(rendered).to include 'QA Reports'


### PR DESCRIPTION
This introduces field value reports based on data that has been indexed into Solr.  The field value reports show all values for a given field in documents with a given provider.  It addresses the following tickets:
https://www.pivotaltracker.com/n/projects/1172184/stories/79608350
https://www.pivotaltracker.com/n/projects/1172184/stories/79330180
https://www.pivotaltracker.com/n/projects/1172184/stories/85081820

__CSV downloads__
This only offers the reports as CSV downloads - there is no web interface for the reports. Each row of the CSV table has three columns: the reporting field, the document `id`, and the document's `isShownAt_id` link.

If a document has a missing value for the reporting field, it will show up in the CSV table with `__MISSING__` as the field value.

If there are no indexed documents for the given provider, a CSV table will be generated with only one row, containing the headers.

__ActiveModel__
In this iteration of the code, `ActiveModelBase` is a superclass.  `FieldValueReport` and `Provider` have both been made subclasses of `ActiveModelBase`.  We may decide to change `ActiveModel` to a module, depending on the outcome of our conversation here: https://gist.github.com/AudreyAltman/002b75e291fc5c7f4ffe  This change can be made in a separate PR so that @guegueng can have access to these reports ASAP.

__Persistence__
In this iteration, field value reports are not persisted, but we may decide to persist them in the future if there are performance issues.

__Relationship between `FieldValueReport` and `Provider`__
The field value report route is nested under the provider route.  This model could be extended to all other reports and to records so we can do away with the `current_provider` strategy.

`FieldValueReports` and `Provider` have a relationship that approximates a `belongs_to` - `has_many` relationship, considering that `ActiveModel` does not support these relationships in the way that `ActiveRecord` does.  `FieldValueReport` has a `provider` attribute, and `Provider` has a (lazy-loading) `field_value_reports` attribute. 

I considered using the `activemodel-associations` gem to manage the relationship between `FieldValueReport` and `Provider`, but it turns out that this gem only works if you are associating an `ActiveModel` object with an `ActiveRecord` object, so it is not appropriate here.

__QaReport code__
I did not delete any of the QaReport code that @no-reply wrote b/c I wasn't sure if we would want to return to it any any time.  This code generates QA reports (including field value reports) from data that has been stored in Marmotta.