### PR TITLE
Add Smithsonian parser

### DIFF
--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -20,5 +20,5 @@ module Krikri
            'krikri/entity_behaviors/aggregation_entity_behavior'
   autoload :OriginalRecordEntityBehavior,
            'krikri/entity_behaviors/original_record_entity_behavior'
-
+  autoload :SmithsonianParser,    'krikri/parsers/smithsonian_parser'
 end

--- a/lib/krikri/parsers/smithsonian_parser.rb
+++ b/lib/krikri/parsers/smithsonian_parser.rb
@@ -1,0 +1,13 @@
+module Krikri
+  ##
+  # A parser for the Smithsonian XML format. Uses XML parser with a root path to match the
+  # metadata path.
+  # @see Krikri::XmlParser
+  class SmithsonianParser < XmlParser
+    include Krikri::OaiParserHeaders
+
+    def initialize(record, root_path = '//doc', ns = {})
+      super(record, root_path, ns)
+    end
+  end
+end


### PR DESCRIPTION
This commit got lost along the way, but belongs with the pull request for the Smithsonian mapping: https://github.com/dpla/heidrun-mappings/pull/37