### PR TITLE
Remove guard dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ gem 'yajl-ruby', require: 'yajl'
 gem 'database_cleaner', '~> 1.3.0', require: false
 
 group :development do
-  gem 'guard'
-  gem 'guard-rspec', require: false
   gem 'pry-rescue'
 end
 


### PR DESCRIPTION
Guard has stopped supporting Ruby 2.1. I'm removing the dependency, pending an upgrade on our end.

See:
https://github.com/guard/guard#important-ruby-21-is-officially-outdated-and-unsupported-please-upgrade-to-ruby-23-or-225-before-installing-guard