### PR TITLE
Entity Consumer Refactor/Deprecation

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -10,15 +10,40 @@ module Krikri
   class Activity < ActiveRecord::Base
     # @!attribute agent
     #    @return [String] a string representing the Krikri::SoftwareAgent
-    #                     responsible for the activity.
+    #      responsible for the activity.
+    # @!attribute start_time
+    #    @return [DateTime] a datestamp marking the activity's start
     # @!attribute end_time
     #    @return [DateTime] a datestamp marking the activity's competion
     # @!attribute opts
     #    @return [JSON] the options to pass to the #agent class when running
-    #                   the activity
-    # @!attribute start_time
-    #    @return [DateTime] a datestamp marking the activity's start
+    #      the activity
+    
     validate :agent_must_be_a_software_agent
+
+    ##
+    # @example building a valid URI from the base
+    #   Krikri::Activity.base_uri / 1
+    #   
+    # @return [RDF::URI] the configured base URI for this class
+    def self.base_uri
+      RDF::URI.intern(Krikri::Settings['marmotta']['ldp']) /
+        Krikri::Settings['prov']['activity']
+    end
+
+    ##
+    # @param uri [#to_s] a uri for this activity
+    #
+    # @return [Krikri::Activity] the activity with the given uri
+    #
+    # @raise [RuntimeError] if the URI form does not match the activity
+    # @raise [ActiveRecord::RecordNotFound] if no activity is found
+    def self.from_uri(uri)
+      raise "Cannot find #{self} from URI: #{uri}" unless 
+        uri.start_with? base_uri
+
+      find(uri.to_s.sub(base_uri.to_s, '').sub('/', ''))
+    end
 
     def agent_must_be_a_software_agent
       errors.add(:agent, 'does not represent a SoftwareAgent') unless
@@ -81,7 +106,9 @@ module Krikri
     def agent_instance
       @agent_instance ||= agent.constantize.new(parsed_opts)
     end
-
+    
+    ##
+    # @return [Hash] the options parsed as JSON
     def parsed_opts
       JSON.parse(opts, symbolize_names: true)
     end
@@ -89,11 +116,9 @@ module Krikri
     ##
     # @return [RDF::URI] the uri for this activity
     def rdf_subject
-      RDF::URI(Krikri::Settings['marmotta']['ldp']) /
-        Krikri::Settings['prov']['activity'] / id.to_s
+      self.class.base_uri / id.to_s
     end
     alias_method :to_term, :rdf_subject
-    
 
     ##
     # @return [String] a string reprerestation of the activity

--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -39,7 +39,8 @@ module Krikri
     # @raise [RuntimeError] if the URI form does not match the activity
     # @raise [ActiveRecord::RecordNotFound] if no activity is found
     def self.from_uri(uri)
-      raise "Cannot find #{self} from URI: #{uri}" unless 
+      raise "Cannot find #{self} from URI: #{uri}; " \
+            "the requested uri does not match #{base_uri}" unless 
         uri.start_with? base_uri
 
       find(uri.to_s.sub(base_uri.to_s, '').sub('/', ''))

--- a/lib/krikri/enricher.rb
+++ b/lib/krikri/enricher.rb
@@ -2,9 +2,8 @@ module Krikri
   ##
   # A SoftwareAgent that runs enrichment processes.
   #
-  # @example
-  #
-  #   To enrich records that were mapped by the mapping activity with ID 3:
+  # @example to enrich records that were mapped by the mapping activity 
+  #   with ID 3:
   #
   #   # Define which enrichments are run, and thier parameters:
   #   chain = {
@@ -43,7 +42,6 @@ module Krikri
     # @see Audumbla::Enrichment
     # @param opts [Hash] a hash of options
     def initialize(opts = {})
-      @generator_uri = RDF::URI(opts.fetch(:generator_uri))
       @chain = deep_sym(opts.fetch(:chain) { {} })
       @entity_behavior = self.class.entity_behavior
       assign_generator_activity!(opts)
@@ -56,8 +54,7 @@ module Krikri
     # instantiation, and apply each enrichment from the enrichment chain.
     #
     def run(activity_uri = nil)
