### PR TITLE
Fix FieldValueReport error where nil can't be coerced into Fixnum (fixes #7883)

### DIFF
--- a/app/models/krikri/field_value_report.rb
+++ b/app/models/krikri/field_value_report.rb
@@ -73,7 +73,7 @@ module Krikri
             yielder <<  headers.map { |header| row[header] }
           end
 
-          opts[:start] += opts[:batch_size]
+          opts[:start] += opts[:rows]
           break if opts[:start] >= response.total
         end
       end
@@ -87,7 +87,7 @@ module Krikri
     def query_opts(opts = {})
       { :fq => "provider_id:\"#{provider.rdf_subject}\"",
         :fl => headers,
-        :rows => opts.fetch(:batch_size, 1000).to_i,
+        :rows => opts.fetch(:rows, 1000).to_i,
         :start => opts.fetch(:start, 0).to_i }
     end
 

--- a/spec/models/field_value_report_spec.rb
+++ b/spec/models/field_value_report_spec.rb
@@ -74,11 +74,9 @@ describe Krikri::FieldValueReport do
     end
 
     context 'with opts' do
-      it 'sets Solr :rows from :batch_size' do
-        enumerate_rows_opts = { batch_size: 50 }
-        expected_query_opts = { rows: 50 }
-        expect(report.instance_eval{ query_opts(enumerate_rows_opts) })
-          .to include expected_query_opts
+      it 'sets :rows' do
+        opts = { rows: 50 }
+        expect(report.instance_eval{ query_opts(opts) }).to include opts
       end
     end
   end


### PR DESCRIPTION
This was introduced by trying to use the admittedly clearer key `:batch_size`. 