### PR TITLE
Feature/ttl update

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.1.6"
   s.add_dependency "rails_config", "~>0.4.0"
   s.add_dependency "audumbla", '~> 0.1'
+  s.add_dependency "rdf-turtle", "~>1.1.8"
   s.add_dependency "dpla-map", "4.0.0.0.pre.12"
   s.add_dependency "rest-client"
   s.add_dependency "rdf-marmotta", '>= 0.0.6'

--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -19,27 +19,5 @@ module Krikri
            'krikri/entity_behaviors/aggregation_entity_behavior'
   autoload :OriginalRecordEntityBehavior,
            'krikri/entity_behaviors/original_record_entity_behavior'
-end
 
-##
-# Monkey-patch the EBNF Scanner to catch larger terminals.
-#
-# @see https://github.com/gkellogg/ebnf/issues/5
-module EBNF::LL1
-  class Scanner
-    def initialize(input, options = {})
-      # use an arbitrarily large low/high water mark. We want to make sure we're
-      # feeding in the entire terminal
-      @options = options.merge(:high_water => 1_048_576, 
-                               :low_water => 1_048_576)
-
-      if input.respond_to?(:read)
-        @input = input
-        super("")
-        feed_me
-      else
-        super(input.to_s)
-      end
-    end
-  end
 end


### PR DESCRIPTION
This version of the Turtle parser uses a hand-written parser that is about 3x faster than the previous version. 

It also addresses the issue with long literals. The monkey patch for that issue is reverted in c0c4448; the regression test added by 0f9a1b7 remains.