-      mapped_records = generator_activity.entities
-      mapped_records.each do |rec|
+      entities.each do |rec|
         begin
           chain_enrichments!(rec)
           activity_uri ? rec.save_with_provenance(activity_uri) : rec.save

--- a/lib/krikri/entity_behavior.rb
+++ b/lib/krikri/entity_behavior.rb
@@ -1,19 +1,36 @@
 
 module Krikri
   ##
-  # Base class for behaviors related to entities that are generated or revised
-  # by activities.
+  # Base class for retrieval behaviors related to entities that were generated 
+  # or revised by a `Krikri::Activity`.
   #
-  # A SoftwareAgent implements #entity_behavior, which returns an appropriate
-  # subclass of EntityBehavior.  When an Activity is queried for its entities,
-  # it instantiates an instance of its particular SoftwareAgent, and then
-  # calls the #entities method of the agent's entity behavior.
+  # @example implementing an entity behavior
+  #   class CustomBehavior < Krikri::EntityBehavior
+  #     def entities(load = true, include_invalidated = false)
+  #       activity_uris(include_invalidated) do |uri|
+  #         # some behavior over URIs to return initialized entities
+  #       end
+  #     end
+  #   end
+  #
+  # @example retrieving entities with a behavior
+  #   Krikri::Activity.find(activity_id)
+  #   CustomBehavor.entities(activity)
+  #
+  # A `SoftwareAgent` implements `#entity_behavior`, which returns an appropriate
+  # subclass of `EntityBehavior`.  When an Activity is queried for its entities,
+  # it instantiates an instance of its particular `SoftwareAgent`, and then
+  # calls the `#entities` method of the agent's entity behavior.
   #
   # @see Krikri::Activity#entities
   # @see lib/krikri/entity_behaviors
-  #
   class EntityBehavior
+    # @!attribute [r] activity
+    #   @return [Krikri::Activity]
     attr_reader :activity
+
+    ##
+    # @param activity [Krikri::Activity]
     def initialize(activity)
       @activity = activity
     end
@@ -21,20 +38,49 @@ module Krikri
     ##
     # Return an Enumerator of objects that have been affected by our @activity.
     #
-    # @return [Enumerator] objects
+    # @param load [Boolean] `true` to force load the entities from the datastore
+    #   on access
+    # @param include_invalidated [Boolean] `true` to include entities marked as
+    #   invalid.
+    #
+    # @return [Enumerator] the entities. When possible, they should be 
+    #   initialized & retrieved lazily.
+    #   
+    #
     # @see lib/krikri/entity_behaviors
     # @see Krikri::Activity#entities
     #
+    # @see Krikri::LDP::Invalidatable for more about "invalidated" entities
     def entities(*args)
-      raise NotImplementedError 
+      raise NotImplementedError
     end
 
     ##
-    # @see Krikri::Activity#entities
-    # @see Krikri::EntityBehavior#entities
+    # Initializes an instance of this class with the given `Activity` and
+    # returns an enumerator of the associated entities.
     #
+    # @param activity   [Krikri::Activity]
+    # @param load                [Boolean]
+    # @param include_invalidated [Boolean]
+    #
+    # @see Krikri::EntityBehavior#entities
+    # @see Krikri::Activity#entities
     def self.entities(activity, *args)
       new(activity).entities(*args)
+    end
+
+    private
+    
+    ##
+    # Private utility method capturing common logic for applying entity logic to
+    # uris gathered from the instance's `Krikri::Activity`.
+    #
+    # @param include_invalided [Boolean]
+    #
+    # @return [Enumerator::Lazy] the uris, lazily mapped to the behavior in the
+    #   given block
+    def activity_uris(include_invalidated, &block)
+      activity.entity_uris(include_invalidated).lazy.map(&block)
     end
   end
 end

--- a/lib/krikri/entity_behaviors/aggregation_entity_behavior.rb
+++ b/lib/krikri/entity_behaviors/aggregation_entity_behavior.rb
@@ -22,7 +22,7 @@ module Krikri
     # @return [Enumerator] DPLA::MAP::Aggregation objects
     #
     def entities(load = true, include_invalidated = false)
