### PR TITLE
Add enrichment to clear WebResource Blank Nodes

### DIFF
--- a/lib/krikri/enrichments/web_resource_uri.rb
+++ b/lib/krikri/enrichments/web_resource_uri.rb
@@ -1,0 +1,20 @@
+module Krikri::Enrichments
+  ##
+  # Enrichment to remove WebResources that are blank nodes. `edm:WebResource`
+  # nodes should *always* be an HTTP URI.
+  class WebResourceURI
+    include Audumbla::FieldEnrichment
+
+    ##
+    # @param [Object] value
+    #
+    # @return [Object] `nil` if `value` is a `DPLA::MAP::WebResource` and a 
+    #    blank node; otherwise, the original `value`.
+    def enrich_value(value)
+      return value unless value.is_a?(DPLA::MAP::WebResource) && value.node?
+      nil
+    end
+  end
+end
+  
+  

--- a/spec/lib/krikri/enrichments/web_resource_uri_spec.rb
+++ b/spec/lib/krikri/enrichments/web_resource_uri_spec.rb
@@ -1,0 +1,36 @@
+
+require 'spec_helper'
+
+describe Krikri::Enrichments::WebResourceURI do
+  it_behaves_like 'a field enrichment'
+  
+  describe '#enrich_value' do
+    it 'with a string returns the original value' do
+      value = 'moomin'
+      expect(subject.enrich_value(value)).to eq value
+    end
+
+    it 'with a date returns the original value' do
+      value = Date.today
+      expect(subject.enrich_value(value)).to eq value
+    end
+
+    it 'with a resource returns the original value' do
+      value = build(:aggregation)
+      expect(subject.enrich_value(value)).to eq value
+    end
+
+    context 'with a WebResource' do
+      let(:web_resource) { build(:web_resource) }
+      
+      it 'returns nil for blank node' do
+        expect(subject.enrich_value(web_resource)).to be_nil
+      end
+
+      it 'retains value with URI' do
+        web_resource.set_subject!('http://example.org/moomin')
+        expect(subject.enrich_value(web_resource)).to eq web_resource
+      end
+    end
+  end
+end


### PR DESCRIPTION
`edm:WebResource` nodes should __always__ be an HTTP URI. This removes them if a blank node is given.