### PR TITLE
Allow OAI harvesters to use alternate ID sources

### DIFF
--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -131,6 +131,7 @@ module Krikri
     # @see Krirki::Harvesters:HarvestBehavior
     def run(activity_uri = nil)
       records.each do |rec|
+        next if rec.nil?
         begin
           process_record(rec, activity_uri)
         rescue => e
@@ -193,5 +194,9 @@ module Krikri
     def mint_id(seed)
       @id_minter.create(*[seed, @name].compact)
     end
+
+    public
+    
+    class IdentifierError < ArgumentError; end
   end
 end

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -453,6 +453,56 @@ EOM
       end
     end
 
+    describe 'identifiers' do
+      let(:id) { 'oai:oaipmh.huygens.knaw.nl:arthurianfiction:MAN0000000010' }
+
+
+      it 'uses oai header identifier by default' do
+        expect(subject).to receive(:mint_id).with(id).and_return('id')
+        subject.records.first
+      end
+
+      context 'with :id_path' do
+        let(:args) do
+          { uri: 'http://example.org/endpoint', 
+            oai: { id_path: '//dc:identifier' } }
+        end
+        
+        it 'returns the identifier from a given xpath' do
+          dcid = 'https://service.arthurianfiction.org/manuscript/MAN0000000010'
+
+          expect(subject).to receive(:mint_id).with(dcid).and_return('id')
+          subject.records.first
+        end
+
+        context 'and bad path' do
+          let(:id_path) { '//dc:not_a_path' }
+          let(:args) do
+            { uri: 'http://example.org/endpoint', 
+              oai: { id_path: id_path } }
+          end
+          
+          it 'fails and raises error' do
+            expect(Rails.logger).to receive(:error).with(include(*id_path, id))
+            subject.records.first
+          end
+        end
+
+        context 'and bad namespace' do
+          let(:id_path) { '//fkns:identifier' }
+          let(:args) do
+            { uri: 'http://example.org/endpoint', 
+              oai: { id_path: '//fkns:identifier' } }
+          end
+
+          it 'fails and raises error' do
+            expect(Rails.logger).to receive(:error).with(include(id_path, id))
+            subject.records.first
+          end
+        end
+      end
+    end
+
     it_behaves_like 'a harvester'
   end
 end


### PR DESCRIPTION
By default, we use the `identifier` field of the OAI header to seed the
record id minter. In the legacy system, the ids used were derived from
the `dc:identifier` field in `metadata`.

This patch allows harvesters for those sources to select a field with an
xpath expression, passed as `[:oai][:id_path]` in options.