### PR TITLE
Fix whitespace bug in RemoveEmptyFields

### DIFF
--- a/lib/krikri/enrichments/remove_empty_fields.rb
+++ b/lib/krikri/enrichments/remove_empty_fields.rb
@@ -18,7 +18,7 @@ module Krikri::Enrichments
 
     def empty?(value)
       return true if value.empty?
-      return true if value =~ /^\s*$/
+      return true if value =~ /\A\s*\z/
       false
     end
   end

--- a/spec/lib/krikri/enrichments/remove_empty_fields_spec.rb
+++ b/spec/lib/krikri/enrichments/remove_empty_fields_spec.rb
@@ -15,6 +15,11 @@ describe Krikri::Enrichments::RemoveEmptyFields do
               :start => "\n\t  \t\n",
               :end => nil
             },
+
+            { :string => 'keeps whitespace heavy fields with newlines',
+              :start => "\n\t value \t\n",
+              :end => "\n\t value \t\n"
+            },
             { :string => 'leaves non-empty fields unaltered',
               :start => 'moomin',
               :end => 'moomin'


### PR DESCRIPTION
A Regex error caused the enrichment to remove fields beginning with whitespace + a newline, even if there was other content present.