### PR TITLE
Asynchronous harvesters

### DIFF
--- a/lib/krikri/async_uri_getter.rb
+++ b/lib/krikri/async_uri_getter.rb
@@ -1,0 +1,144 @@
+require 'faraday'
+require 'faraday_middleware'
+
+require 'net/http'
+require 'thread'
+require 'uri'
+
+module Krikri
+  ##
+  # Helper class for fetching multiple URLs concurrently. For example, to fetch
+  # 5 URLs in 5 threads:
+  #
+  #    urls = ['http://example.com/one',
+  #            'http://example.com/two',
+  #            'http://example.com/three',
+  #            'http://example.com/four',
+  #            'http://example.com/five']
+  #           .map { |url| URI.parse(url) }
+  #
+  #    getter = Krikri::AsyncUriGetter.new
+  #
+  #    requests = urls.map do |url|
+  #      getter.add_request(uri: url,
+  #                         opts: {
+  #                           follow_redirects: true
+  #                         })
+  #    end
+  #
+  # At this point, 5 threads are launched to fetch the list of URLs.  We can
+  # wait for them all to finish if we want to make sure we don't continue until
+  # all threads have terminated:
+  #
+  #    requests.map(&:join)
+  #
+  # Or simply access the responses and have our current thread block until
+  # they're available:
+  #
+  #    requests.each do |request|
+  #      request.with_response do |response|
+  #        if response.status == 200
+  #          puts "Response body: #{response.body}"
+  #        else
+  #          puts "Got return status: #{response.status}"
+  #        end
+  #      end
+  #    end
+  #
+  class AsyncUriGetter
+    MAX_REDIRECTS = 10
+
+    ##
+    # Create a new asynchronous URL fetcher.
+    #
+    # @param opts [Hash] a hash of the supported options, which are:
+    #
+    #  - follow_redirects: (true or false) -- whether to follow HTTP 3xx
+    #      redirects.
+    #
+    #  - max_redirects: [N] (default: 10) -- how many redirects to follow before
+    #      giving up
+    #
+    def initialize(opts: {})
+      @default_opts = { max_redirects: MAX_REDIRECTS }.merge(opts)
+    end
+
+    ##
+    # Run a request (in a new thread) and return a promise-like object for the
+    # response.
+    #
+    # @param uri [URI] the URI to be fetched
+    #
+    # @param headers [Hash<String, String>] HTTP headers to include with the
+    #   request
+    #
+    # @param opts [Hash] options to override the ones provided when
+    #   AsyncUriGetter was initialized. All supported options are available here
+    #   as well.
+    #
+    def add_request(uri: nil, headers: {}, opts: {})
+      fail ArgumentError, 'uri must be a URI' unless uri.is_a?(URI)
+      Request.new(uri, headers, @default_opts.merge(opts))
+    end
+
+    Request = Struct.new(:uri, :headers, :opts) do
+      def initialize(*)
+        super
+        @request_thread = start_request
+      end
+
+      ##
+      # Wait for the request thread to complete
+      #
+      def join
+        @request_thread.join
+      end
+
+      ##
+      # @yield [Faraday::Response] the response returned for the request
+      #
+      def with_response
+        yield(@request_thread.value)
+      end
+
+      private
+
+      ##
+      # Run the Faraday request in a new thread
+      #
+      def start_request
+        Thread.new do
+          http.get(uri) do |request|
+            headers.each do |header, value|
+              request.headers[header.to_s] = value
+            end
+          end
+        end
+      end
+
+      ##
+      # @return [Faraday::Connection] a connection with sensible defaults
+      #
+      def http
+        Faraday.new do |conn|
+          conn.request :retry,
+                       max: 4,
+                       interval: 0.025,
+                       interval_randomness: 0.5,
+                       backoff_factor: 2,
+                       exceptions: [Faraday::ConnectionFailed,
+                                    'Errno::ETIMEDOUT',
+                                    'Timeout::Error',
+                                    'Error::TimeoutError',
+                                    Faraday::TimeoutError]
+          if opts.fetch(:follow_redirects, false)
+            conn.use(FaradayMiddleware::FollowRedirects,
+                     limit: opts.fetch(:max_redirects))
+          end
+
+          conn.adapter Faraday.default_adapter
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/async_uri_getter_spec.rb
+++ b/spec/lib/krikri/async_uri_getter_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+# Adding this to make sure the exception classes are available no matter which
+# order the tests run in.
+require 'faraday_middleware/response/follow_redirects'
+
+describe Krikri::AsyncUriGetter do
+  subject { described_class.new }
+
+  let(:test_uri) { URI.parse('http://example.com') }
+
+  it 'fetches URLs from a new thread' do
+    main_thread = Thread.current
+
+    # extra check to avoid succeeding with a false positive
+    test_hit = false
+    WebMock.after_request do |request_signature, _|
+      if request_signature.uri.to_s.start_with?(test_uri.to_s)
+        test_hit = true
+        expect(Thread.current).to_not be(main_thread)
+      end
+    end
+  end
+
+  it 'retries on request failure' do
+    stub_request(:get, test_uri)
+      .to_raise(Faraday::ConnectionFailed)
+      .to_return(:status => 200, :body => 'No problem!', :headers => {})
+
+    subject.add_request(uri: test_uri).with_response do |r|
+      expect(r.status).to eq(200)
+      expect(r.body).to eq('No problem!')
+    end
+  end
+
+  it 'sends supplied HTTP headers with the request' do
+    test_headers = { 'X-Test-Header' => 'true' }
+
+    stub_request(:get, test_uri)
+      .with(:headers => test_headers)
+      .to_return(status: 200, body: 'OK')
+
+    subject.add_request(uri: test_uri, headers: test_headers).join
+  end
+
+  it 'follows HTTP redirects if requested' do
+    stub_request(:get, test_uri)
+      .to_return(status: 301, headers: { 'Location' => test_uri.to_s })
+      .to_return(status: 200, body: 'OK')
+
+    r = subject.add_request(uri: test_uri, opts: { follow_redirects: true })
+
+    r.with_response do |response|
+      expect(response.body).to eq('OK')
+    end
+  end
+
+  it 'returns the HTTP redirect response if requested' do
+    stub_request(:get, test_uri)
+      .to_return(status: 301, headers: { 'Location' => test_uri.to_s })
+
+    r = subject.add_request(uri: test_uri, opts: { follow_redirects: false })
+
+    r.with_response do |response|
+      expect(response.status).to eq(301)
+      expect(response.headers['Location']).to eq(test_uri.to_s)
+    end
+  end
+
+  it 'aborts when the redirect limit is hit' do
+    stub_request(:get, test_uri)
+      .to_return(status: 301, headers: { 'Location' => test_uri.to_s })
+
+    r = subject.add_request(uri: test_uri, opts: { follow_redirects: true })
+
+    expect { r.join }
+      .to raise_error(FaradayMiddleware::RedirectLimitReached)
+  end
+
+  it 'passes HTTP error responses to #with_response as normal' do
+    stub_request(:get, test_uri)
+      .to_return(status: 500, body: 'Something terrible happened')
+
+    subject.add_request(uri: test_uri).with_response do |r|
+      expect(r.status).to eq(500)
+    end
+  end
+
+  context 'exception propagation' do
+    before(:each) do
+      stub_request(:get, test_uri)
+        .to_raise(Faraday::ConnectionFailed)
+    end
+
+    it 'propagates exceptions to the calling thread when #join is called' do
+      r = subject.add_request(uri: test_uri)
+      expect { r.join }.to raise_error(Faraday::ConnectionFailed)
+    end
+
+    it 'propagates exceptions when the response is requested' do
+      r = subject.add_request(uri: test_uri)
+      expect { r.with_response { |_| } }
+        .to raise_error(Faraday::ConnectionFailed)
+    end
+  end
+end


### PR DESCRIPTION
Replaces #208. See discussion there.

4e272bd is the only commit changed from the previous discussion. It contains some YARD annotation updates, minor style changes, and **one substantial change**:

  - `#http` is cached within the `Request` instance. This should make no difference now (the connection and instance would have garbage collected at the same time anyway), but will prevent spawning multiple `Faraday` connections per `Request` if for some reason `Resquest` changes in the future. https://github.com/dpla/KriKri/compare/asynchronous-harvesters?expand=1#diff-a93afa836b08961677e7a6870c08c992R106

@anarchivist and/or @markbreedlove should sanity check that before merging.