### PR TITLE
Refactor & Document MappingDSL #to_procs

### DIFF
--- a/lib/krikri/mapping_dsl/child_declaration.rb
+++ b/lib/krikri/mapping_dsl/child_declaration.rb
@@ -1,37 +1,101 @@
 module Krikri::MappingDSL
   ##
-  # Returns a proc that can be run to add values for the property to
-  # Passes value(s) through a block, if given.
-  # @return [Proc] a proc that can be used to generate a value for the named
-  # property.
+  # Specifies a mapping between a property and one or more child nodes.
+  #
+  # The child node is built by processing a sub-mapping, generating an object 
+  # that can be set to the property. 
+  #
+  # Multiple sub-mappings can be processed with, the `:each` and `:as` options. 
+  # When given, the sub-mapping is run once for each value given to `:each`, with
+  # the variable `:as` passed to.
+  # 
+  # @example a basic declaration
+  #   class Book; attr_accessor :author; end
+  #   class Agent; attr_accessor :name, :locale; end
+  #
+  #   dec = Krikri::MappingDSL::ChildDeclaration.new(:author, Agent) do
+  #     name   'Moomin'
+  #     locale 'Moomin Valley'
+  #   end
+  #
+  #   book = Book.new
+  #   dec.to_proc.call(book, nil) # nil stands in for a record.
+  #   book.author
+  #   # => #<Agent:0x0055654f5d5138 @locale="Moomin Valley", @name="Moomin">
+  #
+  # @example an :each/:as declaration
+  #   class Book; attr_accessor :author; end
+  #   class Agent; attr_accessor :name, :locale; end
+  #
+  #   dec = Krikri::MappingDSL::ChildDeclaration.new(:author, Agent,
+  #       each: ['Moomin', 'Snuffkin'], as: :agent_name) do
+  #     name    agent_name
+  #     locale 'Moomin Valley'
+  #   end
+  #
+  #   book = Book.new.tap { |b| b.author = [] }
+  #   dec.to_proc.call(book, nil)
+  #   book.author
+  #   # => [#<Agent:0x0055654f405808
+  #   #   @locale="Moomin Valley",
+  #   #   @name="Moomin">,
+  #   #  #<Agent:0x0055654f4040c0
+  #   #   @locale="Moomin Valley",
+  #   #   @name="Snuffkin">]
+  #
+  # @see PropertyDeclaration for more information about how values that respond 
+  #   to `#call` are processed.
   class ChildDeclaration < PropertyDeclaration
+    ##
+    # @param name [Symbol]  a symbol representing the property to set the child
+    #   node(s) to.
+    # @param  target_class [#call, Object] the class to use when building child 
+    #   mappings. Values set through a ChildDeclartaion will be instances of 
+    #   this class
+    #
+    # @param  opts [Hash]
+    # @option opts [#call, Enumerable] :each  the values to bind to 
+    # @option opts [Symbol] :as  the "variable" to bind the values of `:each`
+    #   to within the child Mapping's scope
     def initialize(name, target_class, opts = {}, &block)
-      @name = name
+      @name         = name
       @target_class = target_class
-      @block = block
-      @each = opts.delete(:each)
-      @as = opts.delete(:as)
+      @block        = block
+      @each         = opts.delete(:each)
+      @as           = opts.delete(:as)
     end
 
+    ##
+    # Returns a proc that can be run to create one or more child node as 
+    # instances of the `target_class`. Each node is evaluated as a sub-mapping
+    # with the block given. The values of `:each` are available within the 
+    # block's scope.
+    #
+    # @return [Proc] a callable proc that evaluates the sub-mappings
     def to_proc
-      block = @block if @block
+      block        = @block
       target_class = @target_class
-      each_val = @each
-      as_sym = @as
+      each_val     = @each
+      as_sym       = @as
+      
       lambda do |target, record|
+        # if `@each` is set, iterate through its values and process the mapping for each.
+        # this results in a different child record/node for each value in `@each`.
         if each_val
           iter = each_val.respond_to?(:call) ? each_val.call(record) : each_val
           iter.each do |value|
             map = ::Krikri::Mapping.new(target_class)
+
+            # define as_sym on only this instance
             map.define_singleton_method(as_sym) do
-              each_val.dup.select do |v|
-                v = v.value if v.respond_to? :value
-                v == value 
-              end
+              value.respond_to?(:value) ? value.value : value
             end
+
             map.instance_eval(&block)
             target.send(name) << map.process_record(record)
           end
