### PR TITLE
Expose local_name through the Parser interface

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -29,6 +29,13 @@ module Krikri
     end
 
     ##
+    # @return [String] the local_name of the OriginalRecord wrapped by this
+    #   parser
+    def local_name
+      record.local_name
+    end
+
+    ##
     # A generic parser value.
     #
     # Interface to a single value node which can access typed data values (e.g.


### PR DESCRIPTION
This is used for error reporting by Mapping::Error when a mapping error
occurs inside a ChildDeclaration block.

Without this, errors would throw:

```
NoMethodError: undefined method `local_name' for #<Krikri::PrimoParser:0x007fa42ec51500>
```