### PR TITLE
Fix failing ProdSearchIndex spec that was skipped in CI

### DIFF
--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -83,6 +83,12 @@ module Krikri
     end
 
     initializer :aggregation do
+      class NamespaceError < RuntimeError
+        def initialize(uri)
+          super("Tried to get DPLA ID for non-DPLA URI #{uri}")
+        end
+      end
+
       DPLA::MAP::Aggregation.class_eval do
         include Krikri::MapCrosswalk
         include Krikri::LDP::RdfSource
@@ -124,6 +130,18 @@ module Krikri
             .to_s)
         end
 
+        ##
+        # @return [String, nil] returns only the final portion of the URI (the 
+        #   "local name"), with the `#base_uri` removed. `nil` if this is a node
+        #
+        # @raise NamespaceError
+        def dpla_id
+          return nil if node?
+          raise NamespaceError, rdf_subject unless id.start_with?(base_uri)
+
+          id.gsub("#{base_uri}/", '')
+        end
+          
         private
 
         def local_name_from_original_record

--- a/spec/models/dpla/map/aggregation_spec.rb
+++ b/spec/models/dpla/map/aggregation_spec.rb
@@ -78,6 +78,27 @@ describe DPLA::MAP::Aggregation do
     end
   end
 
+  describe '#dpla_id' do
+    it 'is nil for a bnode' do
+      expect(subject.dpla_id).to be_nil
+    end
+
+    it 'matches local name in URI' do
+      ln = '123'
+      subject.set_subject!(ln)
+      
+      expect(subject.dpla_id).to eq ln
+    end
+
+    it 'raises an error when a non-dpla uri is present' do
+      bad_uri = 'http://example.org/not-dpla/moomin'
+      subject.set_subject!(bad_uri)
+      
+      expect { subject.dpla_id }
+        .to raise_error Krikri::Engine::NamespaceError
+    end
+  end
+
   describe '#original_record' do
 
     context 'with original record' do

--- a/spec/support/shared_contexts/entities_query.rb
+++ b/spec/support/shared_contexts/entities_query.rb
@@ -17,6 +17,7 @@ shared_context 'entities query' do
     allow(DPLA::MAP::Aggregation).to receive(:new)
       .with(solution.record.to_s)
       .and_return(aggregation)
+    aggregation.set_subject!('aggregation_uri')
     allow(aggregation).to receive(:get).and_return(true)
   end
 end


### PR DESCRIPTION
This reorders the spec to used the :opts passed by RSpec to be only used in the context describing `#initialize`, and removes the mock that was preventing the appropriate method from firing. It also modifies the `entities query` shared context to set subject URI for the built aggregations.

The specs that test Krikri::ProdSearchIndex with an Elasticsearch connection were being skipped in Travis, and they failed for me locally. It looked in some cases as though it was trying to make a connection to http://example.org/moomin-index/moomin as used in the describe block.