### PR TITLE
Filter invalid records from `#entities` and `#entity_ids`

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -105,10 +105,18 @@ module Krikri
     # Return an Enumerator of URI strings of entities (e.g. aggregations or
     # original records) that pertain to this activity
     #
+    # @param  include_invalidated [Boolean] Whether to include entities that
+    #   have been invalidated with prov:invalidatedAtTime. Default: false
+    #
     # @return [Enumerator] URI strings
-    def entity_uris
+    #
+    # @see Krikri::ProvenanceQueryClient#find_by_activity regarding
+    #   invalidation.
+    #
+    def entity_uris(include_invalidated = false)
       activity_uri = RDF::URI(rdf_subject)  # This activity's LDP URI
-      query = Krikri::ProvenanceQueryClient.find_by_activity(activity_uri)
+      query = Krikri::ProvenanceQueryClient
+        .find_by_activity(activity_uri, include_invalidated)
       query.each_solution.lazy.map do |s|
         s.record.to_s
       end
@@ -122,9 +130,11 @@ module Krikri
     # that is associated with the SoftwareAgent that is represented by the
     # Activity's `agent' field.
     #
+    # @param [Array<Object>] *args Arguments to pass along to
+    #                              EntityBehavior#entities
     # @return [Enumerator] Objects
-    def entities
-      agent_instance.entity_behavior.entities(self)
+    def entities(*args)
+      agent_instance.entity_behavior.entities(self, *args)
     end
   end
 end

--- a/lib/krikri/entity_behavior.rb
+++ b/lib/krikri/entity_behavior.rb
@@ -25,7 +25,7 @@ module Krikri
     # @see lib/krikri/entity_behaviors
     # @see Krikri::Activity#entities
     #
-    def entities
+    def entities(*args)
       raise NotImplementedError 
     end
 
@@ -33,8 +33,8 @@ module Krikri
     # @see Krikri::Activity#entities
     # @see Krikri::EntityBehavior#entities
     #
-    def self.entities(activity)
-      new(activity).entities
+    def self.entities(activity, *args)
+      new(activity).entities(*args)
     end
   end
 end

--- a/lib/krikri/entity_behaviors/aggregation_entity_behavior.rb
+++ b/lib/krikri/entity_behaviors/aggregation_entity_behavior.rb
@@ -11,15 +11,18 @@ module Krikri
 
     ##
     # @param load [Boolean]  Whether to load the whole record from the LDP
-    #                        server.  Default: true.
-    #                        DPLA::MAP::Aggregation#get is slow, because it
-    #                        results in a network request, so this provides the
-    #                        possibility of avoiding it.
+    #   server.  DPLA::MAP::Aggregation#get is slow, because it results in a
+    #   network request, so this provides the possibility of avoiding it.
+    #   Default: true.
+    #
+    # @param include_invalidated [Boolean] Whether to include entities that
+    #   have been invalidated with prov:invalidatedAtTime.  Default: false
+    #
     # @see Krikri::EntityBehavior::entities
     # @return [Enumerator] DPLA::MAP::Aggregation objects
     #
-    def entities(load = true)
-      @activity.entity_uris.lazy.map do |uri|
+    def entities(load = true, include_invalidated = false)
+      @activity.entity_uris(include_invalidated).lazy.map do |uri|
         agg = DPLA::MAP::Aggregation.new(uri)
         agg.get if load
         agg

--- a/lib/krikri/entity_behaviors/original_record_entity_behavior.rb
+++ b/lib/krikri/entity_behaviors/original_record_entity_behavior.rb
@@ -11,14 +11,19 @@ module Krikri
 
     ##
     # @param load [Boolean]  Whether to load the whole record from the LDP
-    #                        server.  Default: true.  OriginalRecord.load is
-    #                        slow, because it results in a network request, so
-    #                        this provides the possibility of avoiding it.
+    #   server.  OriginalRecord.load is slow, because it results in a network
+    #   request, so this provides the possibility of avoiding it.
+    #   Default: true.
+    #
+    # @param include_invalidated [Boolean] Whether to include entities that
+    #   have been invalidated with prov:invalidatedAtTime.  Default: false
+    #
     # @see Krikri::EntityBehavior::entities
+    #
     # @return [Enumerator] OriginalRecord objects
     #
-    def entities(load = true)
-      @activity.entity_uris.lazy.map do |uri|
+    def entities(load = true, include_invalidated = false)
+      @activity.entity_uris(include_invalidated).lazy.map do |uri|
         load ? OriginalRecord.load(uri) : OriginalRecord.new(uri)
       end
     end

--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -12,15 +12,46 @@ module Krikri
     #
     # @param activity_uri [#to_uri] the URI of the activity to search
     #
+    # @param include_invalidated [Boolean]  Whether to include entities that
+    #   have been invalidated with <http://www.w3.org/ns/prov#invalidatedAtTime>
+    #
+    # @see https://www.w3.org/TR/prov-o/#invalidatedAtTime
+    # @see Krikri::LDP::Invalidatable
+    #
     # @return [RDF::SPARQL::Query] a query object that, when executed, will
     #   give solutions containing the URIs for the resources in `#record`.
-    def find_by_activity(activity_uri)
+    def find_by_activity(activity_uri, include_invalidated = false)
       raise ArgumentError, 'activity_uri must be an RDF::URI' unless
         activity_uri.respond_to? :to_term
-      SPARQL_CLIENT.select(:record)
+      query = SPARQL_CLIENT.select(:record)
         .where([:record,
                 [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy],
                 activity_uri.to_term])
