### PR TITLE
Feature/dsl backtrack

### DIFF
--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -105,15 +105,38 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#and' do
+    include_context 'with fields'
+
+    before do 
+      values.each { |val| allow(val).to receive(:attribute?).and_return(false) }
+    end
+
+    it 'returns top by default' do
+      expect(subject.field(:field_name).and)
+        .to equal subject.bindings[:top]
+    end
+
+    it 'returns bound variable if values are present' do
+      expect(subject.field(:field_name).bind(:bound)
+              .field(:nested_name).and(from: :bound))
+        .to equal subject.bindings[:bound]
+    end
+
+    it 'raises ArgumentError for unbound variables' do
+      expect { subject.and(from: :unbound) }.to raise_error ArgumentError
+    end
+  end
+
   describe '#bind' do
     include_context 'with fields'
 
     it 'returns self' do
-      expect(subject.bind(:moomin)).to eq subject
+      expect(subject.bind(:moomin)).to equal subject
     end
 
     it 'binds the variable' do
-      expect(subject.bind(:moomin).bindings[:moomin]).to eq subject
+      expect(subject.bind(:moomin).bindings[:moomin]).to equal subject
     end
   end
 

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -105,12 +105,27 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#bind' do
+    include_context 'with fields'
+
+    it 'returns self' do
+      expect(subject.bind(:moomin)).to eq subject
+    end
+
+    it 'binds the variable' do
+      expect(subject.bind(:moomin).bindings[:moomin]).to eq subject
+    end
+  end
 
   describe '#if' do
     include_context 'with fields'
 
-    it 'returns self with top set' do
+    it 'returns self' do
       expect(subject.if).to eq subject
+    end
+
+    it 'returns with top set' do
+      expect(subject.if.bindings[:top]).to eq subject
     end
 
     context 'with block given' do
@@ -147,7 +162,7 @@ describe Krikri::Parser::ValueArray do
     end
 
     context 'with #if' do
-      it 'recovers from @top set by #if' do
+      it 'recovers from `top` set by #if' do
         expect(
           subject.field(:field_name).if.field(:nonexistent_field).else do |rec|
             rec.field(:nested_name)


### PR DESCRIPTION
Allows binding arbitrary points in the tree to variables for later
recall. Initially supports an `#and(from: :var)` construction which
recalls the variable if the current node is empty.

This is similar to `#if`/`#else` but with more flexibility.

----

Refactors existing `#if`/`#else` and other `:top` calls to use the more general underlying interface.

----

Note that the underlying `bindings` hash is shared between the many `ValueArray` nodes in a given call chain, so patterns like `record.field(:field).bind(:subject).field(:nested).bind(:subject_label).reject { |_| true }.and(from: :subject)` will leave `:subject_label` bound in the result. I.e. further conditions could result in returning to the label.

----

Closes https://issues.dp.la/issues/8184