-      @activity.entity_uris(include_invalidated).lazy.map do |uri|
+      activity_uris(include_invalidated) do |uri|
         agg = DPLA::MAP::Aggregation.new(uri)
         agg.get if load
         agg

--- a/lib/krikri/entity_behaviors/original_record_entity_behavior.rb
+++ b/lib/krikri/entity_behaviors/original_record_entity_behavior.rb
@@ -23,7 +23,7 @@ module Krikri
     # @return [Enumerator] OriginalRecord objects
     #
     def entities(load = true, include_invalidated = false)
-      @activity.entity_uris(include_invalidated).lazy.map do |uri|
+      activity_uris(include_invalidated) do |uri|
         load ? OriginalRecord.load(uri) : OriginalRecord.new(uri)
       end
     end

--- a/lib/krikri/entity_consumer.rb
+++ b/lib/krikri/entity_consumer.rb
@@ -1,7 +1,7 @@
 module Krikri
   ##
-  # A mixin for classes, like certain software agents, that generates entities.
-  # For example, a mapper usually generates RDF aggregations, such that
+  # A mixin for classes, like certain `SoftwareAgent`s, that generates entities.
+  # For example, a mapper usually generates `DPLA::MAP::Aggregation`s, such that
   # Mapper::Agent includes EntityConsumer, and a mapper agent is instantiated
   # with
   #   a = Krikri::Mapper::Agent.new({
@@ -32,7 +32,6 @@ module Krikri
     #
     # @see Krikri::Mapper::Agent
     # @see Krikri::Harvester
-    #
     def assign_generator_activity!(opts)
       if opts.include?(:generator_uri)
         generator_uri = opts.delete(:generator_uri)

--- a/lib/krikri/entity_consumer.rb
+++ b/lib/krikri/entity_consumer.rb
@@ -35,12 +35,7 @@ module Krikri
     def assign_generator_activity!(opts)
       if opts.include?(:generator_uri)
         generator_uri = opts.delete(:generator_uri)
-        # allow generator_uri to be string or RDF::URI with `to_s' ...
-        activity_id = generator_uri.to_s[/\d+$/].to_i  # 0 if no match
-        fail "Can not determine ID for #{generator_uri}" if activity_id == 0
-        @generator_activity = Krikri::Activity.find_by_id(activity_id)
-        raise "Generator activity not found for id #{activity_id}" \
-          unless @generator_activity
+        @generator_activity = Krikri::Activity.from_uri(generator_uri)
       end
     end
   end

--- a/lib/krikri/entity_consumer.rb
+++ b/lib/krikri/entity_consumer.rb
@@ -1,15 +1,21 @@
 module Krikri
   ##
-  # A mixin for classes, like certain `SoftwareAgent`s, that generates entities.
-  # For example, a mapper usually generates `DPLA::MAP::Aggregation`s, such that
-  # Mapper::Agent includes EntityConsumer, and a mapper agent is instantiated
-  # with
-  #   a = Krikri::Mapper::Agent.new({
-  #     generator_uri: 'http://some.org/activity/1'
-  #   })
-  # such that
-  #   a.generator_activity
-  # returns a Krikri::Activity
+  # A mixin for `Krikri::SoftwareAgent`s that use entities. Provides a
+  # mechanism for setting an `#entity_source` and consuming entities.
+  #
+  # For backwards compatability, this supports an older interface where entities
+  # are selected based on a `generator_activity`.
+  #
+  # @example the deprecated interface
+  #   class AnAgent
+  #     include Krikri::EntityConsumer
+  #   end
+  #
+  #   agent = AnAgent.new
+  #   agent.assign_generator_activity!(generator_uri:
+  #     Krikri::Activity.find(1).rdf_subject)
+  #
+  #   agent.generator_activity.entities
   #
   module EntityConsumer
     extend ActiveSupport::Concern
@@ -35,8 +41,31 @@ module Krikri
     def assign_generator_activity!(opts)
       if opts.include?(:generator_uri)
         generator_uri = opts.delete(:generator_uri)
