### PR TITLE
Display only the `@graph` in JSON-LD displays

### DIFF
--- a/lib/krikri/search_results_helper_behavior.rb
+++ b/lib/krikri/search_results_helper_behavior.rb
@@ -25,7 +25,7 @@ module Krikri
     def render_enriched_record(document)
       agg = document.aggregation
       return error_msg('Aggregation not found.') unless agg.present?
-      JSON.pretty_generate(agg.to_jsonld)
+      JSON.pretty_generate(agg.to_jsonld['@graph'])
     end
 
     # Render original record for view

--- a/spec/helpers/krikri/records_helper_spec.rb
+++ b/spec/helpers/krikri/records_helper_spec.rb
@@ -30,6 +30,11 @@ describe Krikri::RecordsHelper, :type => :helper do
         result = helper.render_enriched_record(document)
         expect { JSON.parse(result) }.not_to raise_error
       end
+
+      it 'does not include context' do
+        expect(helper.render_enriched_record(document))
+          .not_to include '@context'
+      end
     end
 
     context 'without existing aggregation' do


### PR DESCRIPTION
Aggregations previously displayed with full context. This displays them with only the actual records.