### PR TITLE
Map providedLabel in TimeSpan

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -176,7 +176,12 @@ module Krikri
       def build_time_span(source)
         return unless source.is_a? DPLA::MAP::TimeSpan
         date = {}
+
         set_value(date, :displayDate, source.prefLabel, true, &:as_json)
+        set_value(date, :displayDate,
+                  source.providedLabel, true, &:as_json) unless
+          date.has_key?(:displayDate)
+
         set_value(date, :begin, source.begin, true, &:as_json)
         set_value(date, :end, source.end, true, &:as_json)
 

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -132,15 +132,32 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
 
       context 'with timespan containing prefLabel' do
         before do
-          aggregation.sourceResource.first.date.first.prefLabel = prefLabel
-          subject.build
+          aggregation.sourceResource.first.
+            date.first.providedLabel = providedLabel
         end
-
-        let(:prefLabel) { '1969' }
+        
+        let(:providedLabel) { '1968' }
 
         it 'has a displayDate' do
+          subject.build
+
           expect(subject.hash[:sourceResource][:date].first[:displayDate])
-            .to eq prefLabel
+            .to eq providedLabel
+        end
+
+        context 'with prefLabel' do
+          before do 
+            aggregation.sourceResource.first.date.first.prefLabel = prefLabel
+          end
+
+          let(:prefLabel) { '1969' }
+
+          it 'uses prefLabel as displayDate' do
+            subject.build
+          
+            expect(subject.hash[:sourceResource][:date].first[:displayDate])
+              .to eq prefLabel
+          end
         end
       end
       


### PR DESCRIPTION
TimeSpan mappings in the DPLA MAP v3.1 crosswalk need to map labels aggressively. If no label is given, the frontend won't display a date. This maps `prefLabel` with preference, but uses `providedLabel` as a backup.

Closes https://issues.dp.la/issues/8457.