### PR TITLE
Remove Solr docs more carefully in test suite

### DIFF
--- a/spec/lib/krikri/indexer_spec.rb
+++ b/spec/lib/krikri/indexer_spec.rb
@@ -13,7 +13,9 @@ describe Krikri::Indexer do
   behaves_opts = { generator_uri: enrichment_gen_uri,
                    index_class:   'Krikri::QASearchIndex' }
 
-  it_behaves_like 'a software agent', behaves_opts
+  it_behaves_like 'a software agent', behaves_opts do
+    after { clear_search_index }
+  end
   
   # See mapper_agent_spec.rb regarding :opts and behaves_opts...
   let(:opts) do

--- a/spec/lib/krikri/search_index_spec.rb
+++ b/spec/lib/krikri/search_index_spec.rb
@@ -133,8 +133,6 @@ describe Krikri::QASearchIndex do
       let(:aggregation) { build(:aggregation) }
 
       before do
-        subject.delete_by_query('id:*')
-        subject.commit
         aggregation.set_subject!('http://api.dp.la/item/123')
         aggregation.provider << build(:krikri_provider, rdf_subject: 'snork')
           .agent
@@ -142,10 +140,7 @@ describe Krikri::QASearchIndex do
         subject.commit
       end
 
-      after do
-        subject.delete_by_query('id:*')
-        subject.commit
-      end
+      after { clear_search_index }
 
       it 'posts DPLA MAP JSON to solr' do
         response = solr.get('select', :params => { :q => '' })['response']
@@ -165,6 +160,8 @@ describe Krikri::QASearchIndex do
   describe '#update_from_activity' do
     include_context 'provenance queries'
     include_context 'entities query'
+    
+    after { clear_search_index }
 
     # This is not totally realistic because we're indexing the records from a
     # mapping activity, instead of an enrichment activity, but we can change

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -21,15 +21,12 @@ describe Krikri::Provider do
 
   shared_context 'indexed in Solr' do
     before do
-      clear_search_index
       indexer = Krikri::QASearchIndex.new
       indexer.add agg.to_jsonld['@graph'].first
       indexer.commit
     end
 
-    after do
-      clear_search_index
-    end
+    after { clear_search_index }
   end
 
   shared_context 'bnode indexed in Solr' do
@@ -39,11 +36,7 @@ describe Krikri::Provider do
       indexer.commit
     end
 
-    after do
-      indexer = Krikri::QASearchIndex.new
-      indexer.delete_by_query(['*:*'])
-      indexer.commit
-    end
+    after { clear_search_index }
   end
 
   describe '#initialize' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ Rails.backtrace_cleaner.remove_silencers!
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-WebMock.disable_net_connect!(:allow_localhost => true)
+WebMock.disable_net_connect!(:allow_localhost => true, allow: 'codeclimate.com')
 
 RSpec.configure do |config|
   config.color = true
@@ -62,6 +62,5 @@ RSpec.configure do |config|
   config.after(:suite) do
     clear_repository
     clear_search_index
-    WebMock.disable_net_connect!(:allow => 'codeclimate.com')
   end
 end

--- a/spec/support/shared_contexts/indexed_item.rb
+++ b/spec/support/shared_contexts/indexed_item.rb
@@ -8,9 +8,7 @@ shared_context 'with indexed item' do
     indexer.commit
   end
 
-  after do
-    clear_search_index
-  end
+  after { clear_search_index }
 
   let(:records) { [agg] }
 


### PR DESCRIPTION
The particular issue was in the specs for
`Krikri::QASearchIndex#update_from_activity`. These got left behind,
some tests had apparently compensated for this by cleaning up in
`before`. That behavior is removed, to make it easier to catch issues
like this in the future.

Also normalizes solr index cleanup on the `clear_search_index` helper. I
think this was added after some of these specs were written, and some of
them never got migrated.