### PR TITLE
Add support for "inline exceptions"

### DIFF
--- a/lib/krikri/async_uri_getter.rb
+++ b/lib/krikri/async_uri_getter.rb
@@ -51,6 +51,8 @@ module Krikri
     #   redirects.
     # @option opts [Integer] :max_redirects Number of redirects to follow before
     #   giving up. (default: 10)
+    # @option opts [Boolean] :inline_exceptions If true, pass exceptions as a
+    #   5xx response with the exception string in the body. (default: false)
     def initialize(opts: {})
       @default_opts = { max_redirects: MAX_REDIRECTS }.merge(opts)
     end
@@ -80,15 +82,40 @@ module Krikri
       # Wait for the request thread to complete
       def join
         @request_thread.join
+      rescue => e
+        # If the join throws an exception, the thread is dead anyway.  The
+        # subsequent call to `with_response` will propagate the exception to the
+        # calling thread.
+        raise e unless inline_exceptions?
       end
 
       ##
       # @yield [Faraday::Response] the response returned for the request
       def with_response
         yield @request_thread.value
+      rescue => e
+        if inline_exceptions?
+          # Deliver an error response to the caller to allow uniform access
+          msg = e.message + "\n\n" + e.backtrace.join("\n")
+          yield Faraday::Response.new(status: 500,
+                                      body: msg,
+                                      response_headers: {
+                                        'X-Exception' => e,
+                                        'X-Exception-Message' => e.message,
+                                        'X-Internal-Response' => 'true'
+                                      })
+        else
+          raise e
+        end
       end
 
       private
+
+      ##
+      # True if we are using inline exceptions
+      def inline_exceptions?
+        opts.fetch(:inline_exceptions, false)
+      end
 
       ##
       # Run the Faraday request in a new thread

--- a/spec/lib/krikri/async_uri_getter_spec.rb
+++ b/spec/lib/krikri/async_uri_getter_spec.rb
@@ -92,15 +92,39 @@ describe Krikri::AsyncUriGetter do
         .to_raise(Faraday::ConnectionFailed)
     end
 
-    it 'propagates exceptions to the calling thread when #join is called' do
-      r = subject.add_request(uri: test_uri)
-      expect { r.join }.to raise_error(Faraday::ConnectionFailed)
+    context 'without inline exceptions' do
+      it 'propagates exceptions to the calling thread when #join is called' do
+        r = subject.add_request(uri: test_uri)
+        expect { r.join }.to raise_error(Faraday::ConnectionFailed)
+      end
+
+      it 'propagates exceptions when the response is requested' do
+        r = subject.add_request(uri: test_uri)
+        expect { r.with_response { |_| } }
+          .to raise_error(Faraday::ConnectionFailed)
+      end
     end
 
-    it 'propagates exceptions when the response is requested' do
-      r = subject.add_request(uri: test_uri)
-      expect { r.with_response { |_| } }
-        .to raise_error(Faraday::ConnectionFailed)
+    context 'with inline exceptions' do
+      subject { described_class.new(opts: { inline_exceptions: true }) }
+
+      it 'does not throw an exception when #join is called' do
+        r = subject.add_request(uri: test_uri)
+        expect { r.join }.to_not raise_error
+      end
+
+      it 'passes the exception as a 5xx HTTP response' do
+        r = subject.add_request(uri: test_uri)
+        r.with_response do |response|
+          expect(response.status).to eq(500)
+          expect(response.body).to include('Exception')
+
+          headers = response.headers
+          expect(headers.keys).to include('X-Internal-Response')
+          expect(headers.keys).to include('X-Exception-Message')
+          expect(headers['X-Exception']).to be_kind_of(Exception)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If this option is set to true, connection-level errors (like
CONNREFUSED, socket timeouts, etc.) will be delivered to the
caller as HTTP 5xx responses.

-----
The context to this is https://github.com/dpla/heidrun/pull/38, where for the IA harvester we want to ignore connection refused/timeout exceptions and just skip over the affected records.

The IA harvester already skips records when it gets back a 5xx error response, so we really just want it to do the same thing for exceptions caused by connection errors.  It seemed a shame to complicate the harvester code with a bunch of exception handling--especially when future harvesters will likely want the same thing--so I added the option for "inline exceptions" to give the caller the option of handling all types of errors in a uniform way.

The change is backward compatible, so existing harvests shouldn't be affected.  If this looks OK I'll update the IA harvester to use the new option, and then all should be good in the world.