### PR TITLE
Only inline exceptions stemming from Faraday

### DIFF
--- a/spec/lib/krikri/async_uri_getter_spec.rb
+++ b/spec/lib/krikri/async_uri_getter_spec.rb
@@ -127,4 +127,15 @@ describe Krikri::AsyncUriGetter do
       end
     end
   end
+
+  context 'inline exceptions' do
+    subject { described_class.new(opts: { inline_exceptions: true }) }
+
+    it 'does not interfere with exceptions thrown by with_response' do
+      r = subject.add_request(uri: test_uri)
+      expect do
+        r.with_response { |_| raise "Programming error!" }
+      end.to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Previously an exception thrown in the body of a `with_request` block
would be caught and propagated as an inline exception.  This can be
quite confusing when your `with_request` block is suddenly being called
twice!

Added a test to catch this case too.

-----
Only too late do I realize I should have called this branch "inline-exception-inception".  Damn. 