### PR TITLE
Ensure MAPv4 to 3.1 crosswalk date/temporal consistency (fixes #8228)

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "audumbla", '~> 0.1'
   s.add_dependency "rdf-turtle", "~>1.1.8"
   s.add_dependency "rdf", "~> 1.1.13"
-  s.add_dependency "dpla-map", "4.0.0.0.pre.12"
+  s.add_dependency "dpla-map", "4.0.0.0.pre.13"
   s.add_dependency "rest-client"
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"

--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -134,7 +134,6 @@ module Krikri
 
         set_value(sr, :relation, parent_sr.relation)
         set_value(sr, :rights, parent_sr.rights, true)
-        set_value(sr, :temporal, parent_sr.temporal)
         set_value(sr, :title, parent_sr.title)
 
         set_value(sr, :collection, parent_sr.collection) do |coll|
@@ -147,6 +146,10 @@ module Krikri
 
         set_value(sr, :date, parent_sr.date) do |date|
           build_time_span(date)
+        end
+
+        set_value(sr, :temporal, parent_sr.temporal) do |temporal|
+          build_time_span(temporal)
         end
 
         set_value(sr, :spatial, parent_sr.spatial) do |place|
@@ -173,7 +176,7 @@ module Krikri
       def build_time_span(source)
         return unless source.is_a? DPLA::MAP::TimeSpan
         date = {}
-        date[:displayDate]
+        set_value(date, :displayDate, source.prefLabel, true, &:as_json)
         set_value(date, :begin, source.begin, true, &:as_json)
         set_value(date, :end, source.end, true, &:as_json)
 

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -114,9 +114,26 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
             .to eq 'eng'
         end
       end
+
+      context 'with timespan containing prefLabel' do
+        before do
+          aggregation.sourceResource.first.date.first.prefLabel = prefLabel
+          subject.build
+        end
+
+        let(:prefLabel) { '1969' }
+
+        it 'has a displayDate' do
+          expect(subject.hash[:sourceResource][:date].first[:displayDate])
+            .to eq prefLabel
+        end
+      end
       
       context 'with mistyped values' do
         before do
+          # Currently, the factory in dpla_map for the dpla:SourceResource
+          # creates a dcterms:temporal that has a literal value, so nothing
+          # needs to be modified here
           aggregation.hasView = 'NOT REAL'
           aggregation.sourceResource.first.genre << 'not a resource!'
           subject.build
@@ -129,6 +146,7 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
 
         it 'excludes expected objects' do
           expect(subject.hash[:hasView]).to be_nil
+          expect(subject.hash[:sourceResource][:temporal]).to be_nil
         end
       end
     end


### PR DESCRIPTION
* Ensure an `edm:TimeSpan`'s `skos:prefLabel` is being mapped to the `:displayDate` key.
* Make `dct:temporal` crosswalked to MAPv3.1 JSON-LD using the `Krikri::MapCrosswalk::CrosswalkHashbuilder#build_time_span` method.
* Add a spec to ensure that improperly typed `dc:date`/`dct:temporal` values do not get mapped to MAPv3.1 JSON-LD based on the expectations of the index.