### PR TITLE
Allow use of RSpec 3.4.x

### DIFF
--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -30,8 +30,9 @@ module Krikri
       # @param identifier [#to_s] a string representing the #local_name or
       #   fully qualified URI for the resource.  Identifier may have a mime type
       #   extension, ie. '123.xml'.
+      #
       # @return [OriginalRecord] the instantiated record.
-      # @raise when no matching record is found in the LDP datastore
+      # @raise [LoadError] when no matching record is found in the LDP datastore
       def load(identifier)
         identifier = identifier.to_s.split('/').last if
           identifier.start_with? base_uri
@@ -42,8 +43,7 @@ module Krikri
           record = new(identifier)
         end
 
-        raise NameError, "No #{self} found with id: #{identifier}" unless 
-          record.exists?
+        raise LoadError.new(identifier), 'No record found' unless record.exists?
 
         if identifier.include?('.')
           record.rdf_subject = "#{base_uri}/#{identifier}"
@@ -201,6 +201,24 @@ module Krikri
     #   requests.
     def headers
       { 'Content-Type' => content_type }
+    end
+
+    ##
+    # Error class expressing failed load of an OriginalRecord 
+    class LoadError < RuntimeError
+      ##
+      # @param identifier [#to_s]
+      def initialize(identifier)
+        @identifier = identifier
+      end
+      
+      ##
+      # Augments the raised message with generic failure information
+      #
+      # @see Exception#message
+      def message
+        "Could not load OriginalRecord with `#{@identifier}: #{super}"
+      end  
     end
   end
 end

--- a/app/models/krikri/original_record.rb
+++ b/app/models/krikri/original_record.rb
@@ -42,7 +42,8 @@ module Krikri
           record = new(identifier)
         end
 
-        raise "No #{self} found with id: #{identifier}" unless record.exists?
+        raise NameError, "No #{self} found with id: #{identifier}" unless 
+          record.exists?
 
         if identifier.include?('.')
           record.rdf_subject = "#{base_uri}/#{identifier}"

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails", '~> 3.2.0'
+  s.add_development_dependency "rspec-rails", '~> 3.2'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
   s.add_development_dependency 'pry-rails'

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -126,11 +126,14 @@ module Krikri
         # Get the persisted original record for this Aggregation.
         # @return [Krikri::OriginalRecord, nil]
         #
-        # An Exception will be raised if:
-        #   the original record id is invalid.
+        # @raise [NameError] when the original record id is not a URI or the
         #   the original record has not been persisted to Marmotta.
-        #   there is a connection problem with  Marmotta.
+        #
+        # @raise [Faraday::ConnectionError] when there is a connection problem
+        #   with Marmotta.
         def original_record
+          raise NameError, "#{originalRecord.first} is not an OriginalRecord" if
+            originalRecord.empty? || originalRecord.first.node?
           Krikri::OriginalRecord.load(originalRecord.first.rdf_subject
             .to_s)
         end

--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -47,7 +47,7 @@ module Krikri
       #   subsequent harvest. Figure out how to do that, or what we want to do
       #   instead.
       def build_aggregation
