### PR TITLE
facets for pref and provided labels

### DIFF
--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -52,28 +52,46 @@ module Krikri
       # facet bar
 
       config.add_facet_field 'sourceResource_type_name',
-                             label: 'Type',
+                             label: 'Type (pref)',
+                             limit: 20
+      config.add_facet_field 'sourceResource_type_providedLabel',
+                             label: 'Type (provided)',
                              limit: 20
       config.add_facet_field 'sourceResource_format',
                              label: 'Format',
                              limit: 20
       config.add_facet_field 'sourceResource_language_providedLabel',
-                             label: 'Language',
+                             label: 'Language (provided)',
+                             limit: 20
+      config.add_facet_field 'sourceResource_spatial_name',
+                             label: 'Place (pref)',
                              limit: 20
       config.add_facet_field 'sourceResource_spatial_providedLabel',
-                             label: 'Place',
+                             label: 'Place (provided)',
+                             limit: 20
+      config.add_facet_field 'sourceResource_subject_name',
+                             label: 'Subject (pref)',
                              limit: 20
       config.add_facet_field 'sourceResource_subject_providedLabel',
-                             label: 'Subject',
+                             label: 'Subject (provided)',
                              limit: 20
       config.add_facet_field 'sourceResource_collection_title',
-                             label: 'Collection',
+                             label: 'Collection (pref)',
+                             limit: 20
+      config.add_facet_field 'sourceResource_collection_providedLabel',
+                             label: 'Collection (provided)',
+                             limit: 20
+      config.add_facet_field 'dataProvider_name',
+                             label: 'Data Provider (pref)',
                              limit: 20
       config.add_facet_field 'dataProvider_providedLabel',
-                             label: 'Data Provider',
+                             label: 'Data Provider (provided)',
+                             limit: 20
+      config.add_facet_field 'sourceResource_creator_name',
+                             label: 'Creator (pref)',
                              limit: 20
       config.add_facet_field 'sourceResource_creator_providedLabel',
-                             label: 'Creator',
+                             label: 'Creator (provided)',
                              limit: 20
 
       # Have BL send all facet field names to Solr, which has been the default


### PR DESCRIPTION
For all existing facets in the QA interface that have both `prefLabel` and `providedLabel`, this makes facets for both.  One exception is `language`, which has a `providedLabel` but no `prefLabel` in the solr schema.

For most fields, `name` in the solr schema corresponds with `prefLabel`, so `sourceResource_type_name` is the `prefLabel` for `type`.  The one exception seems to be `collection`, for which `title` corresponds to `prefLabel`.

There are no tests b/c this uses Blacklight functionality.  There are currently no tests in `Krikri` for faceting behavior.  This has been tested locally using sample data.  It addresses [ticket #8501](https://issues.dp.la/issues/8501).