### PR TITLE
Fix RSpec warning on `raise_error`

### DIFF
--- a/spec/lib/krikri/async_uri_getter_spec.rb
+++ b/spec/lib/krikri/async_uri_getter_spec.rb
@@ -132,10 +132,13 @@ describe Krikri::AsyncUriGetter do
     subject { described_class.new(opts: { inline_exceptions: true }) }
 
     it 'does not interfere with exceptions thrown by with_response' do
+      stub_request(:get, test_uri).to_return(status: 200, body: 'OK')
+
       r = subject.add_request(uri: test_uri)
+
       expect do
         r.with_response { |_| raise "Programming error!" }
-      end.to raise_error
+      end.to raise_error "Programming error!"
     end
   end
 end


### PR DESCRIPTION
The `raise_error` matcher wants to check against a real error message to
avoid false positives. In addition to giving it a parameter, I needed to
fix a false positive (via WebMock) to make this test pass.