-        raise 'Tried to index a blank node!' if @parent.node?
+        raise NameError, 'Tried to index a blank node!' if @parent.node?
         hash.merge!({ :ingestType => 'item',
                      :ingestionSequence => 999999,
                      :ingestDate => Date.today.as_json,

--- a/spec/ldp/resource_spec.rb
+++ b/spec/ldp/resource_spec.rb
@@ -35,7 +35,7 @@ describe Krikri::LDP::Resource do
         error = Net::HTTPBadResponse.new("alue\" : \"1\"")
         expect_any_instance_of(Faraday::Adapter::NetHttp)
           .to receive(:perform_request).at_least(4).times.and_raise(error)
-        expect { subject.get }.to raise_error
+        expect { subject.get }.to raise_error Faraday::ConnectionFailed
       end
     end
 

--- a/spec/lib/krikri/harvesters/oai_harvester_spec.rb
+++ b/spec/lib/krikri/harvesters/oai_harvester_spec.rb
@@ -206,7 +206,7 @@ EOM
       expect_any_instance_of(Faraday::Adapter::NetHttp)
         .to receive(:perform_request).at_least(4).times
              .and_raise(Net::ReadTimeout.new)
-      expect { subject.records.first }.to raise_error
+      expect { subject.records.first }.to raise_error Faraday::TimeoutError
     end
 
     it 'logs failed requests' do
@@ -214,7 +214,7 @@ EOM
         .to receive(:perform_request).and_raise(Net::ReadTimeout.new)
       
       expect(Rails.logger).to receive(:info).at_least(4).times
-      expect { subject.records.first }.to raise_error
+      expect { subject.records.first }.to raise_error Faraday::TimeoutError
     end
 
     describe 'resumption' do

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -19,7 +19,7 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
   let(:aggregation) { build(:aggregation) }
 
   it 'raises an error with a bnode' do
-    expect { subject.build }.to raise_error
+    expect { subject.build }.to raise_error NameError
   end
 
   context 'with a uri' do

--- a/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/parser_methods_spec.rb
@@ -51,7 +51,8 @@ describe Krikri::MappingDSL::ParserMethods do
     it 'raises an error when record does not exist' do
       allow(record).to receive_message_chain(:record, :exists?)
         .and_return(false)
-      expect { subject.record_uri.call(record) }.to raise_error
+      expect { subject.record_uri.call(record) }
+        .to raise_error start_with('Tried to access subject URI')
     end
   end
 

--- a/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/rdf_subjects_spec.rb
@@ -121,7 +121,7 @@ describe Krikri::MappingDSL::RdfSubjects do
 
         it 'raises an error' do
           expect { subject.to_proc.call(mapped, '') }
-            .to raise_error
+            .to raise_error start_with('Error mapping')
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -56,7 +56,9 @@ describe Krikri::Activity, type: :model do
 
   describe '#end_time' do
     it 'raises an error if not started' do
-      expect { subject.set_end_time }.to raise_error
+      expect { subject.set_end_time }
+        .to raise_error 'Start time must exist and be before now to set an ' \
+                        'end time'
     end
   end
 

--- a/spec/models/dpla/map/aggregation_spec.rb
+++ b/spec/models/dpla/map/aggregation_spec.rb
@@ -67,12 +67,12 @@ describe DPLA::MAP::Aggregation do
       end
 
       context 'with more than one originalRecord' do
-        before do
-          subject.originalRecord << RDF::Node.new
-        end
+        before { subject.originalRecord << RDF::Node.new }
 
         it 'raises an error' do
-          expect { subject.mint_id! }.to raise_error
+          expect { subject.mint_id! }
+            .to raise_error start_with("#{subject} has more than " \
+                                       'one OriginalRecord')
         end
       end
     end
@@ -117,7 +117,7 @@ describe DPLA::MAP::Aggregation do
 
     context 'without original record' do
       it 'raises an error' do
-        expect { subject.original_record }.to raise_error
+        expect { subject.original_record }.to raise_error NameError
       end
     end
   end

--- a/spec/models/original_record_spec.rb
+++ b/spec/models/original_record_spec.rb
@@ -33,9 +33,14 @@ describe Krikri::OriginalRecord do
     end
   end
 
-  describe '#load' do
+  describe '.load' do
     context 'existing record' do
       before { subject.save }
+
+      it 'raises an error when a bad id is passed' do
+        expect { described_class.load('fake') }
+          .to raise_error Krikri::OriginalRecord::LoadError, include("fake")
+      end
 
       it 'loads resource with correct content' do
         expect(described_class.load(identifier).content).to eq subject.content

--- a/spec/support/matchers/active_triple_matchers.rb
+++ b/spec/support/matchers/active_triple_matchers.rb
@@ -7,7 +7,7 @@ end
 RSpec::Matchers.define :have_provided_label do |expected|
   match do |actual|
     pattern = [actual, RDF::DPLA.providedLabel, nil]
-    expect(actual.query(pattern).map(&:object)).to contain_exactly(expected)
+    expect(actual.query(pattern).map(&:object)).to include(expected)
     true
   end
 end


### PR DESCRIPTION
RSpec is nearing a 3.5 release, which will be necessary for Rails 5 compatibility. This gets us closer to that.

It also fixes up warnings raised by newer versions of RSpec.

The dependency is loosened so engine users aren't forced to upgrade.