### PR TITLE
Feature/count query

### DIFF
--- a/app/models/krikri/activity.rb
+++ b/app/models/krikri/activity.rb
@@ -102,6 +102,13 @@ module Krikri
     end
 
     ##
+    # @return [Integer] count of entities changed by this activity
+    def entity_count(include_invalidated = false)
+      Krikri::ProvenanceQueryClient
+        .count_by_activity(self.to_term, include_invalidated)
+    end
+
+    ##
     # Return an Enumerator of URI strings of entities (e.g. aggregations or
     # original records) that pertain to this activity
     #
@@ -114,9 +121,8 @@ module Krikri
     #   invalidation.
     #
     def entity_uris(include_invalidated = false)
-      activity_uri = RDF::URI(rdf_subject)  # This activity's LDP URI
       query = Krikri::ProvenanceQueryClient
-        .find_by_activity(activity_uri, include_invalidated)
+        .find_by_activity(self.to_term, include_invalidated)
       query.each_solution.lazy.map do |s|
         s.record.to_s
       end

--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -11,15 +11,14 @@ module Krikri
     # given.
     #
     # @param activity_uri [#to_uri] the URI of the activity to search
-    #
     # @param include_invalidated [Boolean]  Whether to include entities that
     #   have been invalidated with <http://www.w3.org/ns/prov#invalidatedAtTime>
     #
-    # @see https://www.w3.org/TR/prov-o/#invalidatedAtTime
-    # @see Krikri::LDP::Invalidatable
-    #
     # @return [RDF::SPARQL::Query] a query object that, when executed, will
     #   give solutions containing the URIs for the resources in `#record`.
+    #
+    # @see https://www.w3.org/TR/prov-o/#invalidatedAtTime
+    # @see Krikri::LDP::Invalidatable
     def find_by_activity(activity_uri, include_invalidated = false)
       raise ArgumentError, 'activity_uri must be an RDF::URI' unless
         activity_uri.respond_to? :to_term
@@ -28,30 +27,22 @@ module Krikri
                 [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy],
                 activity_uri.to_term])
 
-      if include_invalidated
-        query
-      else
-        # We need to say "and if RDF::PROV.invalidatedAtTime is not set."
-        #
-        # The SPARQL query should be:
-        #
-        # PREFIX prov: <http://www.w3.org/ns/prov#>
-        # SELECT * WHERE {
-        #   ?subject prov:wasGeneratedBy  <http://xampl.org/ldp/activity/n> .
-        #   FILTER NOT EXISTS { ?subject prov:invalidatedAtTime ?x }
-        # }
-        #
-        # ... However there doesn't appear to be a way of constructing
-        # 'FILTER NOT EXISTS' with SPARQL::Client.  Instead, we've managed to
-        # hack the following solution together.
-        #
-        # SPARQL::Client#filter is labeled @private in its YARD comment (and
-        # has no other documentation) but it's not private, at least for
-        # now.
-        query.filter \
-          'NOT EXISTS ' \
-          '{ ?record <http://www.w3.org/ns/prov#invalidatedAtTime> ?x }'
-      end
+      return query if include_invalidated
+
+      # When `include_invalidated` is false, we need to say "and if 
+      # RDF::PROV.invalidatedAtTime is not set."
+      #
+      # The SPARQL query should be:
+      #
+      # ```
+      #   PREFIX prov: <http://www.w3.org/ns/prov#>
+      #   SELECT * WHERE {
+      #     ?subject prov:wasGeneratedBy  <http://xampl.org/ldp/activity/n> .
+      #     FILTER NOT EXISTS { ?subject prov:invalidatedAtTime ?x }
+      #   }
+      # ```
+      query.filter 'NOT EXISTS ' \
+                   "{ ?record #{RDF::PROV.invalidatedAtTime.to_base} ?x }"
     end
   end
 end

--- a/lib/krikri/provenance_query_client.rb
+++ b/lib/krikri/provenance_query_client.rb
@@ -10,39 +10,87 @@ module Krikri
     # Finds all entities generated or revised by the activity whose URI is
     # given.
     #
