### PR TITLE
Pin rails_config to version 0.4.0

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.1.6"
-  s.add_dependency "rails_config"
+  s.add_dependency "rails_config", "~>0.4.0"
   s.add_dependency "audumbla", '~> 0.1'
   s.add_dependency "dpla-map", "4.0.0.0.pre.10"
   s.add_dependency "rest-client"


### PR DESCRIPTION
Pin rails_config to version 0.4.0 to prevent the error
"NameError: uninitialized constant Settings."

https://rubygems.org/gems/rails_config/versions/0.99.0 says "Please
install the Config gem instead."