### PR TITLE
Allow OAI to recover on errors when iterating sets

### DIFF
--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -329,6 +329,21 @@ EOM
                                        .and_return(result)
             subject.send(method, { :skip_set => 'moomin' }).first
           end
+
+          it 'skips sets that error' do
+            args[:oai].delete(:set)
+            invalid = args[:oai].dup
+            invalid[:set] = 'invalid'
+            valid = args[:oai].dup
+            valid[:set] = 'valid'
+
+            allow(subject).to receive(:sets).and_return(['invalid', 'valid', 'moomin'])
+            expect(subject.client).to receive(request_type).with(invalid)
+                                       .and_raise(OAI::Exception, '')
+            expect(subject.client).to receive(request_type).with(valid)
+                                       .and_return(result)
+            subject.send(method, { :skip_set => 'moomin' }).first
+          end
         end
       end
 


### PR DESCRIPTION
Adds error recovery when an attempt to retrieve a set throws an
`OAI::Excepton`. OAI-PMH requests throw errors when no matches can be
found with (e.g.) the required metadata prefix. When this happens we
want to pass over the set, logging & returning empty, instead of
aborting the harvest.

Note that the failover applies to *any* OAI exception. We've observed
that some provider endpoints report different errors, and
`OAI::Exception` does little to help us identify error types. This may
turn out to be heavy-handed.