### PR TITLE
Corrects ending punctuation enrichment

### DIFF
--- a/lib/krikri/enrichments/strip_ending_punctuation.rb
+++ b/lib/krikri/enrichments/strip_ending_punctuation.rb
@@ -14,7 +14,7 @@ module Krikri::Enrichments
     def enrich_value(value)
       return value unless value.is_a? String
       value.gsub!(/[^\p{Alnum}\'\"\)\]\}]*$/, '') unless
-        value.match /\s*[a-z]{1,2}\.$/i
+        value.match /\s+[a-z]{1,2}\.$/i
       value
     end
   end

--- a/spec/lib/krikri/enrichments/strip_ending_punctuation_spec.rb
+++ b/spec/lib/krikri/enrichments/strip_ending_punctuation_spec.rb
@@ -19,6 +19,14 @@ describe Krikri::Enrichments::StripEndingPunctuation do
               :start => "66 cm.",
               :end => "66 cm."
             },
+            { :string => 'removes period from longer words',
+              :start => "Regents Examinations.",
+              :end => "Regents Examinations"
+            },
+            { :string => 'removes period from longer words with parens',
+              :start => "Budget - New York (State).",
+              :end => "Budget - New York (State)"
+            },
             { :string => 'leaves other fields unaltered',
               :start => "moominpapa;:;:; moominmama",
               :end => "moominpapa;:;:; moominmama"


### PR DESCRIPTION
The ending punctuation enrichment was missing long words that ended with '.' due to an error in the regexp that was intended to keep it from removing the trailing '.' on initials. This fixes that by changing `*` to `+`.