### PR TITLE
Fix definition of Krikri::Harvester.entity_behavior

### DIFF
--- a/lib/krikri/harvester.rb
+++ b/lib/krikri/harvester.rb
@@ -43,13 +43,13 @@ module Krikri
         def queue_name
           :harvest
         end
-      end
-    end
 
-    ##
-    # @see Krikri::SoftwareAgent::ClassMethods#entity_behavior
-    def self.entity_behavior
-      Krikri::OriginalRecordEntityBehavior
+        ##
+        # @see Krikri::SoftwareAgent::ClassMethods#entity_behavior
+        def entity_behavior
+          Krikri::OriginalRecordEntityBehavior
+        end
+      end
     end
 
     ##

--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -31,6 +31,12 @@ describe Krikri::Harvester do
     end
   end
 
+  describe '.entity_behavior' do
+    it 'knows its entity behavior' do
+      expect(klass.entity_behavior).to eq(Krikri::OriginalRecordEntityBehavior)
+    end
+  end
+
   describe '#record_ids' do
     it { expect { subject.record_ids }.to raise_error NotImplementedError }
   end


### PR DESCRIPTION
Move the definition of `Krikri::Harvester.entity_behavior` to the `included` block, because `Harvester` is a mixin.

Add a test to ensure that a class mixing in Harvester receives `Krikri::OriginalRecordEntityBehavior` from a call to `.entity_behavior`.