### PR TITLE
Make language code matching case insensitive

### DIFF
--- a/lib/krikri/enrichments/language_to_lexvo.rb
+++ b/lib/krikri/enrichments/language_to_lexvo.rb
@@ -125,7 +125,7 @@ module Krikri::Enrichments
     # @param code [#to_sym] a three letter iso code
     # @return [DPLA::MAP::Controlled::Language]
     def match_iso(code)
-      match = QNAMES.find { |c| c == code.to_sym }
+      match = QNAMES.find { |c| c == code.downcase.to_sym }
       from_sym(match)
     end
 

--- a/spec/lib/krikri/enrichments/language_to_lexvo_spec.rb
+++ b/spec/lib/krikri/enrichments/language_to_lexvo_spec.rb
@@ -142,6 +142,11 @@ describe Krikri::Enrichments::LanguageToLexvo do
       expect(subject.match_iso('eng').rdf_subject)
         .to eq english
     end
+
+    it 'finds 3 letter ISO codes case insensitively' do
+      expect(subject.match_iso('Eng').rdf_subject)
+        .to eq english
+    end
   end
 
   describe '#match_label' do


### PR DESCRIPTION
`LanguageToLexvo` now matches three-letter language codes independent of case.