-        @generator_activity = Krikri::Activity.from_uri(generator_uri)
+        @entity_source =
+          @generator_activity = Krikri::Activity.from_uri(generator_uri)
       end
+    end
+
+    ##
+    # @return [Enumerator<Krikri::LDP::Resource>] entities this agent will use
+    def entities
+      entity_source ? entity_source.entities : []
+    end
+
+    ##
+    # @return [#entities, nil]
+    def entity_source
+      @entity_source
+    end
+
+    ##
+    # Sets the entity source to a new instance of the provided class,
+    # initialized with the provided arguments and block.
+    #
+    # @param klass [Class] a class with an instance method `#entities`
+    # @return [void]
+    def set_entity_source!(klass, *args, &block)
+      @entity_source = klass.new(*args, &block)
     end
   end
 end

--- a/lib/krikri/indexer.rb
+++ b/lib/krikri/indexer.rb
@@ -2,21 +2,21 @@ module Krikri
   ##
   # A SoftwareAgent to run indexing processes.
   #
-  # @example
-  #
-  #   To index records enriched by the enrichment activity with ID 3:
-  #
+  # @example To index records enriched by the enrichment activity with ID 3:
   #   Krikri::Indexer.enqueue({
   #     index_class: 'Krikri::QASearchIndex',
   #     generator_uri: 'http://ldp.local.dp.la/ldp/activity/3'
   #     some_option_for_index_class: 'abc'
   #   })
   #
-  #   The options hash contains options for the Indexer as well as the
-  #   SearchIndex.
+  # The options hash contains options for the `Indexer` as well as the
+  # `SearchIndex`.
   #
+  # @todo use generalized `EntityConsumer` interface that is independent from
+  #   `Activity`. `#index` needs to be largely rewritten due to 
+  #   `#update_from_activity`, which is tighly bound to `Activity` rather than
+  #   `Enumerator<#entities>`.
   # @see Krikri::SoftwareAgent#enqueue
-  #
   class Indexer
     include SoftwareAgent
     include EntityConsumer

--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -75,35 +75,46 @@ module Krikri
     ##
     # A SoftwareAgent to run mapping processes.
     #
-    # @example
-    #
-    #   To map the records harvested by the harvest activity with ID 1:
-    #
-    #   Krikri::Mapper::Agent.enqueue(
-    #     :mapping,
-    #     opts = {
-    #       name: 'scdl_qdc',
-    #       generator_uri: 'http://ldp.local.dp.la/ldp/activity/1'
-    #     }
-    #   )
+    # @example to map the records harvested by the harvest activity with ID 1:
+    #   Krikri::Mapper::Agent.enqueue(name: :scdl_qdc,
+    #     generator_uri: 'http://ldp.local.dp.la/ldp/activity/1')
     #
     # @see: Krikri::SoftwareAgent, Krikri::Activity
     class Agent
       include SoftwareAgent
       include EntityConsumer
 
+      # @!attribute [r] name
+      #   @return [Symbol]
       attr_reader :name
 
+      ##
+      # @return [Symbol] the default queue for jobs using this agent
       def self.queue_name
         :mapping
       end
 
+      ##
+      # @see Krikri::Activity#entities
+      # @see Krikri::EntityBehavior
+      # @see Krikri::SoftwareAgent#entity_behavior
+      def entity_behavior
+        @entity_behavior ||= Krikri::AggregationEntityBehavior
+      end
+
+      ##
+      # @param opts [Hash]
+      # @option opts [#to_sym] name  the symbol naming the mapping to use
       def initialize(opts = {})
         @name = opts.fetch(:name).to_sym
         @entity_behavior = self.class.entity_behavior
         assign_generator_activity!(opts)
       end
 
+      ##
+      # @param activity_uri [RDF::URI] the uri of the activity to attribute
+      #   for provenance purposes (default: nil)
+      # @see SoftwareAgent#run
       def run(activity_uri = nil)
         harvest_records = generator_activity.entities
         Krikri::Mapper.map(name, harvest_records).each do |rec|
@@ -116,7 +127,6 @@ module Krikri
           end
         end
       end
-
     end
   end
 end

