### PR TITLE
Handle EDTF Intervals

### DIFF
--- a/lib/krikri/util/extended_date_parser.rb
+++ b/lib/krikri/util/extended_date_parser.rb
@@ -87,7 +87,20 @@ module Krikri::Util
       run = str.gsub!(/.*c[irca\.]*/i, '')
       run ||= str.gsub!(/.*about/i, '')
       date = parse(str) if run
-      date.nil? ? nil : date.uncertain!
+
+      return nil if date.nil?
+
+      # The EDTF grammar does not support uncertainty on masked precision dates
+      if date.respond_to? :uncertain!
+        date.uncertain!
+      elsif date.is_a? EDTF::Interval
+        # Interval uncertainty is scoped to the begin and end dates;
+        # to be safe, we mark both.
+        date.from = date.from.uncertain! if date.from.respond_to? :uncertain!
+        date.to   = date.to.uncertain!   if date.to.respond_to? :uncertain!
+      end
+
+      date
     end
 
     ##

--- a/spec/lib/krikri/util/extended_date_parser_spec.rb
+++ b/spec/lib/krikri/util/extended_date_parser_spec.rb
@@ -21,6 +21,7 @@ describe Krikri::Util::ExtendedDateParser do
                  '1992.12',
                  '1992?',
                  'circa 1992',
+                 'circa 1992/1993',
                  'ca 1992',
                  'c 1992',
                  'ca. 1992',
@@ -44,13 +45,19 @@ describe Krikri::Util::ExtendedDateParser do
     date_forms.each do |str|
       it "parses #{str} to timespan" do
         result = subject.parse(str)
-        if result.is_a? EDTF::Decade
+        if result.is_a? EDTF::Interval
+          expect(result.from).to eq Date.edtf('1992-01-01')
+            .send("#{result.from.precision}_precision".to_sym)
+          expect(result.to).to eq Date.edtf('1993-12-01')
+            .send("#{result.to.precision}_precision".to_sym)
+        elsif result.is_a? EDTF::Decade
           expect(result).to eq Date.edtf('199x')
         elsif result.is_a? EDTF::Century
           expect(result).to eq Date.edtf('19xx')
         else
           expect(result).to eq Date.edtf('1992-12-01')
             .send("#{result.precision}_precision".to_sym)
+
         end
       end
     end


### PR DESCRIPTION
Intervals do not have their own precision, but instead rely on the precision of their begin and end date/time. This fixes a `NoMethodError` on `EDTF::Interval#uncertain!` and adds coarse handling for interval uncertainty.