### PR TITLE
Limit `RDF::URI.cache` capacity

### DIFF
--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -81,12 +81,24 @@ module Krikri
         record
       end
 
+      ##
+      # @return [String] the URI namespace/LDP container for resources of this 
+      #   class
       def base_uri
         Krikri::Settings['marmotta']['record_container']
       end
 
+      ##
+      # @param localname [#to_s] the unique portion of the URI to build; this 
+      #   will be combined with `.base_uri` to form the returned URI
+      # @return [RDF::URI] a URI built from the `.base_uri` and the `local_name` 
+      #   parameter
+      #
+      # @note we use `RDF::URI.intern` (rather than `.new`) to avoid allocating
+      #   memory for a new object for the LDP base URI, taking advantage of 
+      #   `RDF::URI.cache`.
       def build_uri(local_name)
-        RDF::URI(base_uri) / local_name
+        RDF::URI.intern(base_uri) / local_name
       end
 
       ##

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -57,6 +57,11 @@ module Krikri
       Krikri::Settings = Kernel.const_get(RailsConfig.const_name)
     end
 
+    initializer :uri_cache do
+      RDF::URI::CACHE_SIZE = 
+        (Krikri::Settings['uri_cache_size'] || 1_000_000).to_i.freeze
+    end
+
     initializer :append_migrations do |app|
       unless app.root.to_s == root.to_s
         config.paths['db/migrate'].expanded.each do |exp_path|

--- a/spec/krikri_spec.rb
+++ b/spec/krikri_spec.rb
@@ -18,6 +18,14 @@ describe Krikri::Engine do
       expect(Krikri::Settings.qa_test).to eq 'test!'
     end
 
+    it 'sets RDF::URI::CACHE_SIZE' do
+      expect(RDF::URI::CACHE_SIZE).not_to eq -1
+    end
+
+    it 'sets RDF::URI.cache capacity' do
+      expect(RDF::URI.cache).to have_capacity
+    end
+
     it 'allows app to override configuration' do
       app_settings_path = Rails.root.join('config', 'settings.local.yml').to_s
       allow(File).to receive(:exists?).with(app_settings_path).and_return(true)


### PR DESCRIPTION
By default, `RDF::URI::CACHE_SIZE` is `-1` and all URIs initialized with
`RDF::URI.intern` are cached for the life of the application. In job
scenarios, this leads to a slow growth of the cache, as more unique URIs
are added. For a good number of the URIs we're using (e.g. LDP URIs and
their `#sourceResource` fragments), use is scoped to the processing of
one record. Limiting the cache size allows these to cycle out, while
commonly used URIs should stay in the cache avoiding duplicate objects
in memory.

The cache size is given by `Krikri::Settings['uri_cache_size']`, and
defaults to `1_000_000` (cached URIs). We could choose to change the
cache size on various worker boxes by installing unique settings
values.

Setting the cache size at application startup causes a warning to be
thrown that the previous value of the "constant" `CACHE_SIZE` is being
overwritten. An issue is open to find a way to squash the warnings,
hopefully with a better cache capacity management pattern, at
https://github.com/ruby-rdf/rdf/issues/256