### PR TITLE
Error handling in Mapping

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -62,28 +62,11 @@ module Krikri
         begin
           Registry.get(name).process_record(rec)
         rescue => e
-          desc = mapping_exception_desc(rec)
-          bt = e.backtrace.join("\n")
-          Rails.logger.error("Error processing mapping.\n" \
-                             "#{desc}\n#{e.message}\n#{bt}")
+          Rails.logger.error(e.message)
           nil
         end
       end
     end
-
-    ##
-    # @param [#content] rec
-    #
-    # @return [String] description of the object encountered by the exception
-    #   handler in #map
-    def mapping_exception_desc(rec)
-      if defined? rec.content
-        "content:\n#{rec.content || '[no content]'}"
-      else
-        "object:\n#{rec.inspect}"
-      end
-    end
-    private_class_method :mapping_exception_desc
 
     ##
     # An application-wide registry of defined mappings

--- a/lib/krikri/mapping.rb
+++ b/lib/krikri/mapping.rb
@@ -8,6 +8,24 @@ module Krikri
   #    map.process_record(my_original_record)
   #    # => #<MyModelClass:0x3ff8b7459210()>
   #
+  # When one or more errors are encoutered during processing, they are collected
+  # in a `Krikri::Kapping::Error` and re-raised.
+  #
+  # @example When an error is thrown during property mapping
+  #    map = Mapping.new(MyModelClass)
+  #    begin
+  #      map.process_record(my_original_record)
+  #    rescue Mapping::Error => e
+  #      e.message
+  #    end
+  #    # => Property failed on subject:
+  #    #       {subject error message}
+  #    #       {subject error backtrace}
+  #    #    Property failed on title:
+  #    #       {title error message}
+  #    #       {title error backtrace}
+  #   
+  # @see Krikri::MappingDSL
   class Mapping
     include MappingDSL
 
@@ -31,12 +49,67 @@ module Krikri
     #
     # @return [Object] A model object of type @klass, processed through the
     #   mapping DSL
+    # @raise [Krikri::Mapper::Error] when an error is thrown when handling any
+    #   of the properties
     def process_record(record)
       mapped_record = klass.new
-      properties.each do |prop|
-        prop.to_proc.call(mapped_record, parser.parse(record, *@parser_args))
+      error = properties.each_with_object(Error.new(record)) do |prop, error|
+        begin
+          prop.to_proc.call(mapped_record, parser.parse(record, *@parser_args))
+        rescue => e
+          error.add(prop.name, e)
+        end
       end
+      raise error unless error.errors.empty?
       mapped_record
+    end
+    
+    ##
+    # An error class for exceptions thrown during `Krikri::Mapping` processes.
+    #
+    # Collects the full set of errors encountered when mapping a given record,
+    # along with the property names that were being processed when throwing the 
+    # error.
+    #
+    # @example collecting exceptions and reraising
+    #   err = Krikri::Mapping::Error.new(record)
+    #   err.add(:title, exception)
+    #   raise err
+    #
+    class Error < RuntimeError
+      attr_accessor :original_record, :errors
+
+      ##
+      # @param [Krikri::OriginalRecord] record
+      def initialize(record)
+        @original_record = record
+        @errors = {}
+      end
+
+      ##
+      # @param [Symbol] property  the name of the property for the error
+      # @param [Exception] parent_error  the error to add
+      def add(property, parent_error)
+        errors[property] = parent_error
+      end
+
+      ##
+      # @return [Array<Symbol>] the property names that caused errors
+      def properties
+        errors.keys
+      end
+      
+      ##
+      # @return [String] a message describing the full error set
+      def message
+        msg = "Error processing mapping for #{original_record.local_name}\n"
+        errors.each do |property, error|
+          msg << "Failed on property #{property}:\n"
+          msg << "\t#{error.message}\n\t#{error.backtrace.join("\n\t")}"
+        end
+
+        msg
+      end
     end
   end
 end

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -147,9 +147,7 @@ describe Krikri::Mapper do
         end
 
         it 'logs errors and continues' do
-          expect(Rails.logger)
-            .to receive(:error).with(start_with('Error processing mapping'))
-                 .exactly(3).times
+          expect(Rails.logger).to receive(:error).exactly(3).times
           Krikri::Mapper.map(:my_map_2, records)
         end
 

--- a/spec/lib/krikri/mapping_spec.rb
+++ b/spec/lib/krikri/mapping_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Krikri::Mapping do
 
-  let(:target_class) { double }
-  let(:parser) { double }
+  let(:target_class) { double('target class') }
+  let(:parser) { double('parser') }
   let(:parser_args) { [1,2,3] }
 
   describe '#new' do
@@ -28,15 +28,52 @@ describe Krikri::Mapping do
       expect(new_mapping.process_record(record)).to be_a klass
     end
 
-    context 'with parser' do
+    shared_context 'property declarations' do
       before do
-        target_instance = double
         allow(target_class).to receive(:new).and_return(target_instance)
         allow(target_instance).to receive(:my_property=).and_return('')
+        allow(parser).to receive(:parse).and_return(record)
         subject.my_property ''
       end
 
       subject { described_class.new(target_class, parser, *parser_args) }
+      let(:target_instance) { double('target instance') }
+    end
+    
+    describe 'error handling' do  
+      include_context 'property declarations'
+
+      before do
+        allow(target_instance).to receive(:error_property=).and_raise error
+        subject.error_property 'moomin'
+      end
+
+      let(:error) { RuntimeError.new }
+    
+      it 'catches errors and raises Mapping::Error ' do
+        expect { subject.process_record(record) }
+          .to raise_error described_class::Error
+      end
+
+      it 'tracks failed properties' do
+        begin 
+          subject.process_record(record)
+        rescue described_class::Error => err
+          expect(err.properties).to contain_exactly :error_property
+        end
+      end
+
+      it 'stores properties and errors in Mapping::Error' do
+        begin 
+          subject.process_record(record)
+        rescue described_class::Error => err
+          expect(err.errors[:error_property]).to eq error
+        end
+      end
+    end
+
+    context 'with parser' do
+      include_context 'property declarations'
 
       it 'parses record before mapping' do
         expect(parser)


### PR DESCRIPTION
Introduces a `Mapping::Error` that tracks multiple errors for a given
record and handles messaging.

In the `Mapping`, we catch errors for each declaration on a given
record, storing them with the relevant property name, and re-raise. The
`Mapper` then simply catches the error and logs its message.

This simplifies handling outside the DSL code, and creates richer error
messages.