--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -116,8 +116,7 @@ module Krikri
       #   for provenance purposes (default: nil)
       # @see SoftwareAgent#run
       def run(activity_uri = nil)
-        harvest_records = generator_activity.entities
-        Krikri::Mapper.map(name, harvest_records).each do |rec|
+        Krikri::Mapper.map(name, entities).each do |rec|
           begin
             rec.mint_id! if rec.node?
             activity_uri ? rec.save_with_provenance(activity_uri) : rec.save

--- a/lib/krikri/search_index.rb
+++ b/lib/krikri/search_index.rb
@@ -6,6 +6,10 @@ module Krikri
   ##
   # Search index base class that gets extended by QA and Production index
   # classes
+  #
+  # @todo rewrite to use generalized `EntityConsumer` interface & avoid 
+  #   `#update_from_activity`, which is tighly bound to `Activity` rather than
+  #   `Enumerator<#entities>`.
   class SearchIndex
     def initialize(opts)
       @bulk_update_size = opts.delete(:bulk_update_size) { 10 }

--- a/lib/krikri/software_agent.rb
+++ b/lib/krikri/software_agent.rb
@@ -1,13 +1,17 @@
 module Krikri
   ##
-  # SoftwareAgent is a mixin for logic common to code that generates a
-  # `Krikri::Activity`.
+  # SoftwareAgent is a mixin for logic common to classes that carry out the 
+  # work involved in a `Krikri::Activity`. This corresponds to a 
+  # prov:SoftwareAgent within PROV-O & PROV-DM.
   #
   # Software Agents should handle internal errors that do not result in full
   # activity failure, and raise a `RuntimeError` when the job fails. `Activity`
   # handles logging of activity start/stop, and failure status.
   #
+  # Implementers must provide a `#run` method.
+  #
   # @see Krikri::Activity
+  # @see https://www.w3.org/TR/prov-dm/#concept-software-agent
   module SoftwareAgent
     extend ActiveSupport::Concern
 
@@ -30,13 +34,13 @@ module Krikri
 
     ##
     # @abstract Perform this agent's work. The method may accept an
-    #   `activity_uri` to record as the Activity in provenance metadata.
+    #   `activity_uri` to record as the prov:Activity in provenance metadata.
     #   If so, the implementation must be optional and handle `nil` values by
     #   declining to record provenance
     #
     # @return [Boolean] `true` if the run has succeeded; otherwise `false`
     #
-    # @raise [RuntimeError] when the software agent's activity fails
+    # @raise [RuntimeError] when the software agent's process fails
     #
     # @see Krirkri::Activity
     # @see Krikri::Job.run

--- a/spec/lib/krikri/entity_consumer_spec.rb
+++ b/spec/lib/krikri/entity_consumer_spec.rb
@@ -9,10 +9,9 @@ describe Krikri::EntityConsumer do
   end
 
   context 'as a mapper agent' do
-    let(:generator_uri) { 'http://example.org/ldp/activity/2' }
-    let(:opts) do
-      {name: :agent_map, generator_uri: generator_uri}
-    end
+    let(:generator_uri) { Krikri::Activity.base_uri / 2 }
+    let(:opts) { { name: :agent_map, generator_uri: generator_uri } }
+
     let(:mapper_agent) { Krikri::Mapper::Agent.new(opts) }
 
     describe '#assign_generator_activity!' do
@@ -21,7 +20,5 @@ describe Krikri::EntityConsumer do
           .to respond_to(:entities)
       end
     end
-
   end
-
 end

--- a/spec/lib/krikri/entity_consumer_spec.rb
+++ b/spec/lib/krikri/entity_consumer_spec.rb
@@ -1,17 +1,50 @@
 require 'spec_helper'
 
 describe Krikri::EntityConsumer do
-
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)
     create(:krikri_harvest_activity)
     create(:krikri_mapping_activity)
   end
 
-  context 'as a mapper agent' do
-    let(:generator_uri) { Krikri::Activity.base_uri / 2 }
-    let(:opts) { { name: :agent_map, generator_uri: generator_uri } }
+  subject { DummyAgent.new }
+  let(:generator_uri) { Krikri::Activity.base_uri / 2 }
 
