### PR TITLE
Fix coordinates for MAP 3.1 JSON Crosswalk

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -218,7 +218,7 @@ module Krikri
         place = {}
         place[:name] = source.label.first if source.label.any?
         place[:name] ||= source.providedLabel.first if source.providedLabel.any?
-        place[:coordinates] = "#{source.lat}, #{source.long}" if
+        place[:coordinates] = "#{source.lat.first}, #{source.long.first}" if
           source.lat.any? && source.long.any?
         place.any? ? place : nil
       end

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -71,6 +71,29 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
         end
       end
 
+      context 'with place' do
+        before do
+          aggregation.sourceResource.first.spatial.first.label = label
+          aggregation.sourceResource.first.spatial.first.lat   = lat
+          aggregation.sourceResource.first.spatial.first.long  = long
+          subject.build
+        end
+
+        let(:lat) { '35.14953' }
+        let(:long) { '-90.04898' }
+        let(:label) { 'Memphis (Tenn.)' }
+        
+        it 'has lat & long' do
+          expect(subject.hash[:sourceResource][:spatial].first[:coordinates])
+            .to eq [lat, long].join(', ')
+        end
+
+        it 'has label' do
+          expect(subject.hash[:sourceResource][:spatial].first[:name])
+            .to eq label
+        end
+      end
+
       context 'with language' do
         before do
           aggregation.sourceResource.first.language.first.prefLabel = label


### PR DESCRIPTION
The 3.1 crosswalk mistakenly mapped arrays of lats & long into a string, resulting in coordinates like `"[\"12.34\"], [\"56.78\"]"`. This patch grabs the first value of each, resulting in the correct value.