### PR TITLE
Mapping DSL match/reject based on child node.

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -449,6 +449,15 @@ module Krikri
       end
 
       ##
+      # @param *children [Array<String>]
+      #
+      # @return [ValueArray] an array containing nodes for which the specified
+      #   attribute does not have a child node matching the given child name
+      def match_child(*children)
+        select { |v| !(v.children & children).empty? }
+      end
+
+      ##
       # @param name [#to_sym] an attribute name
       # @param other [Object] an object to check for equality with the
       #   values from the given attribute.
@@ -463,6 +472,15 @@ module Krikri
       #   #select.
       def reject_attribute(name, other = nil, &block)
         reject(&compare_to_attribute(name, other, &block))
+      end
+
+      ##
+      # @param *children [Array<String>]
+      #
+      # @return [ValueArray] an array containing nodes for which the specified
+      #   attribute does not have a childnode matching the given child name
+      def reject_child(*children)
+        reject { |v| !(v.children & children).empty? }
       end
 
       ##

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -424,4 +424,60 @@ describe Krikri::Parser::ValueArray do
         .to contain_exactly(values[1], values[2])
     end
   end
+
+  describe '#match_child' do
+    let(:child_nodes) { ['first:child', 'second:child']}
+    
+    before do
+      values.each do |val| 
+        allow(val).to receive(:children).and_return(child_nodes)
+      end
+    end
+
+    it 'selects nodes with matching children' do
+      expect(subject.match_child('first:child'))
+        .to contain_exactly(*subject.to_a)
+
+      expect(subject.match_child('second:child'))
+        .to contain_exactly(*subject.to_a)
+    end
+    
+    it 'passes over nodes without matching children' do
+      expect(subject.match_child('not_a_child')).to be_empty
+    end
+
+    it 'matches nodes only when children match' do
+      allow(subject.first).to receive(:children).and_return(['new_child'])
+      
+      expect(subject.match_child('new_child'))
+        .to contain_exactly(subject.first)
+    end
+  end
+
+  describe '#reject_child' do
+    let(:child_nodes) { ['first:child', 'second:child']}
+    
+    before do
+      values.each do |val| 
+        allow(val).to receive(:children).and_return(child_nodes)
+      end
+    end
+
+    it 'passes over nodes without matching children' do
+      expect(subject.reject_child('not_a_child'))
+        .to contain_exactly(*subject.to_a)
+    end
+    
+    it 'rejects nodes when children match' do
+      expect(subject.reject_child('first:child')).to  be_empty
+      expect(subject.reject_child('second:child')).to be_empty
+    end
+
+    it 'rejects nodes only when children match' do
+      allow(subject.first).to receive(:children).and_return(['new_child'])
+      
+      expect(subject.reject_child('new_child'))
+        .to contain_exactly(*subject.to_a[1..-1])
+    end
+  end
 end


### PR DESCRIPTION
Introduces a syntax for matching or rejecting nodes based on the
presence of a child node.

For instance:

    record.field('mods:subject').reject_child('mods:hierarchicalGeographic')

Closes https://issues.dp.la/issues/8207