### PR TITLE
Update DPLA::MAP dependency to -pre.11

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.1.6"
   s.add_dependency "rails_config", "~>0.4.0"
   s.add_dependency "audumbla", '~> 0.1'
-  s.add_dependency "dpla-map", "4.0.0.0.pre.10"
+  s.add_dependency "dpla-map", "4.0.0.0.pre.11"
   s.add_dependency "rest-client"
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"


### PR DESCRIPTION
This updates DPLA::MAP to deal with the language handling issue we saw with previous enrichhments.