### PR TITLE
Call `next` when logging errors in `#record`

### DIFF
--- a/lib/krikri/harvesters/oai_harvester.rb
+++ b/lib/krikri/harvesters/oai_harvester.rb
@@ -97,6 +97,7 @@ module Krikri::Harvesters
                                 record_xml(rec))
           rescue => e
             Krikri::Logger.log(:error, e.message)
+            next
           end
         end
       end


### PR DESCRIPTION
The OAIHarvester previously gave `true` in `#records` when an error was caught building the record. `#run` handles `nil`, so we should return that instead.

Logging an error returns `true`, so code like this:

```ruby
map do |r|
  begin
    some_logic(r)
  rescue => e
    log(e)
  end
end
```

...results in `true` in the mapped enum. Calling `next` gives `nil` as required.

This fixes an issue originally identified here: https://dpla.slack.com/archives/tech/p1456162536000069