-    # @param activity_uri [#to_uri] the URI of the activity to search
+    # @param activity [#to_term] the URI of the activity to search
     # @param include_invalidated [Boolean]  Whether to include entities that
     #   have been invalidated with <http://www.w3.org/ns/prov#invalidatedAtTime>
     #
-    # @return [RDF::SPARQL::Query] a query object that, when executed, will
+    # @return [SPARQL::Client::Query] a query object that, when executed, will
     #   give solutions containing the URIs for the resources in `#record`.
+    #
+    # @example 
+    #   query = Krikri::ProvenanceQueryClient.find_by_activity(activity_uri)
+    #   uris = query.solutions.map(&:record)
+    #
+    # @see SPARQL::Client::Query for details on how to use a query
     #
     # @see https://www.w3.org/TR/prov-o/#invalidatedAtTime
     # @see Krikri::LDP::Invalidatable
-    def find_by_activity(activity_uri, include_invalidated = false)
-      raise ArgumentError, 'activity_uri must be an RDF::URI' unless
-        activity_uri.respond_to? :to_term
-      query = SPARQL_CLIENT.select(:record)
-        .where([:record,
-                [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy],
-                activity_uri.to_term])
+    def find_by_activity(activity, include_invalidated = false)
+      validate_activity!(activity)
+      query = SPARQL_CLIENT.select(:record).where(pattern_for(activity))
 
-      return query if include_invalidated
+      include_invalidated ? query : add_invalidated_filter(query)
+    end
 
-      # When `include_invalidated` is false, we need to say "and if 
-      # RDF::PROV.invalidatedAtTime is not set."
-      #
-      # The SPARQL query should be:
-      #
-      # ```
-      #   PREFIX prov: <http://www.w3.org/ns/prov#>
-      #   SELECT * WHERE {
-      #     ?subject prov:wasGeneratedBy  <http://xampl.org/ldp/activity/n> .
-      #     FILTER NOT EXISTS { ?subject prov:invalidatedAtTime ?x }
-      #   }
-      # ```
+    ##
+    # @param activity [#to_term] the URI of the activity to search
+    # @param include_invalidated [Boolean]  Whether to include entities that
+    #   have been invalidated with <http://www.w3.org/ns/prov#invalidatedAtTime>
+    #
+    # @return [Integer] the count of distinct matches
+    def count_by_activity(activity, include_invalidated = false)
+      validate_activity!(activity)
+      query = SPARQL_CLIENT.select(:ct, count: { record: :ct })
+              .where(pattern_for(activity))
+
+      query = include_invalidated ? query : add_invalidated_filter(query)
+      query.solutions.first[:ct].object
+    end
+
+    ##
+    # Adds a filter, removing results with a `prov:invalidedAtTime`.
+    #
+    # @param query [SPARQL::Client::Query]
+    # @return [SPARQL::Client::Query] the original query with an added filter
+    #
+    # We need to say "and if RDF::PROV.invalidatedAtTime is not set."
+    #
+    # The SPARQL query should be:
+    #
+    # ```
+    #   PREFIX prov: <http://www.w3.org/ns/prov#>
+    #   SELECT * WHERE {
+    #     ?subject prov:wasGeneratedBy  <http://xampl.org/ldp/activity/n> .
+    #     FILTER NOT EXISTS { ?subject prov:invalidatedAtTime ?x }
+    #   }
+    # ```
+    # 
+    # @note this assumes that the query originated from this module's query 
+    #   generators
+    def add_invalidated_filter(query)
       query.filter 'NOT EXISTS ' \
                    "{ ?record #{RDF::PROV.invalidatedAtTime.to_base} ?x }"
+    end
+
+    private
+
+    ##
+    # @param activity_uri [Object]
+    # @return [void]
+    # @raise [ArgumentError] unless `activity_uri` is an `RDF::Term`
+    def self.validate_activity!(activity_uri)
+      raise ArgumentError, 'activity_uri must be an RDF::URI' unless
+        activity_uri.respond_to? :to_term
+    end
+
+    ##
+    # @param activity [#to_term]
+    # @return [Array] an array representing an RDF::Query::Pattern for the 
+    #   given activity
+    def self.pattern_for(activity)
+      [:record, 
+       [RDF::PROV.wasGeneratedBy, '|', RDF::DPLA.wasRevisedBy], 
+       activity.to_term]
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -167,6 +167,17 @@ describe Krikri::Activity, type: :model do
     end
   end
 
