### PR TITLE
Fix map crosswalk language

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -120,7 +120,7 @@ module Krikri
         set_value(sr, :identifier, parent_sr.identifier)
 
         set_value(sr, :language, parent_sr.language) do |lang|
-          get_label(lang)
+          build_language(lang)
         end
 
         set_value(sr, :publisher, parent_sr.publisher) do |pub|
@@ -197,6 +197,22 @@ module Krikri
         RDF::DCMITYPE[vocab_sym].label.downcase
       end
 
+      def build_language(source)
+        return unless source.is_a? DPLA::MAP::Controlled::Language
+        lang = {}
+
+        lang[:name] = source.prefLabel.first if source.prefLabel.any?
+        return if lang[:name].nil?
+
+        if source.exactMatch.any?
+          lexvo = source.exactMatch.first
+          lang[:iso639_3] = lexvo.rdf_subject.to_s.split('/').last unless 
+            lexvo.node?
+        end
+
+        lang
+      end
+
       def build_place(source)
         return unless source.is_a? DPLA::MAP::Place
         place = {}
@@ -212,7 +228,7 @@ module Krikri
         subject = {}
         subject[:name] = source.prefLabel.first if
           source.prefLabel.any?
-        subject[:name] = source.providedLabel.first if
+        subject[:name] ||= source.providedLabel.first if
           source.providedLabel.any?
 
         subject.any? ? subject : nil

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -60,17 +60,38 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
 
       context 'with prefLabel' do
         before do
-          aggregation.sourceResource.first.language.first.prefLabel = label
+          aggregation.dataProvider.first.label = label
           subject.build
         end
         
-        let(:label) { 'en' }
+        let(:label) { 'nypl' }
         
         it 'uses prefLabel' do
-          expect(subject.hash[:sourceResource][:language]).to contain_exactly label
+          expect(subject.hash[:dataProvider]).to eq label
         end
       end
 
+      context 'with language' do
+        before do
+          aggregation.sourceResource.first.language.first.prefLabel = label
+          aggregation.sourceResource.first.language.first.exactMatch = match
+          subject.build
+        end
+
+        let(:label) { 'English' }
+        let(:match) { RDF::ISO_639_3.eng }
+
+        it 'has a name' do 
+          expect(subject.hash[:sourceResource][:language].first[:name])
+            .to eq label
+        end
+
+        it 'has a match' do 
+          expect(subject.hash[:sourceResource][:language].first[:iso639_3])
+            .to eq 'eng'
+        end
+      end
+      
       context 'with mistyped values' do
         before do
           aggregation.hasView = 'NOT REAL'


### PR DESCRIPTION
Maps language to a structure like:

  { name: 'English', iso639_3: 'eng' }

Also fixes a minor bug on subject terms, allowing us to index prefLabels
with preference over providedLabels.