### PR TITLE
Add array index access; mimics `Array#at`

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -213,6 +213,14 @@ module Krikri
       end
 
       ##
+      # @param idx [#to_i, Range]
+      # @return [ValueArray] an array containing the node(s) in the 
+      #   specified index posiition(s).
+      def at(idx)
+        self.class.new(Array(@array[idx]))
+      end
+
+      ##
       # Accesses a given field. Use multiple arguments to travel down the node
       # hierarchy.
       #

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -39,6 +39,25 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#at' do
+    it 'returns a ValueArray' do
+      expect(subject.at(0)).to be_a described_class
+    end
+
+    it 'returns the correct nodes' do
+      expect(subject.at(0)).to contain_exactly values[0]
+    end
+
+    it 'returns the correct nodes with range' do
+      range = 0..-2
+      expect(subject.at(range)).to contain_exactly(*values[range])
+    end
+
+    it 'returns empty when out of bounds' do
+      expect(subject.at(10_000)).to be_empty
+    end
+  end
+
   shared_context 'with fields' do
     before do
       values.each do |val|


### PR DESCRIPTION
Allows index and range access on `Krikri::Parser::ValueArray` objects, maintaining method chaining.