### PR TITLE
Fix prefLabel issue in map_crosswalk

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -232,7 +232,7 @@ module Krikri
 
       def get_label(resource)
         return resource if resource.is_a? String
-        return resource.preflabel if resource.respond_to?(:prefLabel) &&
+        return resource.prefLabel if resource.respond_to?(:prefLabel) &&
                                  resource.prefLabel.any?
         return resource.label if resource.respond_to?(:label) &&
                                  resource.label.any?

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -53,6 +53,24 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
           .to eq 'http://dp.la/api/items/moomin#sourceResource'
       end
 
+      it 'has prefLabels' do
+        expect(subject.hash[:sourceResource][:@id])
+          .to eq 'http://dp.la/api/items/moomin#sourceResource'
+      end
+
+      context 'with prefLabel' do
+        before do
+          aggregation.sourceResource.first.language.first.prefLabel = label
+          subject.build
+        end
+        
+        let(:label) { 'en' }
+        
+        it 'uses prefLabel' do
+          expect(subject.hash[:sourceResource][:language]).to contain_exactly label
+        end
+      end
+
       context 'with mistyped values' do
         before do
           aggregation.hasView = 'NOT REAL'


### PR DESCRIPTION
Fixes a typo on `prefLabel` which caused failure on index for certain records.

Adds a regression test.