### PR TITLE
Avoid calling `Registry#get` repeatedly

### DIFF
--- a/lib/krikri/mapper.rb
+++ b/lib/krikri/mapper.rb
@@ -57,10 +57,12 @@ module Krikri
     #
     # @see Mapping
     def map(name, records)
+      mapping = Registry.get(name)
       records = Array(records) unless records.is_a? Enumerable
+
       result = records.map do |rec|
         begin
-          Registry.get(name).process_record(rec)
+          mapping.process_record(rec)
         rescue => e
           Rails.logger.error(e.message)
           nil


### PR DESCRIPTION
There's no need to lookup the mapping in the registry for each record. Just look it up once and hold the mapping in memory.

This is a minor optimization, but it was easy and might make a difference in GC.