+        # else, process a single child mapping over a single instance of 
+        # `target_class`
         else
           map = ::Krikri::Mapping.new(target_class)
           map.instance_eval(&block)

--- a/lib/krikri/mapping_dsl/property_declaration.rb
+++ b/lib/krikri/mapping_dsl/property_declaration.rb
@@ -3,15 +3,52 @@ module Krikri::MappingDSL
   # Specifies a mapping between a property name and its mapped value(s).
   # Deals with static properties (given a specific value or values), and
   # dynamic properties (where values are modified by a block).
+  #
+  # @example a basic declaration
+  #   class Book; attr_accessor :author; end
+  #
+  #   dec = Krikri::MappingDSL::PropertyDeclaration.new(:author, 
+  #     ['Moomin', 'Snuffkin'])
+  #
+  #   book = Book.new
+  #   dec.to_proc.call(book, nil) # nil stands in for a record.
+  #   
+  #   book.author # => ['Moomin', 'Snuffkin']
+  #
+  #
+  # @example a declaration with a callable value
+  #   class Book; attr_accessor :author; end
+  #
+  #   values = lambda { |_| ['Moomin', 'Snuffkin'] }
+  #   dec = Krikri::MappingDSL::PropertyDeclaration.new(:author, values)
+  #
+  #   book = Book.new
+  #   dec.to_proc.call(book, nil) # nil stands in for a record.
+  #   
+  #   book.author # => ['Moomin', 'Snuffkin']
+  #   
   class PropertyDeclaration
     attr_reader :name, :value
 
+    ##
+    # Initializes a declaration with a given name and value. `value` may 
+    # respond to `#call`, which will be called with a record to generate the
+    # values.
+    #
+    # @param name  [Symbol]
+    # @param value [#call, Object] 
+    # @param _opts [Hash] A hash of options for for the declaration. default: {}
+    #
+    # @raise ArgumentError  when a block with arity other than 1 is passed
     def initialize(name, value, _opts = {}, &block)
       if block_given?
-        raise 'Block must have arity of 1 to be applied to property' unless
-          block.arity == 1
+        unless block.arity == 1
+          raise(ArgumentError, 
+                'Block must have arity of 1 to be applied to property')
+        end
         @block = block
       end
+
       @name = name
       @value = value
     end
@@ -24,13 +61,15 @@ module Krikri::MappingDSL
     # OriginalRecord as an argument to determine the value.
     #
     # @return [Proc] a proc that can be used to generate a value for the named
-    # property.
+    #   property.
     def to_proc
-      block = @block if @block
+      block = @block
       value = @value
+      
       lambda do |target, record|
         value = value.call(record) if value.respond_to? :call
         return target.send(setter, value) unless block
+
         if value.is_a? Enumerable
           values = value.map { |v| instance_exec(v, &block) }
           target.send(setter, values)
@@ -42,6 +81,8 @@ module Krikri::MappingDSL
 
     private
 
+    ##
+    # @return [Symbol] A symbol for the setter method; e.g. `:name=`
     def setter
       "#{@name}=".to_sym
     end

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -13,16 +13,22 @@ describe Krikri::Mapper do
             providedLabel record.field('dc:creator')
           end
 
-          contributor :class => DPLA::MAP::Agent, :each => record.field('dc:creator').map { |v| v.value }, :as => :ident do
+          contributor :class => DPLA::MAP::Agent,
+                      :each => record.field('dc:creator'),
+                      :as => :ident do
             providedLabel ident
           end
 
-          spatial :class => DPLA::MAP::Place, :each => ['nyc', 'bos', 'pdx'], :as => :place do
+          spatial :class => DPLA::MAP::Place,
+                  :each => %w('nyc bos pdx'),
+                  :as => :place do
             providedLabel place
           end
         end
 
-        provider :class => DPLA::MAP::Agent, :each => header.field('xmlns:identifier'), :as => :ident do
+        provider :class => DPLA::MAP::Agent,
+                 :each => header.field('xmlns:identifier'),
+                 :as => :ident do
           providedLabel ident
         end
       end
@@ -38,11 +44,12 @@ describe Krikri::Mapper do
 
       expect(mapped.sourceResource.first.contributor.first.providedLabel)
         .to contain_exactly record.root['dc:creator'].first.value
-      expect(mapped.sourceResource.first.contributor.map(&:providedLabel).flatten)
+      expect(mapped.sourceResource.first
+              .contributor.map(&:providedLabel).flatten)
         .to eq record.root['dc:creator'].to_a.map(&:value)
 
       expect(mapped.sourceResource.first.spatial.map(&:providedLabel).flatten)