+
+      if include_invalidated
+        query
+      else
+        # We need to say "and if RDF::PROV.invalidatedAtTime is not set."
+        #
+        # The SPARQL query should be:
+        #
+        # PREFIX prov: <http://www.w3.org/ns/prov#>
+        # SELECT * WHERE {
+        #   ?subject prov:wasGeneratedBy  <http://xampl.org/ldp/activity/n> .
+        #   FILTER NOT EXISTS { ?subject prov:invalidatedAtTime ?x }
+        # }
+        #
+        # ... However there doesn't appear to be a way of constructing
+        # 'FILTER NOT EXISTS' with SPARQL::Client.  Instead, we've managed to
+        # hack the following solution together.
+        #
+        # SPARQL::Client#filter is labeled @private in its YARD comment (and
+        # has no other documentation) but it's not private, at least for
+        # now.
+        query.filter \
+          'NOT EXISTS ' \
+          '{ ?record <http://www.w3.org/ns/prov#invalidatedAtTime> ?x }'
+      end
     end
   end
 end

--- a/spec/lib/krikri/aggregation_entity_behavior_spec.rb
+++ b/spec/lib/krikri/aggregation_entity_behavior_spec.rb
@@ -33,5 +33,12 @@ describe Krikri::AggregationEntityBehavior do
       # what's coming back from Marmotta is correct.
       expect(agg).to eq(agg_record_double)
     end
+
+    it 'requests only validated entities by default' do
+      expect(activity).to receive(:entity_uris)
+        .with(false)
+        .and_return([mapped_record_uri])
+      activity.entities
+    end
   end
 end

--- a/spec/lib/krikri/original_record_entity_behavior_spec.rb
+++ b/spec/lib/krikri/original_record_entity_behavior_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Krikri::OriginalRecordEntityBehavior do
+
+  before do
+    # @see aggregation_entity_behavior_spec.rb
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  describe '#entities' do
+
+    let(:orig_record_uri) { double('record uri') }
+    let(:orig_record_double) { instance_double(Krikri::OriginalRecord) }
+    let(:activity) { create(:krikri_harvest_activity) }
+
+    it 'requests only validated entities by default' do
+      expect(activity).to receive(:entity_uris)
+        .with(false)
+        .and_return([orig_record_uri])
+      activity.entities
+    end
+  end
+end

--- a/spec/lib/krikri/provenance_query_client_spec.rb
+++ b/spec/lib/krikri/provenance_query_client_spec.rb
@@ -18,6 +18,10 @@ describe Krikri::ProvenanceQueryClient do
   end
 
   describe '#find_by_activity' do
+    let(:not_exists_condition) do
+      'NOT EXISTS { ?record <http://www.w3.org/ns/prov#invalidatedAtTime> ?x }'
+    end
+
     it 'raises an argument error for non-uris' do
       expect { subject.find_by_activity(activity_uri.to_s) }
         .to raise_error ArgumentError
@@ -26,6 +30,20 @@ describe Krikri::ProvenanceQueryClient do
     it 'returns a query object' do
       expect(subject.find_by_activity(activity_uri))
         .to be_a SPARQL::Client::Query
+    end
+
+    context 'without optional arguments' do
+      it 'defaults to excluding invalidated records' do
+        expect(subject.find_by_activity(activity_uri).to_s)
+          .to include(not_exists_condition)
+      end
+    end
+
+    context 'when optional include_invalidated is true' do
+      it 'includes invalidated records' do
+        expect(subject.find_by_activity(activity_uri, true).to_s)
+          .not_to include(not_exists_condition)
+      end
     end
 
     context 'without matching subjects' do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -175,6 +175,20 @@ describe Krikri::Activity, type: :model do
     # See 'provenance queries' shared context.  
     let(:generator_uri) { subject.rdf_subject }
 
+    it 'requests validated records by default' do
+      expect(Krikri::ProvenanceQueryClient)
+        .to receive(:find_by_activity)
+        .with(RDF::URI(generator_uri), false).and_return(query)
+      subject.entity_uris
+    end
+
+    it 'requests invalidated records if specifically requested' do
+      expect(Krikri::ProvenanceQueryClient)
+        .to receive(:find_by_activity)
+        .with(RDF::URI(generator_uri), true).and_return(query)
+      subject.entity_uris(true)
+    end
+
     it 'enumerates generated entity URIs' do
       # 'result uri' is what the mocked query solution's record should contain.
       expect(subject.entity_uris.first).to match 'result uri'

--- a/spec/support/shared_contexts/provenance_query_client.rb
+++ b/spec/support/shared_contexts/provenance_query_client.rb
@@ -17,7 +17,7 @@ shared_context 'provenance queries' do
 
   before do
     allow(Krikri::ProvenanceQueryClient).to receive(:find_by_activity)
-      .with(RDF::URI(generator_uri)).and_return(query)
+      .with(RDF::URI(generator_uri), false).and_return(query)
     allow(query).to receive(:execute).and_return([solution])
     allow(query).to receive(:each_solution).and_return(solution_enum)
     allow(solution).to receive(:record).and_return(uri)


### PR DESCRIPTION
By default, filter aggregations from `Krikri::Activity#entity_uris` and `#entities` that have been invalidated -- i.e. soft-deleted.

See https://www.w3.org/TR/prov-o/#invalidatedAtTime
See https://github.com/dpla/KriKri/commit/aab20d906e67f23aa5728bec3c6048e081dfd016

The most significant change is to `Krikri::ProvenanceQueryClient`, which is responsible for the SPARQL query that either includes or excludes invalidated aggregations.

Addresses https://issues.dp.la/issues/8237

If there's any concern about making the SPARQL query more complex and having that negatively impact query speed, I've benchmarked the old and new queries; and the new one, without invalidated records, appears to complete faster.  I've benchmarked these by restarting PostgreSQL and Marmotta in between, and by rebooting server VMs in my development environment, to avoid having caching skew the results.
