### PR TITLE
Add #invalidate! for LDP resources

### DIFF
--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -3,6 +3,7 @@ module Krikri
   # Handles records as harvested, prior to mapping
   class OriginalRecord
     include Krikri::LDP::Resource
+    include Krikri::LDP::Invalidatable
 
     attr_accessor :content, :local_name, :rdf_subject
     attr_writer :content_type

--- a/lib/krikri/ldp.rb
+++ b/lib/krikri/ldp.rb
@@ -4,7 +4,8 @@ module Krikri
   # As LDP support develops, it might be possible to excract this or replace it
   # with a tool like the `ldp` gem.
   module LDP
-    autoload :Resource,     'krikri/ldp/resource'
-    autoload :RdfSource,    'krikri/ldp/rdf_source'
+    autoload :Resource,         'krikri/ldp/resource'
+    autoload :RdfSource,        'krikri/ldp/rdf_source'
+    autoload :Invalidatable,    'krikri/ldp/invalidatable'
   end
 end

--- a/lib/krikri/ldp/invalidatable.rb
+++ b/lib/krikri/ldp/invalidatable.rb
@@ -1,0 +1,107 @@
+module Krikri::LDP
+  ##
+  # Implements invalidation for `Krikri::LDP::Resource`s. This is different 
+  # from deletion, in that the resource continues to respond `200 OK`, and 
+  # return the representation, Nothing is removed from the LDP server.
+  # 
+  # Works as a mixin to `Krikri::LDP::Resource`, assuming an implementation of
+  # `#rdf_source`, which may simply return `self`.
+  #
+  # @example invalidating a resource
+  #   class MyResource
+  #     include Krikri::LDP::Resource
+  #     include Krikri::LDP::Invalidatable
+  #
+  #     def rdf_subject
+  #       @rdf_subject ||= RDF::URI('http://example.com/ldp/a/resource/path')
+  #     end
+  #   end
+  #  
+  #   invalidatable_resource = MyResource.new
+  #   # the resource must exist before it can be invalidated! 
+  #   invalidatable_resource.save
+  #
+  #   invalidatable_resource.invalidate!
+  #   invalidatable_resource.invalidated? # => true
+  #   invalidatable_resource.invalidated_at_time 
+  #   # => Thu, 03 Dec 2015 10:27:45 -0800
+  #
+  # @see http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation 
+  #   for documentation on PROV invalidation
+  module Invalidatable
+    # @see RDF::PROV
+    INVALIDATED_BY_URI = RDF::PROV.wasInvalidatedBy
+    INVALIDATED_TIME_URI = RDF::PROV.invalidatedAtTime
+
+    ##
+    # Invalidates the resource by marking it with a `prov:invalidatedAtTime`. If
+    # an `RDF::Term` is passed as the first argument, that term is used as the 
+    # value of `prov:wasInvalidatedBy`.
+    #
+    # @example invalidating with an activity
+    #   invalidatable_resource.invalidate!(RDF::URI('http://example.org/moomin'))
+    #   invalidatable_resource.was_invalidated_by
+    #   # => #<RDF::URI:0x2acab846109c URI:http://example.org/moomin>
+    #
+    # @param activity_uri [RDF::Term] a URI for the invalidating activity. If 
+    #   none is given, this defaults to `nil` and no `prov:wasInvalidatedBy`
+    #   statement is added.
+    # @param ignore_invalid [Boolean] if true, supresses errors on already,
+    #   invalid records
+    #
+    # @raise [RuntimeError] when the resource does not exist or is already 
+    #   invalid; unless `ignore_invalid` is `true`
+    # @return [void]
+    def invalidate!(activity_uri = nil, ignore_invalid = false)
+      raise "Cannot invalidate #{rdf_subject}, does not exist." unless exists?
+
+      # force a reload unless we have cached an invalidatedAtTime
+      rdf_source.get({}, true) unless invalidated?
+      # we check invalidated again in case the reload came back invalid
+      if invalidated?
+        return if ignore_invalid
+        raise "Cannot invalidate #{rdf_subject}, already invalid." 
+      end
+
+      uri = RDF::URI(rdf_subject)
+      
+      rdf_source << [uri, INVALIDATED_BY_URI, activity_uri] unless 
+        activity_uri.nil?
+      rdf_source << [uri, INVALIDATED_TIME_URI, DateTime.now]
+
+      rdf_source.save
+    end
+
+    ##
+    # @return [Boolean] `true` if the resource has been marked invalidated.
+    def invalidated?
+      !invalidated_at_time.nil?
+    end
+
+    ##
+    # @return [DateTime, nil] the time this resource was marked invalidated;
+    #   gives `nil` if the resource has not been invalidated.
+    # 
+    # @note if two invalidatedAtTimes exist, we may get either of them back!
+    def invalidated_at_time
+      time = first_property(INVALIDATED_TIME_URI)
+      time.nil? ? nil : time.object
+    end
+
+    ##
+    # @return [RDF::URI, nil] the activity responsible for invalidating the 
+    #   resource
+    # 
+    # @note if two wasInvalidatedBys exist, we may get either of them back!
+    def was_invalidated_by
+      first_property(INVALIDATED_BY_URI)
+    end
+
+    private 
+    
+    def first_property(predicate)
+      res = rdf_source.query([RDF::URI(rdf_subject), predicate, nil])
+      res.empty? ? nil : res.first.object
+    end
+  end
+end

--- a/lib/krikri/ldp/resource.rb
+++ b/lib/krikri/ldp/resource.rb
@@ -3,7 +3,28 @@ require 'faraday_middleware'
 
 module Krikri::LDP
   ##
