### PR TITLE
Merge index options with defaults

### DIFF
--- a/lib/krikri/search_index.rb
+++ b/lib/krikri/search_index.rb
@@ -304,10 +304,11 @@ module Krikri
     #   - index_name [String]  The name of the ElasticSearch index
     # Other options are passed along to Elasticsearch::Client.
     #
-    def initialize(opts = Krikri::Settings.elasticsearch.to_h)
-      super(opts)
-      @index_name = opts.delete(:index_name) { 'dpla_alias' }
-      @elasticsearch = Elasticsearch::Client.new(opts)
+    def initialize(opts = {})
+      options = Krikri::Settings.elasticsearch.to_h.merge(opts)
+      super(options)
+      @index_name = options.delete(:index_name) { 'dpla_alias' }
+      @elasticsearch = Elasticsearch::Client.new(options)
     end
 
     ##


### PR DESCRIPTION
Passing in an empty options hash overwrote the default options, so jobs
would never use the defaults. This merges the options.

A side effect is that we avoid calling `#delete` on the original options
hash, leaving it intact for the caller.