+  before  { class DummyAgent; include Krikri::EntityConsumer; end }
+  after   { Object.send(:remove_const, :DummyAgent) }
+
+  describe 'deprecated interface' do
+    it 'sets the activity' do
+      expect { subject.assign_generator_activity!(generator_uri: generator_uri) }
+        .to change { subject.generator_activity }
+             .to Krikri::Activity.from_uri(generator_uri)
+    end
+
+    it 'activity defaults to nil' do
+      expect(subject.generator_activity).to be_nil
+    end
+
+    it 'integrates with new interface' do
+      expect { subject.assign_generator_activity!(generator_uri: generator_uri) }
+        .to change { subject.entity_source }
+             .to Krikri::Activity.from_uri(generator_uri)
+    end
+  end
+
+  describe '#entities' do
+    it 'is empty when no source is available' do
+      expect(subject.entities).to be_empty
+    end
+  end
+
+  describe '#entity_source' do
+    it 'is nil by default' do
+      expect(subject.entities).to be_empty
+    end
+  end
+
+  context 'as a mapper agent' do
+    let(:opts) { { name: :agent_map, generator_uri: generator_uri } }
     let(:mapper_agent) { Krikri::Mapper::Agent.new(opts) }
 
     describe '#assign_generator_activity!' do

--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -4,8 +4,11 @@ describe Krikri::Harvester do
 
   # Our subject is an instance of a dummy class that mixes in
   # Krikri::Harvester.
-  let(:klass) { class DummyHarvester; end; DummyHarvester }
-  subject { klass.include(Krikri::Harvester).new(:uri => 'urn:fake_uri') }
+  before { class DummyHarvester; include(Krikri::Harvester); end }
+  after  { Object.send(:remove_const, :DummyHarvester) }
+
+  let(:klass) { DummyHarvester }
+  subject { klass.new(:uri => 'urn:fake_uri') }
 
   context 'with record_ids implemented' do
     before do

--- a/spec/lib/krikri/indexer_spec.rb
+++ b/spec/lib/krikri/indexer_spec.rb
@@ -8,15 +8,16 @@ describe Krikri::Indexer do
 
   subject { described_class.new(opts) }
 
