### PR TITLE
Add `#compact` to mapping DSL

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -315,6 +315,12 @@ module Krikri
         self.class.new([@array.last].compact, @top)
       end
 
+      ##
+      # @see Array#compact
+      # @return [ValueArray]
+      def compact
+        self.class.new(@array.compact, @top)
+      end
 
       ##
       # @see Array#concat

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -262,6 +262,18 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#compact' do
+    before { values << nil }
+
+    it 'removes nil values' do
+      expect(subject.compact).not_to include nil
+    end
+
+    it 'returns an instance of its class' do
+      expect(subject.concat(subject)).to be_a described_class
+    end
+  end
+
   describe '#concat' do
     it 'gives union of two arrays' do
       vals = subject.to_a.dup


### PR DESCRIPTION
Makes it possible to squash out `nil` values in value array with `#compact`.