-        .to eq ['nyc', 'bos', 'pdx']
+        .to eq %w('nyc bos pdx')
 
       expect(mapped.sourceResource.first.identifier)
         .to eq Array(record.header.first['xmlns:identifier'].first.value)
@@ -76,7 +83,7 @@ describe Krikri::Mapper do
     end
 
     it 'passes parser_args to mapping' do
-      args = [1,2,3]
+      args = [1, 2, 3]
       expect(Krikri::Mapping).to receive(:new)
         .with(DPLA::MAP::Aggregation, Krikri::XmlParser, *args).once
       Krikri::Mapper.define(:klass_map, parser_args: args)
@@ -126,7 +133,7 @@ describe Krikri::Mapper do
         before do
           records.each do |rec|
             expect(mapping).to receive(:process_record).with(rec)
-                                .and_return(:mapped_record).ordered
+              .and_return(:mapped_record).ordered
           end
         end
 
@@ -142,7 +149,7 @@ describe Krikri::Mapper do
 
           records.each do |rec|
             allow(mapping).to receive(:process_record).with(rec)
-                               .and_raise(StandardError.new)
+              .and_raise(StandardError.new)
           end
         end
 

--- a/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
@@ -2,51 +2,52 @@ describe Krikri::MappingDSL::ChildDeclaration do
   include_context 'mapping dsl'
   it_behaves_like 'a named property'
   subject { described_class.new(:my_property, klass) {} }
-  let(:klass) { double }
 
-  let(:target) { double }
-  let(:mapping) { double }
+  let(:klass)   { double('class') }
+  let(:target)  { double('target') }
+  let(:record)  { double('record') }
+  let(:mapping) { instance_double('Krikri::Mapping') }
 
-  before do
-    allow(::Krikri::Mapping).to receive(:new).and_return(mapping)
-  end
+  before { allow(::Krikri::Mapping).to receive(:new).and_return(mapping) }
 
   describe '#to_proc' do
     before do
-      allow(mapping).to receive(:process_record).with('').and_return(:value)
+      allow(mapping).to receive(:process_record).with(record).and_return(value)
     end
 
+    let(:value) { double('value') }
+
     it 'sets value of property to result of process_record' do
-      expect(target).to receive(:my_property=).with(:value)
-      subject.to_proc.call(target, '')
+      expect(target).to receive(:my_property=).with(value)
+      subject.to_proc.call(target, record)
     end
   end
 
   context 'with each/as declarations' do
-    subject { described_class.new(:my_property, klass, opts) {  } }
-    let(:opts) { { :each => record_proxy, :as => :my_val } }
-    let(:record_proxy) { double }
-    let(:record_proxy_dup) { double }
-    let(:values) { [:a, :b, :c] }
+    subject { described_class.new(:my_property, klass, opts) {} }
+
+    let(:opts)         { { :each => record_proxy, :as => :my_val } }
+    let(:values)       { [:a, :b, :c] }
+    let(:record_proxy) { double('record proxy') }
 
     before do
       allow(target).to receive(:my_property).and_return(double)
       allow(record_proxy).to receive(:call).and_return(values)
-      allow(record_proxy).to receive(:dup).and_return(record_proxy_dup)
-      allow(record_proxy_dup).to receive(:select).and_return(values.first)
-      allow(mapping).to receive(:process_record).with('').and_return(values.first)
+
+      allow(mapping).to receive(:process_record).with(record)
+        .and_return(*values)
     end
 
     it 'sets values of property to results of process_record' do
-      expect(target.my_property).to receive(:<<).with(values.first)
-        .exactly(3).times
-      subject.to_proc.call(target, '')
+      values.each { |v| expect(target.my_property).to receive(:<<).with(v) }
+      subject.to_proc.call(target, record)
     end
 
-    it 'defines DSL method for access to individual value' do
-      allow(target.my_property).to receive(:<<).with(values.first)
-      subject.to_proc.call(target, '')
-      expect(mapping.my_val).to eq values.first
+    it 'defines DSL method for access to individual value in mapping scope' do
+      values.each { |v| allow(target.my_property).to receive(:<<).with(v) }
+
+      subject.to_proc.call(target, record)
+      expect(mapping.my_val).to eq values.last
     end
   end
 end


### PR DESCRIPTION
MappingDSL Declarations were somewhat messy and under-documented, particularly the `#to_proc` methods. This refactors slightly, removing some undue complexity. It also documents the Declaration classes much more thoroughly.

The second commit satisfies rubocop about the related integration tests in `mapper_spec.rb`.