-  # Implements basic LDP CRUD operations
+  # Implements basic LDP CRUD operations. Requires an implementation of 
+  # `#rdf_subject` returning an `RDF::URI`. The resource idenitified by the URI
+  # must conform to LDP Resource's interaction patterns. 
+  #
+  # @example implementing a resource
+  #   class MyResource
+  #     include Krikri::LDP::Resource
+  #
+  #     def rdf_subject
+  #       @rdf_subject ||= RDF::URI('http://example.com/ldp/a/resource/path')
+  #     end
+  #   end
+  #
+  # @note Ideally, this is a general purpose LDP resource. However some HTTP 
+  #   PUT creation behavior may be specific to Marmotta. This avoids the need to
+  #   interact directly with the owning container, but is a less generalized 
+  #   implementation.
+  #
+  # @see http://www.w3.org/TR/ldp/#h-ldpr-resource LDP Resource interaction 
+  #   patterns.
+  # @see https://wiki.apache.org/marmotta/LDPImplementationReport for 
+  #   information about Marmotta's PUT.
   module Resource
     extend ActiveSupport::Concern
 

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 describe Krikri::OriginalRecord do
   it_behaves_like 'an LDP Resource'
+  it_behaves_like 'an invalidatable resource' do
+    subject { described_class.build(identifier, record) }
+  end
 
   include_context 'clear repository'
 

--- a/spec/support/shared_examples/ldp_invalidatable.rb
+++ b/spec/support/shared_examples/ldp_invalidatable.rb
@@ -1,0 +1,98 @@
+shared_examples 'an invalidatable resource' do
+  describe '#invalidate!' do
+    it 'raises an error' do
+      expect { subject.invalidate! }
+        .to raise_error('Cannot invalidate ' \
+                        "#{subject.rdf_subject}, does not exist.")
+    end
+
+    it 'does not add triples' do
+      expect { begin; subject.invalidate!; rescue; end }
+        .not_to change { subject.rdf_source.statements.to_a }
+    end
+
+    context 'with URI subject' do
+      include_context 'clear repository'
+      include_context 'with RDF subject'
+      
+      before do
+        if subject.rdf_subject.nil?
+          allow(subject)
+            .to receive(:rdf_subject)
+                 .and_return(subject.rdf_source.rdf_subject / '.xml')
+        end
+      end
+
+      it 'raises an error' do
+        expect { subject.invalidate! }
+          .to raise_error('Cannot invalidate ' \
+                          "#{subject.rdf_subject}, does not exist.")
+      end
+
+      context 'when saved' do
+        before { subject.save }
+
+        it 'invalidates the subject' do
+          expect { subject.invalidate! }.to change { subject.invalidated? }.to(true)
+        end
+
+        it 'sets prov:wasInvalidatedBy' do
+          uri = RDF::URI('http://example.org/groak')
+
+          expect { subject.invalidate!(uri) }
+            .to change { subject.was_invalidated_by }.to(uri)
+        end
+
+        context 'and invalidated' do
+          before { subject.invalidate! }
+
+          it 'raises an error' do
+            expect { subject.invalidate! }
+              .to raise_error('Cannot invalidate ' \
+                              "#{subject.rdf_subject}, already invalid.")
+          end
+
+          it 'ignores when ignore_invalid is given' do
+            expect { subject.invalidate!(nil, true) }
+              .not_to raise_error
+          end
+        end
+      end
+    end
+  end
+
+  describe '#invalidated?' do
+    it 'gives appropriate boolean value' do
+      st = [RDF::URI(subject.rdf_subject), RDF::PROV.invalidatedAtTime, DateTime.now]
+
+      expect { subject.rdf_source << st }
+        .to change { subject.invalidated? }.from(false).to(true)
+    end
+  end
+
+  describe '#invalidated_at_time' do
+    it 'is nil' do
+      expect(subject.invalidated_at_time).to be_nil
+    end
+
+    context 'when invalidated' do
+      it 'gives invalidated time' do
+        time = DateTime.now
+        st = [RDF::URI(subject.rdf_subject), RDF::PROV.invalidatedAtTime, time]
+
+        expect { subject.rdf_source << st }
+          .to change { subject.invalidated_at_time }.to(time)
+      end
+    end
+
+    describe '#was_invalidated_by' do
+      it 'gives prov:wasInvalidatedBy' do
+        uri = RDF::URI('http://example.org/groak')
+        st = [RDF::URI(subject.rdf_subject), RDF::PROV.wasInvalidatedBy, uri]
+
+        expect { subject.rdf_source << st }
+          .to change { subject.was_invalidated_by }.from(nil).to(uri)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/rdf_source.rb
+++ b/spec/support/shared_examples/rdf_source.rb
@@ -1,5 +1,6 @@
 shared_examples 'an LDP RDFSource' do
   it_behaves_like 'an LDP Resource'
+  it_behaves_like 'an invalidatable resource'
 
   include_context 'clear repository'
 
@@ -109,7 +110,7 @@ shared_examples 'an LDP RDFSource' do
           subject.get
           statements.each { |s| expect(subject.statements).to include s }
         end
-        
+
         context 'with long multi-line literals' do
           let(:statements) do
             [RDF::Statement(subject, RDF::DC.description, "#{'0' * 10000}\n'blah'")]


### PR DESCRIPTION
Uses prov:invalidatedAtTime to mark resources as invalidated (soft
deleted). This is different from `#delete!` which sends an HTTP/LDP
DELETE request, permanently marking the resource as `410 Gone`.

We aim to invalidate, usually, rather than delete.

Implemented as a mixin that works with objects implementing an
`#rdf_source` method returning a `Krikri::LDP::RDFSource`.