+  describe '#entity_count' do
+    include_context 'provenance queries'
+    include_context 'entities query'
+
+    let(:generator_uri) { subject.to_term }
+
+    it 'gives a record count' do
+      expect(subject.entity_count).to eq 1
+    end
+  end
+
   describe '#entity_uris' do
     include_context 'provenance queries'
     include_context 'entities query'
@@ -175,7 +186,7 @@ describe Krikri::Activity, type: :model do
     # generator_uri matches what Krikri::Activity will construct as the
     # uri, given its value of #rdf_subject, in #aggregations_as_json
     # See 'provenance queries' shared context.  
-    let(:generator_uri) { subject.rdf_subject }
+    let(:generator_uri) { subject.to_term }
 
     it 'requests validated records by default' do
       expect(Krikri::ProvenanceQueryClient)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ Rails.backtrace_cleaner.remove_silencers!
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-WebMock.disable_net_connect!(:allow_localhost => true)
+WebMock.disable_net_connect!(:allow_localhost => true, allow: 'codeclimate.com')
 
 RSpec.configure do |config|
   config.color = true
@@ -62,6 +62,5 @@ RSpec.configure do |config|
   config.after(:suite) do
     clear_repository
     clear_search_index
-    WebMock.disable_net_connect!(:allow => 'codeclimate.com')
   end
 end

--- a/spec/support/shared_contexts/provenance_query_client.rb
+++ b/spec/support/shared_contexts/provenance_query_client.rb
@@ -6,20 +6,24 @@
 #   - generator_uri [String] URI that corresponds to the ID of your activity
 #
 shared_context 'provenance queries' do
-  let(:query) { double('RDF::Query') }
-  let(:solution) { double('RDF::Query::Solution') }
-  let(:solution_enum) do
-    Enumerator.new do |e|
-      e.yield solution
-    end
-  end
-  let(:uri) { double('result uri') }
+  let(:uri)           { double('result uri') }
+  let(:query)         { double('RDF::Query') }
+  let(:solution)      { double('RDF::Query::Solution') }
+  let(:solution_enum) { Enumerator.new { |e| e.yield solution } }
 
   before do
+    # query and solution mocks
+    allow(query).to    receive(:execute).and_return([solution])
+    allow(query).to    receive(:solutions).and_return(solution_enum)
+    allow(query).to    receive(:each_solution).and_return(solution_enum)
+    allow(solution).to receive(:record).and_return(uri)
+
+    # find by activity query
     allow(Krikri::ProvenanceQueryClient).to receive(:find_by_activity)
       .with(RDF::URI(generator_uri), false).and_return(query)
-    allow(query).to receive(:execute).and_return([solution])
-    allow(query).to receive(:each_solution).and_return(solution_enum)
-    allow(solution).to receive(:record).and_return(uri)
+
+    # count by activity query
+    allow(Krikri::ProvenanceQueryClient).to receive(:count_by_activity)
+      .with(RDF::URI(generator_uri), false).and_return(1)
   end
 end


### PR DESCRIPTION
Adds support for `ProvenanceQueryClient#count_by_activity` using
SPARQL's `COUNT` functionality. Refactors `ProvenanceQueryClient`
significantly in the process.

`Krikri::Activity` gets an `#entity_count` method, which is much faster
in practice than `#entity_uris.count`. This allows optimized counting on
the server side, instead of returning an entire result set and iterating
through the `RDF::Query::Solutions`.

Note: this commit is WIP. The pending test on `#count_by_activity` is
critical, but fails on H2 when the `|` operator is used in the
predicate. This is being pushed up to track the WIP, but needs testing
in a more production like environment before it can be merged. It may be
that we'll need to report a bug on Marmotta and leave the test marked as
pending, for the moment.

__I intend to deploy this to staging after check-in tomorrow (3/9) to test the 
pending example with the real database backend. The generated query 
works against the production system, but not in testing; I want to isolate H2
as a possible cause.__