### PR TITLE
pin gems to minor versions

### DIFF
--- a/krikri.gemspec
+++ b/krikri.gemspec
@@ -23,25 +23,25 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.1.6"
-  s.add_dependency "rails_config", "~>0.4.0"
-  s.add_dependency "audumbla", '~> 0.1'
+  s.add_dependency "rails_config", "~> 0.4.0"
+  s.add_dependency "audumbla", "~> 0.2"
   s.add_dependency "rdf-turtle", "~>1.1.8"
   s.add_dependency "rdf", "~> 1.1.13"
   s.add_dependency "dpla-map", "4.0.0.0.pre.13"
-  s.add_dependency "rest-client"
-  s.add_dependency "rdf-marmotta", '>= 0.0.6'
-  s.add_dependency "blacklight", "~>5.8.0"
-  s.add_dependency "therubyracer"
+  s.add_dependency "rest-client", "~> 2.0"
+  s.add_dependency "rdf-marmotta", "~> 0.0.6"
+  s.add_dependency "blacklight", "~> 5.8.0"
+  s.add_dependency "therubyracer", "~> 0.12"
   s.add_dependency "edtf", '~> 3.0'
-  s.add_dependency "text"
-  s.add_dependency "oai", '~>0.4.0'
-  s.add_dependency "jsonpath"
-  s.add_dependency "devise", "~>3.4.1"
-  s.add_dependency "resque", "~>1.0"
+  s.add_dependency "text", "~> 1.3"
+  s.add_dependency "oai", '~> 0.4.0'
+  s.add_dependency "jsonpath", '~> 0.5'
+  s.add_dependency "devise", "~> 3.4.1"
+  s.add_dependency "resque", "~> 1.26"
   s.add_dependency "analysand", "4.0.0"
-  s.add_dependency "yajl-ruby"
-  s.add_dependency "elasticsearch", "~>0.4.0"
-  s.add_dependency "nokogiri", ">=1.6.8"
+  s.add_dependency "yajl-ruby", "1.2"
+  s.add_dependency "elasticsearch", "~> 0.4.0"
+  s.add_dependency "nokogiri", "~> 1.6.8"
   s.add_dependency "blacklight-gallery", "0.3.0"
 
   ##
@@ -59,12 +59,12 @@ Gem::Specification.new do |s|
   s.add_dependency "sass-rails", "~> 4.0.5"
   s.add_dependency "bootstrap-sass", "3.3.4.1"
 
-  s.add_development_dependency 'krikri-spec', '~> 0.0'
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "jettywrapper", '~> 2.0'
-  s.add_development_dependency "rspec-rails", '~> 3.3'
-  s.add_development_dependency 'webmock'
-  s.add_development_dependency 'factory_girl_rails', '~>4.4.0'
-  s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'timecop'
+  s.add_development_dependency "krikri-spec", "~> 0.0.1"
+  s.add_development_dependency "sqlite3", "~> 1.3"
+  s.add_development_dependency "jettywrapper", "~> 2.0"
+  s.add_development_dependency "rspec-rails", "~> 3.4"
+  s.add_development_dependency "webmock", "~> 2.1"
+  s.add_development_dependency "factory_girl_rails", "~> 4.4.0"
+  s.add_development_dependency "pry-rails", "~> 0.3"
+  s.add_development_dependency "timecop", "~> 0.8"
 end


### PR DESCRIPTION
Pin gems to tiny versions currently running in heidrun production.

This addresses (in part) [ticket #8538](https://issues.dp.la/issues/8538).