### PR TITLE
Force encoding on RDFSource response bodies

### DIFF
--- a/lib/krikri/ldp/rdf_source.rb
+++ b/lib/krikri/ldp/rdf_source.rb
@@ -73,11 +73,18 @@ module Krikri::LDP
     private
 
     ##
-    # Clears the RDF::Graph and repopulates it from the http body.
+    # Clears the RDF::Graph and repopulates it from the http body. Forces text
+    # encoding to UTF-8 before passing to the `RDF::Reader`.
+    # 
+    # @return [void]
+    #
+    # @see http://www.w3.org/TR/turtle/#sec-mime for info about Turtle encoding
+    # @see http://www.w3.org/TR/ldp/#h-ldprs-get-turtle for info about LDP GET
+    #   and Turtle.
     def reload_ldp
       return reload unless !node? && exists?
       clear
-      self << RDF::Reader.for(:ttl).new(@http_cache.body).statements
+      self << RDF::Reader.for(:ttl).new(@http_cache.body.force_encoding('UTF-8'))
     end
   end
 end


### PR DESCRIPTION
`Net::HTTP` is returning `ASCII-8BIT` strings for some responses (see [this code](https://github.com/ruby/ruby/blob/trunk/lib/net/http/response.rb#L373-L377) and [this issue](https://bugs.ruby-lang.org/issues/2567)). This forces `RDFSource` responses (which for LDP MUST be `text/turtle` and therefore UTF-8, if requested) to read as UTF-8.

We considered using middleware like [`Faraday::Encoding`](https://github.com/ma2gedev/faraday-encoding) but Marmotta does not return an explict encoding in `content-type` headers.