### PR TITLE
Handle errors in indexer

### DIFF
--- a/lib/krikri/enricher.rb
+++ b/lib/krikri/enricher.rb
@@ -63,17 +63,16 @@ module Krikri
     # instantiation, and apply each enrichment from the enrichment chain.
     #
     def run(activity_uri = nil)
-      log :info, 'enricher is running'
       mapped_records = generator_activity.entities
       mapped_records.each do |rec|
         begin
           chain_enrichments!(rec)
           activity_uri ? rec.save_with_provenance(activity_uri) : rec.save
         rescue => e
-          log :error, "Enrichment error: #{e.message}\n#{e.backtrace}"
+          Krikri::Logger.log(:error, 
+                             "Enrichment error: #{e.message}\n#{e.backtrace}")
         end
       end
-      log :info, 'enricher is done'
     end
 
     ##

--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -130,17 +130,16 @@ module Krikri
     # @return [Boolean]
     # @see Krirki::Harvesters:HarvestBehavior
     def run(activity_uri = nil)
-      log :info, 'harvest is running'
       records.each do |rec|
         begin
           process_record(rec, activity_uri)
         rescue => e
-          log :error, "Error harvesting record:\n#{rec.content}\n\t" \
-                      "with message:\n#{e.message}"
+          Krikri::Logger.log :error, "Error harvesting record:\n" \
+                                     "#{rec.content}\n\twith message:\n"\
+                                     "#{e.message}"
           next
         end
       end
-      log :info, 'harvest is done'
       true
     end
 

--- a/lib/krikri/indexer.rb
+++ b/lib/krikri/indexer.rb
@@ -38,16 +38,7 @@ module Krikri
     end
 
     def run
-      log :info, 'indexer is running'
-      
-      begin
-        index.update_from_activity(generator_activity)
-      rescue => e
-        log :error, "INDEXER FAILED\n#{e.message}"
-        raise e
-      ensure  
-        log :info, 'indexer is done'
-      end
+      index.update_from_activity(generator_activity)
     end
   end
 end

--- a/lib/krikri/indexer.rb
+++ b/lib/krikri/indexer.rb
@@ -21,7 +21,7 @@ module Krikri
     include SoftwareAgent
     include EntityConsumer
 
-    attr_reader :index_class, :index_opts
+    attr_reader :index, :index_class, :index_opts
 
     def self.queue_name
       :indexing
@@ -33,14 +33,21 @@ module Krikri
       @index_opts = opts
     end
 
+    def index
+      @index ||= index_class.constantize.new(index_opts)
+    end
+
     def run
       log :info, 'indexer is running'
-      search_index = index_class.constantize.new(index_opts)
-      search_index.update_from_activity(generator_activity)
-    rescue => e
-      Rails.logger.error("Indexing error: #{e.message}\n#{e.backtrace}")
-    ensure
-      log :info, 'indexer is done'
+      
+      begin
+        index.update_from_activity(generator_activity)
+      rescue => e
+        log :error, "INDEXER FAILED\n#{e.message}"
+        raise e
+      ensure  
+        log :info, 'indexer is done'
+      end
     end
   end
 end

--- a/lib/krikri/logger.rb
+++ b/lib/krikri/logger.rb
@@ -1,0 +1,38 @@
+module Krikri
+  ##
+  # An application-wide tagged logger
+  # 
+  # @example with default logger
+  #   Krikri::Logger.log :info, 'message'
+  #
+  # @example with custom logger
+  #   logger = Logger.new(my_logger)
+  #   logger.log :info, 'message'
+  class Logger
+    ##
+    # @param [ActiveSupport::TaggedLogging] logger
+    def initialize(logger = ActiveSupport::TaggedLogging.new(Rails.logger))
+      @logger = logger
+    end
+
+    class << self
+      ##
+      # Initializes a logger with the default settings and logs a message to it
+      # @see #log
+      def log(priority, msg)
+        new.log(priority, msg)
+      end
+    end
+
+    ##
+    # Log a message, tagged for application-wide consistency
+    #
+    # @param [Symbol] priority  a priority tag
+    # @param [string] msg  the message to log
+    def log(priority, msg)
+      @logger.tagged(Time.now.to_s, Process.pid, to_s) do
+        @logger.send(priority, msg)
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/enricher_spec.rb
+++ b/spec/lib/krikri/enricher_spec.rb
@@ -82,7 +82,7 @@ EOS
       end
 
       it 'logs errors' do
-        expect(Krikri::SoftwareAgent::Logger)
+        expect(Rails.logger)
           .to receive(:error)
           .with(start_with('Enrichment error'))
           .exactly(3).times