-  enrichment_gen_uri_str = 'http://example.org/ldp/activity/5'
-  behaves_opts = { generator_uri: enrichment_gen_uri_str,
+  enrichment_gen_uri = Krikri::Activity.base_uri / 5
+
+  behaves_opts = { generator_uri: enrichment_gen_uri,
                    index_class:   'Krikri::QASearchIndex' }
 
   it_behaves_like 'a software agent', behaves_opts
   
   # See mapper_agent_spec.rb regarding :opts and behaves_opts...
   let(:opts) do
-    { generator_uri: enrichment_gen_uri_str,
+    { generator_uri: enrichment_gen_uri,
       index_class:   index_class.to_s }
   end
 

--- a/spec/lib/krikri/mapper_agent_spec.rb
+++ b/spec/lib/krikri/mapper_agent_spec.rb
@@ -7,11 +7,11 @@ describe Krikri::Mapper::Agent do
     create(:krikri_harvest_activity)
   end
 
-  harvest_gen_uri_str = 'http://example.org/ldp/activity/2'
-  mapping_gen_uri_str = 'http://example.org/ldp/activity/3'
+  harvest_gen_uri = Krikri::Activity.base_uri / 2
+  mapping_gen_uri = Krikri::Activity.base_uri / 3
 
   # This must be defined with `let' as a macro.  See below.
-  let(:opts) { {name: :agent_map, generator_uri: harvest_gen_uri_str} }
+  let(:opts) { { name: :agent_map, generator_uri: harvest_gen_uri } }
 
   # This can not be a macro, because it has to be passed as an argument to
   # `it_behaves_like', which is interpreted at compile time.  It should be the
@@ -25,7 +25,7 @@ describe Krikri::Mapper::Agent do
   # macro), then `subject' will not instantiate an object with the same options
   # when it's invoked repeatedly.
   # 
-  behaves_opts = {name: :agent_map, generator_uri: harvest_gen_uri_str}
+  behaves_opts = {name: :agent_map, generator_uri: harvest_gen_uri}
   it_behaves_like 'a software agent', behaves_opts
 
   subject { described_class.new(opts) }
@@ -35,10 +35,10 @@ describe Krikri::Mapper::Agent do
   # generator_uri matches what Krikri::Activity will construct as the
   # uri, given its value of #rdf_subject, in #aggregations_as_json
   # See 'provenance queries' shared context.  
-  let(:generator_uri) { harvest_gen_uri_str }
+  let(:generator_uri) { harvest_gen_uri }
 
   # activity_uri is the URI of the mapping activity
-  let(:activity_uri) { mapping_gen_uri_str }
+  let(:activity_uri) { mapping_gen_uri }
 
   let(:mapping_name) { :agent_map }
   let(:opts) { { name: mapping_name, generator_uri: generator_uri } }
@@ -85,9 +85,10 @@ describe Krikri::Mapper::Agent do
 
     context 'with mapped records returned' do
       before do
-        expect(Krikri::Mapper).to receive(:map)
-                                   .with(mapping_name, subject.generator_activity.entities)
-                                   .and_return(generated_records)
+        expect(Krikri::Mapper)
+          .to receive(:map)
+               .with(mapping_name, subject.generator_activity.entities)
+               .and_return(generated_records)
       end
 
       it 'calls mapper' do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -14,6 +14,36 @@ end
 describe Krikri::Activity, type: :model do
   subject { create(:krikri_activity) }
 
+  describe `.base_uri` do
+    it 'returns an RDF::URI' do
+      expect(described_class.base_uri).to be_a RDF::URI
+    end
+  end
+
+  describe `.from_uri` do
+    it 'initializes from RDF::URI' do
+      expect(described_class.from_uri(subject.rdf_subject)).to eq subject
+    end
+
+    it 'initializes from string containing uri' do
+      expect(described_class.from_uri(subject.rdf_subject.to_s)).to eq subject
+    end
+
+    it 'raises error for inapproprate uri' do
+      bad_uri = "http://example.com/nonsense/#{subject.id}"
+
+      expect { described_class.from_uri(bad_uri) }
+        .to raise_error "Cannot find #{described_class} from URI: #{bad_uri}"
+    end
+
+    it 'raises error for wrong id' do
+      bad_uri = subject.rdf_subject.to_s.gsub(subject.id.to_s, '1001')
+
+      expect { described_class.from_uri(bad_uri) }
+        .to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
   describe '#save' do
     subject { build(:krikri_activity_with_long_opts) }
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -33,7 +33,9 @@ describe Krikri::Activity, type: :model do
       bad_uri = "http://example.com/nonsense/#{subject.id}"
 
       expect { described_class.from_uri(bad_uri) }
-        .to raise_error "Cannot find #{described_class} from URI: #{bad_uri}"
+        .to raise_error "Cannot find #{described_class} from " \
+                        "URI: #{bad_uri}; the requested uri does not match " \
+                        "#{described_class.base_uri}"
     end
 
     it 'raises error for wrong id' do

--- a/spec/support/shared_examples/software_agent.rb
+++ b/spec/support/shared_examples/software_agent.rb
@@ -1,6 +1,6 @@
 
 shared_examples 'a software agent' do |args|
-  subject { described_class.new(args) }
+  subject { args.nil? ? described_class.new : described_class.new(args) }
   let(:agent_class) { described_class }
 
   it 'represents its agent name as the correct string, as a class' do


### PR DESCRIPTION
Refactors `EntityConsumer` to respond to `#entities` and to accept a generalized entity_source.  For the moment, it retains the previous generator activity behavior as a deprecated interface, to continue to serve the index classes, which are tightly coupled to `Activity`. `Mapper::Agent` and `Enricher` are refactored to use the new interface.

Moves activity URI lookup to `Activity` & exposes more public interfaces for working with activity URIs; Refactors `EntityConsumer` to rely on this logic, instead of using a coarse string based matcher.

Tests and docs are fixed up throughout.