### PR TITLE
Fix harvester_spec.rb test with wrong expect subject

### DIFF
--- a/spec/lib/krikri/harvester_spec.rb
+++ b/spec/lib/krikri/harvester_spec.rb
@@ -36,7 +36,8 @@ describe Krikri::Harvester do
 
   describe '.entity_behavior' do
     it 'knows its entity behavior' do
-      expect(klass.entity_behavior).to eq(Krikri::OriginalRecordEntityBehavior)
+      expect(subject.class.entity_behavior)
+        .to eq(Krikri::OriginalRecordEntityBehavior)
     end
   end
 


### PR DESCRIPTION
In Harvester spec, fix ".entity_behavior knows its entity_behavior" to expect `subject.entity_behavior` instead of `klass.entity_behavior`.

That should normally fail, because `klass` should not be expected to have `include`d `Krikri::Harvester` yet.  Depending on the order in which the specs were run, the issue was being masked, because the spec was operating on a `klass` that had had `Harvester` included by an earlier spec.