--- a/spec/lib/krikri/indexer_spec.rb
+++ b/spec/lib/krikri/indexer_spec.rb
@@ -40,23 +40,5 @@ describe Krikri::Indexer do
                                 .with(subject.generator_activity)
       subject.run
     end
-
-    it 'logs to info for start and finish' do
-      expect(Rails.logger).to receive(:info).exactly(2).times
-      subject.run
-    end
-
-    context 'with errors' do
-      before do
-        allow(agg).to receive(:to_jsonld).and_raise(RuntimeError, 'any err')
-      end
-
-      let(:agg) { double('bad agg') }
-
-      it 'logs errors, once for each batch' do
-        expect(Rails.logger).to receive(:error).exactly(1).times
-        expect { subject.run }.to raise_error RuntimeError
-      end
-    end
   end
 end

--- a/spec/lib/krikri/indexer_spec.rb
+++ b/spec/lib/krikri/indexer_spec.rb
@@ -6,23 +6,21 @@ describe Krikri::Indexer do
     create(:krikri_enrichment_activity)
   end
 
-  enrichment_gen_uri_str = 'http://example.org/ldp/activity/5'
+  subject { described_class.new(opts) }
 
-  # See mapper_agent_spec.rb regarding :opts and behaves_opts...
-  let(:opts) do
-    {
-      generator_uri: enrichment_gen_uri_str,
-      index_class: 'Krikri::QASearchIndex'
-    }
-  end
-  behaves_opts = {
-    generator_uri: enrichment_gen_uri_str,
-    index_class: 'Krikri::QASearchIndex'
-  }
+  enrichment_gen_uri_str = 'http://example.org/ldp/activity/5'
+  behaves_opts = { generator_uri: enrichment_gen_uri_str,
+                   index_class:   'Krikri::QASearchIndex' }
 
   it_behaves_like 'a software agent', behaves_opts
+  
+  # See mapper_agent_spec.rb regarding :opts and behaves_opts...
+  let(:opts) do
+    { generator_uri: enrichment_gen_uri_str,
+      index_class:   index_class.to_s }
+  end
 
-  subject { described_class.new(opts) }
+  let(:index_class) { Krikri::QASearchIndex }
 
   describe '::queue_name' do
     it { expect(described_class.queue_name.to_s).to eq 'indexing' }
@@ -30,19 +28,35 @@ describe Krikri::Indexer do
 
   describe '#run' do
     let(:agg) { build(:aggregation) }   # :aggregation defined in DPLA::MAP
-    let(:entity_enum) do
-      (1..50).lazy.map do |e|
-        record = agg
-        e.yield record
-      end
-    end
+    let(:entity_enum) { Array.new(3, agg) }
+    
     before do
       allow(subject.generator_activity).to receive(:entities)
         .and_return(entity_enum)
     end
 
     it 'indexes records' do
+      expect(subject.index).to receive(:update_from_activity)
+                                .with(subject.generator_activity)
       subject.run
+    end
+
+    it 'logs to info for start and finish' do
+      expect(Rails.logger).to receive(:info).exactly(2).times
+      subject.run
+    end
+
+    context 'with errors' do
+      before do
+        allow(agg).to receive(:to_jsonld).and_raise(RuntimeError, 'any err')
+      end
+
+      let(:agg) { double('bad agg') }
+
+      it 'logs errors, once for each batch' do
+        expect(Rails.logger).to receive(:error).exactly(1).times
+        expect { subject.run }.to raise_error RuntimeError
+      end
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -88,6 +88,11 @@ describe Krikri::Activity, type: :model do
       expect(subject).to have_duration_of(duration)
     end
 
+    it 'logs start and finish' do
+      expect(Rails.logger).to receive(:info).exactly(2).times
+      subject.run { }
+    end
+
     context 'after first run' do
       before do
         subject.run { }

--- a/spec/support/shared_examples/software_agent.rb
+++ b/spec/support/shared_examples/software_agent.rb
@@ -64,5 +64,10 @@ shared_examples 'a software agent' do |args|
       expect { agent_class.enqueue(args) }
         .to change { Krikri::Activity.count }.by(1)
     end
+
+    it 'logs queue creation' do
+      expect(Rails.logger).to receive(:info).exactly(2).times
+      agent_class.enqueue(args)
+    end
   end
 end


### PR DESCRIPTION
Instead of catching everything at the top level Indexer, we now handle
errors within the index implementation. Anything that reaches the
Indexer is treated as an failure state and logged accordingly, then
reraised.