### PR TITLE
Force Nokogiri security upgrade

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "analysand", "4.0.0"
   s.add_dependency "yajl-ruby"
   s.add_dependency "elasticsearch", "~>0.4.0"
+  s.add_dependency "nokogiri", ">=1.6.8"
 
   ##
   # FIXME on Rails 4.2 upgrade: pin bootstrap-sass to 3.3.4.1


### PR DESCRIPTION
Nokogiri had security vulnerabilities in versions `>= 1.6.0`, `< 1.6.8`. Since Blacklight requires `~> 1.6`, it seems good to force engine users to use `1.6.8` or greater.

Our production instance upgraded in a deployment some time ago.