### PR TITLE
Upgrade EDTF to 3.0

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rdf-marmotta", '>= 0.0.6'
   s.add_dependency "blacklight", "~>5.8.0"
   s.add_dependency "therubyracer"
-  s.add_dependency "edtf"
+  s.add_dependency "edtf", '~> 3.0'
   s.add_dependency "text"
   s.add_dependency "oai", '~>0.4.0'
   s.add_dependency "jsonpath"


### PR DESCRIPTION
Upgrades the `edtf` gem and locks to the most recent major version.

The new version was released over the weekend. 