### PR TITLE
Add prefLabels to languages

### DIFF
--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -110,8 +110,11 @@ module Krikri::Enrichments
       match = match_iso(label.to_s)
       match = match_label(label.to_s) if match.node?
 
-      node.exactMatch = match unless match.node?
+      # if match is still a node, we didn't find anything
+      return node if match.node?
 
+      node.exactMatch = match 
+      node.prefLabel = RDF::ISO_639_3[match.rdf_subject.qname[1]].label.last
       node
     end
 

--- a/spec/lib/krikri/enrichments/language_to_lexvo_spec.rb
+++ b/spec/lib/krikri/enrichments/language_to_lexvo_spec.rb
@@ -35,6 +35,11 @@ describe Krikri::Enrichments::LanguageToLexvo do
       expect(subject.enrich_value('finnish')).to be_node
     end
 
+    it 'adds a prefLabel' do
+      expect(subject.enrich_value('finnish').prefLabel)
+        .to contain_exactly 'Finnish'
+    end
+
     context 'and no match' do
       it 'gives a language' do
         expect(subject.enrich_value('INVALID'))


### PR DESCRIPTION
We prefer the last rdf:Label from [RDF::ISO_639_3](https://raw.githubusercontent.com/dpla/dpla_map/map-4.0/lib/rdf/iso_639_3.rb). I.e. "French" rather than "French language" and "Creole, French" rather than "French Creole".