### PR TITLE
add more field value reports

### DIFF
--- a/app/models/krikri/field_value_report.rb
+++ b/app/models/krikri/field_value_report.rb
@@ -30,24 +30,37 @@ module Krikri
     ##
     # All of the fields for which a report can be created.
     def self.fields
-      [:dataProvider_providedLabel,
-       :sourceResource_alternative_providedLabel,
+      [:dataProvider_name,
+       :dataProvider_providedLabel,
+       :preview_id,
+       :sourceResource_alternative,
        :sourceResource_collection_title,
+       :sourceResource_contributor_name,
        :sourceResource_contributor_providedLabel,
+       :sourceResource_creator_name,
        :sourceResource_creator_providedLabel,
+       :sourceResource_date_name,
        :sourceResource_date_providedLabel,
        :sourceResource_description,
-       :sourceResource_format,
+       :sourceResource_genre_name,
        :sourceResource_genre_providedLabel,
+       :sourceResource_format,
+       :sourceResource_language_name,
        :sourceResource_language_providedLabel,
+       :sourceResource_publisher_name,
        :sourceResource_publisher_providedLabel,
        :sourceResource_rights,
+       :sourceResource_rightsHolder_name,
        :sourceResource_rightsHolder_providedLabel,
+       :sourceResource_spatial_name,
        :sourceResource_spatial_providedLabel,
+       :sourceResource_subject_name,
        :sourceResource_subject_providedLabel,
+       :sourceResource_temporal_name,
        :sourceResource_temporal_providedLabel,
        :sourceResource_title,
-       :sourceResource_type_name]
+       :sourceResource_type_name,
+       :sourceResource_type_providedLabel]
     end
 
     ##

--- a/spec/models/field_value_report_spec.rb
+++ b/spec/models/field_value_report_spec.rb
@@ -10,7 +10,7 @@ describe Krikri::FieldValueReport do
 
   let(:agg) do
     p = DPLA::MAP::Agent.new(RDF::URI(provider_base) / provider_id)
-    build(:aggregation, :provider => p)
+    build(:aggregation, provider: p)
   end
 
   shared_context 'item indexed in Solr' do
@@ -68,8 +68,7 @@ describe Krikri::FieldValueReport do
     end
 
     it 'returns "__MISSING__" for field without value' do
-      r = described_class.find('sourceResource_alternative_providedLabel',
-                               provider_id)
+      r = described_class.find('sourceResource_date_name', provider_id)
       expect(r.enumerate_rows.first).to include('__MISSING__')
     end
 


### PR DESCRIPTION
This adds more fields for generating field value reports.
It also corrects the key name for `sourceResource_alternative`.

This has been tested locally.  It addresses [ticket #8205](https://issues.dp.la/issues/8502).
