### PR TITLE
Feature/entity behavior refactor

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -127,14 +127,14 @@ module Krikri
     # that have been affected by this activity.
     #
     # The kind of object that is returned depends on the EntityBehavior class
-    # that is associated with the SoftwareAgent that is represented by the
+    # that is associated with the SoftwareAgent class that is represented by the
     # Activity's `agent' field.
     #
     # @param [Array<Object>] *args Arguments to pass along to
     #                              EntityBehavior#entities
     # @return [Enumerator] Objects
     def entities(*args)
-      agent_instance.entity_behavior.entities(self, *args)
+      agent.constantize.entity_behavior.entities(self, *args)
     end
   end
 end

--- a/lib/krikri/enricher.rb
+++ b/lib/krikri/enricher.rb
@@ -34,14 +34,6 @@ module Krikri
     end
 
     ##
-    # @see Krikri::Activity#entities
-    # @see Krikri::EntityBehavior
-    # @see Krikri::SoftwareAgent#entity_behavior
-    def entity_behavior
-      @entity_behavior ||= Krikri::AggregationEntityBehavior
-    end
-
-    ##
     # Create a new Enricher, given a hash of options:
     #   generator_uri:  the LDP URI of the Activity that generated the mapped
     #      records that this one will enrich.
@@ -53,6 +45,7 @@ module Krikri
     def initialize(opts = {})
       @generator_uri = RDF::URI(opts.fetch(:generator_uri))
       @chain = deep_sym(opts.fetch(:chain) { {} })
+      @entity_behavior = self.class.entity_behavior
       assign_generator_activity!(opts)
     end
 

--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -47,11 +47,9 @@ module Krikri
     end
 
     ##
-    # @see Krikri::Activity#entities
-    # @see Krikri::EntityBehavior
-    # @see Krikri::SoftwareAgent#entity_behavior
-    def entity_behavior
-      @entity_behavior ||= Krikri::OriginalRecordEntityBehavior
+    # @see Krikri::SoftwareAgent::ClassMethods#entity_behavior
+    def self.entity_behavior
+      Krikri::OriginalRecordEntityBehavior
     end
 
     ##
@@ -79,6 +77,7 @@ module Krikri
       @harvest_behavior = opts.delete(:harvest_behavior) do
         Krikri::Harvesters::BasicSaveBehavior
       end.to_s.constantize
+      @entity_behavior = self.class.entity_behavior
     end
 
     delegate :process_record, :to => :@harvest_behavior

--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -98,16 +98,9 @@ module Krikri
         :mapping
       end
 
-      ##
-      # @see Krikri::Activity#entities
-      # @see Krikri::EntityBehavior
-      # @see Krikri::SoftwareAgent#entity_behavior
-      def entity_behavior
-        @entity_behavior ||= Krikri::AggregationEntityBehavior
-      end
-
       def initialize(opts = {})
         @name = opts.fetch(:name).to_sym
+        @entity_behavior = self.class.entity_behavior
         assign_generator_activity!(opts)
       end
 

--- a/lib/krikri/software_agent.rb
+++ b/lib/krikri/software_agent.rb
@@ -11,20 +11,12 @@ module Krikri
   module SoftwareAgent
     extend ActiveSupport::Concern
 
-    included do
-      attr_writer :entity_behavior
-    end
-
     ##
-    # Return the EntityBehavior associated with the SoftwareAgent.
-    # Meant to be overridden as necessary.
-    #
-    # @see Krikri::Activity#entities
-    # @see Krikri::EntityBehavior
-    #
-    def entity_behavior
-      @entity_behavior ||= nil
-    end
+    # @!attribute [rw] entity_behavior
+    #   @return [Krikri::EntityBehavior] the entity initialization behavior to  use with this 
+    #     SoftwareAgent.
+    #   @see Krikri::Activity#entities
+    included { attr_accessor :entity_behavior }
 
     ##
     # Return an agent name suitable for saving in an Activity.
@@ -59,6 +51,14 @@ module Krikri
       # @return a string representation of this SoftwareAgent class
       def agent_name
         to_s
+      end
+
+      ##
+      # @return [Krikri::EntityBehavior] the default entity initializiation 
+      #   behavior for this class of SoftwareAgents
+      # @see #entity_behavior
+      def entity_behavior
+        Krikri::AggregationEntityBehavior
       end
 
       ##


### PR DESCRIPTION
Refactors EntityBehavior & SoftwareAgent to use a default entity_behavior at the class level. Sets @entity_behavior on initialization to avoid `||=` in the accessor method.

Since `Krikri::Activity` never alters the `SoftwareAgent`'s entity behavior after initialization, there's no need to initialize it at all. Instead, we simply use the default `EntityBehavior` for the `SoftwareAgent` class.