### PR TITLE
Restores `ValueArray` in scoped DSL variables

### DIFF
--- a/lib/krikri/mapping_dsl/child_declaration.rb
+++ b/lib/krikri/mapping_dsl/child_declaration.rb
@@ -84,11 +84,15 @@ module Krikri::MappingDSL
         if each_val
           iter = each_val.respond_to?(:call) ? each_val.call(record) : each_val
           iter.each do |value|
-            map = ::Krikri::Mapping.new(target_class)
+            map = Krikri::Mapping.new(target_class)
 
-            # define as_sym on only this instance
+            # define as_sym to return the node (not the value) for this value, 
+            # only on this instance
             map.define_singleton_method(as_sym) do
-              value.respond_to?(:value) ? value.value : value
+              each_val.dup.select do |v|
+                v = v.value if v.respond_to? :value
+                v == value
+              end
             end
 
             map.instance_eval(&block)
@@ -97,7 +101,7 @@ module Krikri::MappingDSL
         # else, process a single child mapping over a single instance of 
         # `target_class`
         else
-          map = ::Krikri::Mapping.new(target_class)
+          map = Krikri::Mapping.new(target_class)
           map.instance_eval(&block)
           target.send(setter, map.process_record(record))
         end

--- a/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
+++ b/spec/lib/krikri/mapping_dsl/child_declaration_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Krikri::MappingDSL::ChildDeclaration do
   include_context 'mapping dsl'
   it_behaves_like 'a named property'
@@ -28,11 +30,11 @@ describe Krikri::MappingDSL::ChildDeclaration do
 
     let(:opts)         { { :each => record_proxy, :as => :my_val } }
     let(:values)       { [:a, :b, :c] }
-    let(:record_proxy) { double('record proxy') }
+    let(:record_proxy) { values }
 
     before do
       allow(target).to receive(:my_property).and_return(double)
-      allow(record_proxy).to receive(:call).and_return(values)
+      allow(record_proxy).to receive(:call).with(record).and_return(values)
 
       allow(mapping).to receive(:process_record).with(record)
         .and_return(*values)
@@ -44,10 +46,10 @@ describe Krikri::MappingDSL::ChildDeclaration do
     end
 
     it 'defines DSL method for access to individual value in mapping scope' do
-      values.each { |v| allow(target.my_property).to receive(:<<).with(v) }
+      values.each { |v| expect(target.my_property).to receive(:<<).with(v) }
 
       subject.to_proc.call(target, record)
-      expect(mapping.my_val).to eq values.last
+      expect(mapping.my_val).to contain_exactly values.last
     end
   end
 end


### PR DESCRIPTION
"Variables" declared as scoped DSL methods were mistakenly cast to their
`#value` when we want a `ValueArray`. This restores the old behavior and
adds an integration test.

This could still use a significant refactor. There is probably a way to
do this without nested iterations through the values. Additionally,
`RecordProxy#dup` is customized in a way that makes this somewhat
tightly coupled and hard to read.

Fixes https://issues.dp.la/issues/8522.