### PR TITLE
Use providedLabel in TimeSpan for MAP 3.1

### DIFF
--- a/lib/krikri/map_crosswalk.rb
+++ b/lib/krikri/map_crosswalk.rb
@@ -177,9 +177,8 @@ module Krikri
         return unless source.is_a? DPLA::MAP::TimeSpan
         date = {}
 
-        set_value(date, :displayDate, source.prefLabel, true, &:as_json)
-        set_value(date, :displayDate,
-                  source.providedLabel, true, &:as_json) unless
+        set_value(date, :displayDate, source.providedLabel, true, &:as_json) 
+        set_value(date, :displayDate, source.prefLabel, true, &:as_json) unless
           date.has_key?(:displayDate)
 
         set_value(date, :begin, source.begin, true, &:as_json)

--- a/spec/lib/krikri/map_crosswalk_spec.rb
+++ b/spec/lib/krikri/map_crosswalk_spec.rb
@@ -133,30 +133,33 @@ describe Krikri::MapCrosswalk::CrosswalkHashBuilder do
       context 'with timespan containing prefLabel' do
         before do
           aggregation.sourceResource.first.
-            date.first.providedLabel = providedLabel
+            date.first.providedLabel = nil
+          aggregation.sourceResource.first.
+            date.first.prefLabel = prefLabel
         end
 
-        let(:providedLabel) { '1968' }
+        let(:prefLabel) { '1968' }
 
         it 'has a displayDate' do
           subject.build
 
           expect(subject.hash[:sourceResource][:date].first[:displayDate])
-            .to eq providedLabel
+            .to eq prefLabel
         end
 
-        context 'with prefLabel' do
+        context 'with providedLabel' do
           before do
-            aggregation.sourceResource.first.date.first.prefLabel = prefLabel
+            aggregation.sourceResource.first.date
+              .first.providedLabel = providedLabel
           end
 
-          let(:prefLabel) { '1969' }
+          let(:providedLabel) { '1969' }
 
-          it 'uses prefLabel as displayDate' do
+          it 'uses providedLabel as displayDate' do
             subject.build
 
             expect(subject.hash[:sourceResource][:date].first[:displayDate])
-              .to eq prefLabel
+              .to eq providedLabel
           end
         end
       end


### PR DESCRIPTION
Use providedLabel with preference, falling back on prefLabel if needed.