### PR TITLE
add gallery view for search results

### DIFF
--- a/app/controllers/krikri/records_controller.rb
+++ b/app/controllers/krikri/records_controller.rb
@@ -140,6 +140,8 @@ module Krikri
       config.show.route = { controller: 'records' }
 
       config.solr_document_model = Krikri::SearchIndexDocument
+
+      config.view.gallery.partials = []
     end
 
     private

--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "yajl-ruby"
   s.add_dependency "elasticsearch", "~>0.4.0"
   s.add_dependency "nokogiri", ">=1.6.8"
+  s.add_dependency "blacklight-gallery", "0.3.0"
 
   ##
   # FIXME on Rails 4.2 upgrade: pin bootstrap-sass to 3.3.4.1

--- a/lib/generators/krikri/install_generator.rb
+++ b/lib/generators/krikri/install_generator.rb
@@ -45,6 +45,7 @@ module Krikri
 
     def run_required_generators
       generate "blacklight:install"
+      generate "blacklight_gallery:install"
     end
 
     ##

--- a/lib/krikri.rb
+++ b/lib/krikri.rb
@@ -4,6 +4,7 @@
 require 'rails'
 require 'devise'
 require 'blacklight'
+require 'blacklight/gallery'
 require 'audumbla'
 require 'krikri/engine'
 


### PR DESCRIPTION
This adds a gallery view for search results, using the blacklight-gallery gem.

Since we are still using blacklight 5, the most recent version of blacklight-gallery we can use is 0.3.0.  Unfortunately, blacklight-gallery 0.3.0 fails with ruby 2.3.0, so we have to allow failure for ruby 2.3.0 until we can upgrade our dependencies.  [Ticket 8534](https://issues.dp.la/issues/8534) addresses this issue.

As requested by GG, the gallery view only shows the image - no additional metadata is displayed.

This has been tested locally.  It addresses [ticket #8504](https://issues.dp.la/issues/8504).