### PR TITLE
Upgrade DPLA::MAP

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.1.6"
   s.add_dependency "rails_config", "~>0.4.0"
   s.add_dependency "audumbla", '~> 0.1'
-  s.add_dependency "dpla-map", "4.0.0.0.pre.11"
+  s.add_dependency "dpla-map", "4.0.0.0.pre.12"
   s.add_dependency "rest-client"
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -1,4 +1,5 @@
 require 'rdf/isomorphic'
+require 'linkeddata'
 require 'active_support'
 require 'rails_config'
 require 'krikri/ldp'

--- a/lib/krikri/enrichments/dcmi_enforcer.rb
+++ b/lib/krikri/enrichments/dcmi_enforcer.rb
@@ -4,13 +4,15 @@ module Krikri::Enrichments
   class DcmiEnforcer
     include Audumbla::FieldEnrichment
 
+    TERMS = RDF::DCMITYPE.to_a
+
     ##
     # @param value [Object] the value to enrich
     #
     # @return [DPLA::MAP::Controlled::DCMIType, nil] the original value or `nil`
     def enrich_value(value)
       return nil unless value.is_a? DPLA::MAP::Controlled::DCMIType
-      return nil unless value.valid?
+      return nil unless TERMS.include? value.rdf_subject
       value
     end
   end

--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -48,7 +48,7 @@ module Krikri::Enrichments
   class LanguageToLexvo
     include Audumbla::FieldEnrichment
 
-    TERMS = DPLA::MAP::Controlled::Language.list_terms.freeze
+    TERMS = RDF::ISO_639_3.to_a
     QNAMES = TERMS.map { |t| t.qname[1] }.freeze
 
     ##


### PR DESCRIPTION
This upgrades to DPLA::MAP pre.12. It removes the dependency on LinkedVocabs, which is deserving of a rewrite against the latest `ActiveTriples` work and updated BNode handling.