### PR TITLE
Add configurable Marmotta read timeout

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,6 +4,8 @@ marmotta:
   ldp: 'http://localhost:8983/marmotta/ldp'
   record_container: 'http://localhost:8983/marmotta/ldp/original_record'
   item_container: 'http://localhost:8983/marmotta/ldp/items'
+  # read_timeout: Seconds to wait for marmotta's HTTP response.
+  read_timeout: 360
 
 elasticsearch:
   host: 'localhost:9200'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,8 @@ marmotta:
   ldp: 'http://localhost:8983/marmotta/ldp'
   record_container: 'http://localhost:8983/marmotta/ldp/original_record'
   item_container: 'http://localhost:8983/marmotta/ldp/items'
+  # read_timeout: Seconds to wait for marmotta's HTTP response.
+  read_timeout: 360
 
 elasticsearch:
   host: 'localhost:9200'

--- a/lib/krikri/engine.rb
+++ b/lib/krikri/engine.rb
@@ -80,7 +80,10 @@ module Krikri
 
     initializer :rdf_repository do
       Krikri::Repository =
-        RDF::Marmotta.new(Krikri::Settings['marmotta']['base'])
+        RDF::Marmotta.new(
+          Krikri::Settings['marmotta']['base'],
+          { read_timeout: Krikri::Settings['marmotta']['read_timeout'] }
+        )
     end
 
     initializer :blacklight_settings do

--- a/spec/krikri_spec.rb
+++ b/spec/krikri_spec.rb
@@ -36,6 +36,11 @@ describe Krikri::Engine do
       expect(Krikri::Settings.api_test).to eq 'app!'
     end
 
+    it 'has its Marmotta read timeout correctly set' do
+      expect(Krikri::Repository.query_client.options[:read_timeout])
+        .to eq(Krikri::Settings['marmotta']['read_timeout'])
+    end
+
     describe '#configure_blacklight!' do
       before do
         @old_solr_config = Blacklight.solr_config


### PR DESCRIPTION
Add a `read_timeout` parameter that governs how long our SPARQL client will wait for Marmotta to respond to HTTP requests.

This is useful for avoiding timeouts of provenance queries.
