### PR TITLE
Add TimespanLabel enrichment

### DIFF
--- a/lib/krikri/enrichments/timespan_label.rb
+++ b/lib/krikri/enrichments/timespan_label.rb
@@ -1,0 +1,48 @@
+module Krikri::Enrichments
+  ##
+  # Builds and sets a `prefLabel` based on existing begin/end dates within an 
+  # `edm:TimeSpan`.
+  #
+  # @example
+  #   date = DPLA::MAP::TimeSpan.new.tap do |t| 
+  #     t.begin = Date.today
+  #     t.end = (Date.today + 1)
+  #   end
+  #
+  #   TimespanLabel.new.enrich_value(date).prefLabel
+  #   # => ["2016-07-08/2016-07-09"]
+  #
+  class TimespanLabel
+    include Audumbla::FieldEnrichment
+
+    ##
+    # Add a prefLabel for `DPLA::MAP::TimeSpan` objects with begin/end dates
+    #
+    # @param value [DPLA::MAP::TimeSpan, String, Object]
+    #
+    # @return [DPLA::MAP::TimeSpan, Object] a new `TimeSpan` object containing
+    #   the generated prefLabel
+    def enrich_value(value)
+      set_label(value) if value.is_a?(DPLA::MAP::TimeSpan) && 
+                          value.prefLabel.empty?
+      value
+    end
+
+    private
+
+    ##
+    # @param  [DPLA::MAP::TimeSpan]
+    # @return [void] 
+    def set_label(value)
+      start  = value.begin.sort.first
+      finish = value.end.sort.last
+
+      if start.nil? || finish.nil? || (start == finish)
+        date            = start || finish
+        value.prefLabel = date.to_s if date
+      else
+        value.prefLabel = EDTF::Interval.new(start, finish).to_s
+      end
+    end
+  end
+end

--- a/spec/lib/krikri/enrichments/timespan_label_spec.rb
+++ b/spec/lib/krikri/enrichments/timespan_label_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe Krikri::Enrichments::TimespanLabel do
+  it_behaves_like 'a field enrichment'
+
+  context 'with a non-timespan object' do
+    it 'returns value' do
+      val = RDF::Node.new
+      expect(subject.enrich_value(val)).to be val
+    end
+  end
+
+  context 'with timespan object' do
+    let(:timespan) do
+      build(:timespan, prefLabel: label, begin: begin_date, end: end_date)
+    end
+
+    let(:label)      { nil }
+    let(:begin_date) { nil }
+    let(:end_date)   { nil }
+
+    context 'with no properties' do
+      it 'does nothing' do
+        statements = timespan.statements.to_a
+
+        expect(subject.enrich_value(timespan).statements)
+          .to contain_exactly(*statements)
+      end
+    end
+
+    context 'with label' do
+      let(:label) { '199x - 2018' }
+      let(:begin_date) { Date.parse('1000-01-01') }
+      let(:end_date)   { Date.parse('1001-01-01') }
+
+      it 'does nothing' do
+        expect(subject.enrich_value(timespan).prefLabel)
+          .to contain_exactly(label)
+      end
+    end
+    
+    context 'with begin date' do
+      let(:begin_date) { Date.parse('1000-01-01') }
+      
+      it 'assigns label to begin date' do
+        expect(subject.enrich_value(timespan).prefLabel)
+          .to contain_exactly(begin_date.to_s)
+      end
+    end
+
+    context 'with end date' do
+      let(:end_date) { Date.parse('1001-01-01') }
+      
+      it 'assigns label to begin date' do
+        expect(subject.enrich_value(timespan).prefLabel)
+          .to contain_exactly(end_date.to_s)
+      end
+    end
+
+    context 'with begin and end dates' do
+      let(:begin_date) { Date.parse('1000-01-01') }
+      let(:end_date)   { Date.parse('1001-01-01') }
+      
+      it 'assigns label to begin date' do
+        expect(subject.enrich_value(timespan).prefLabel)
+          .to contain_exactly("#{begin_date}/#{end_date}")
+      end
+      
+      context 'and dates are the same' do
+        let(:begin_date) { Date.parse('1000-01-01') }
+        let(:end_date)   { begin_date }
+
+        it 'assigns label to just begin date' do
+          expect(subject.enrich_value(timespan).prefLabel)
+            .to contain_exactly(begin_date.to_s)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new enrichment sets a `prefLabel` based on existing begin/end dates
within a TimeSpan.

Does nothing if:

  - a `prefLabel` is already present
  - neither a begin, nor end date is given