### PR TITLE
allow failure for ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ addons:
     repo_token: 9b8c58a49bdfba5582d6a766fbe198e3720158e5e65c2ae00b1667e5e1bb8769
 env: CI=yes
 before_install: 'gem install bundler -v "~> 1.11.0"'
+matrix:
+  allow_failures:
+    - rvm: 2.3.0


### PR DESCRIPTION
Allow failure for ruby 2.3.0.  This is a prerequisite for adding the blacklight-gallery gem with our current dependencies.  See https://github.com/dpla/KriKri/pull/263