### PR TITLE
Clean up dependencies

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -20,26 +20,26 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.1.6"
-  s.add_dependency "rails_config", "~>0.4.0"
-  s.add_dependency "audumbla", '~> 0.1'
-  s.add_dependency "rdf-turtle", "~>1.1.8"
-  s.add_dependency "rdf", "~> 1.1.13"
-  s.add_dependency "dpla-map", "4.0.0.0.pre.13"
-  s.add_dependency "rest-client"
-  s.add_dependency "rdf-marmotta", '>= 0.0.6'
-  s.add_dependency "blacklight", "~>5.8.0"
-  s.add_dependency "therubyracer"
-  s.add_dependency "edtf"
-  s.add_dependency "text"
-  s.add_dependency "oai", '~>0.4.0'
-  s.add_dependency "jsonpath"
-  s.add_dependency "devise", "~>3.4.1"
-  s.add_dependency "resque", "~>1.0"
-  s.add_dependency "analysand", "4.0.0"
-  s.add_dependency "yajl-ruby"
-  s.add_dependency "elasticsearch", "~>0.4.0"
-  s.add_dependency "nokogiri", ">=1.6.8"
+  s.add_dependency "rails",         '~>4.1.6'
+  s.add_dependency "rails_config",  '0.4.2'
+  s.add_dependency "audumbla",      '~>0.1'
+  s.add_dependency "rdf-turtle",    '~>1.1.8'
+  s.add_dependency "rdf",           '~>1.1.13'
+  s.add_dependency "dpla-map",      '4.0.0.0.pre.13'
+  s.add_dependency "rest-client",   '~>1.8'
+  s.add_dependency "rdf-marmotta",  '~>0.0', '>=0.0.6'
+  s.add_dependency "blacklight",    '~>5.8.0'
+  s.add_dependency "therubyracer",  '~>0.12'
+  s.add_dependency "edtf",          '~>2.3'
+  s.add_dependency "text",          '~>1.3'
+  s.add_dependency "oai",           '~>0.4'
+  s.add_dependency "jsonpath",      '~>0.5'
+  s.add_dependency "devise",        '~>3.4', '>=3.4.1'
+  s.add_dependency "resque",        '~>1.0'
+  s.add_dependency "analysand",     '4.0.0'
+  s.add_dependency "yajl-ruby",     '~>1.2'
+  s.add_dependency "elasticsearch", '~>0.4'
+  s.add_dependency "nokogiri",      '~>1.6', '>=1.6.8'
 
   ##
   # FIXME on Rails 4.2 upgrade: pin bootstrap-sass to 3.3.4.1
@@ -55,12 +55,12 @@ Gem::Specification.new do |s|
   # properly.
   s.add_dependency "bootstrap-sass", "3.3.4.1"
 
-  s.add_development_dependency 'krikri-spec', '~> 0.0'
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails", '~> 3.3'
-  s.add_development_dependency 'webmock'
-  s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
-  s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'timecop'
+  s.add_development_dependency 'krikri-spec',        '~>0.0'
+  s.add_development_dependency "sqlite3",            '~>0.0'
+  s.add_development_dependency "jettywrapper",       '~>2.0'
+  s.add_development_dependency "rspec-rails",        '~>3.3'
+  s.add_development_dependency 'webmock',            '~>2.1'
+  s.add_development_dependency 'factory_girl_rails', '~>4.4'
+  s.add_development_dependency 'pry-rails',          '~>0.0'
+  s.add_development_dependency 'timecop',            '~>0.8'
 end


### PR DESCRIPTION
Some of the dependencies were sloppily specified, this cleans them up to
be a bit more precise. Some versions are given, where none were
specified before. Others are loosened up to depend on a major version,
but with a minimum version specified (e.g. from '~>0.0.6' to '~>0.0',
'>=0.0.6').

Blacklight is left alone, since I'm pretty sure we can't trust minor
versions to be free upgrades.