### PR TITLE
Pin to RDF 1.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 # use engine_cart instead of generic dummy app
-gem 'engine_cart'
+gem 'engine_cart', '~> 0.7.1'
 
 gem 'rubocop', require: false
 gem 'yajl-ruby', require: 'yajl'

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails_config", "~>0.4.0"
   s.add_dependency "audumbla", '~> 0.1'
   s.add_dependency "rdf-turtle", "~>1.1.8"
+  s.add_dependency "rdf", "~> 1.1.13"
   s.add_dependency "dpla-map", "4.0.0.0.pre.12"
   s.add_dependency "rest-client"
   s.add_dependency "rdf-marmotta", '>= 0.0.6'


### PR DESCRIPTION
RDF 1.99.0 was released recently and introduces many deprecation warnings in preparation for the RDF 2.0 release coming around the turn of the calendar year. We expect 1.99.1, and perhaps some other minor releases between now and then. 1.99.1 will contain most or all of the features that make it into 2.0.

This locks us to `1.1.x` until we can make a deliberate upgrade. My suggestion would be to wait for that until *at least* 1.99.1, reducing the number and complexity of the upgrades.