### PR TITLE
DSL method for accessing field names

### DIFF
--- a/lib/krikri/parser.rb
+++ b/lib/krikri/parser.rb
@@ -301,6 +301,19 @@ module Krikri
       end
 
       ##
+      # Lists field names on this node.
+      #
+      # This can be useful in cases where the desired value is a key or child 
+      # node label, rather than a value.
+      #
+      # @return [ValueArray] an array containing the field names.
+      #
+      # @see #select_child, #reject_child for methods that filter on these names
+      def field_names
+        self.class.new(flat_map(&:children).uniq, bindings)
+      end
+
+      ##
       # Sets the top of the call chain to self and returns or yields self.
       #
       # This is syntactic sugar for `#bind(:top)`, with the addition of block 

--- a/spec/lib/krikri/mapper_spec.rb
+++ b/spec/lib/krikri/mapper_spec.rb
@@ -25,6 +25,12 @@ describe Krikri::Mapper do
             providedLabel ident
           end
 
+          relation :class => DPLA::MAP::Agent,
+                   :each => record.field_names,
+                   :as => :rel do
+            providedLabel rel
+          end
+
           spatial :class => DPLA::MAP::Place,
                   :each => %w('nyc bos pdx'),
                   :as => :place do
@@ -61,6 +67,9 @@ describe Krikri::Mapper do
       expect(mapped.sourceResource.first
               .contributor.map(&:providedLabel).flatten)
         .to eq record.root['dc:creator'].to_a.map(&:value)
+
+      expect(mapped.sourceResource.first.relation.map(&:providedLabel).flatten)
+        .to contain_exactly(*record.root.children.uniq)
 
       expect(mapped.sourceResource.first.spatial.map(&:providedLabel).flatten)
         .to eq %w('nyc bos pdx')

--- a/spec/lib/krikri/parser_value_array_spec.rb
+++ b/spec/lib/krikri/parser_value_array_spec.rb
@@ -254,6 +254,22 @@ describe Krikri::Parser::ValueArray do
     end
   end
 
+  describe '#field_names' do
+    include_context 'with fields'
+
+    let(:child_nodes) { ['first:child', 'second:child']}
+    
+    before do
+      values.each do |val| 
+        allow(val).to receive(:children).and_return(child_nodes)
+      end
+    end
+    
+    it 'contains immediate child node field names' do
+      expect(subject.field_names).to contain_exactly(*child_nodes)
+    end
+  end
+
   describe '#first_value' do
     it 'returns a single item ValueArray without an arguments' do
       expect(subject.first_value).to contain_exactly values[0]


### PR DESCRIPTION
The new `#field_names` method returns a value array with the available field names (labels of child nodes) for the current node. This supports cases like `{'language' => { 'english' => 'some value', 'french' => 'some other value' }` with `.language.field_names` giving the keys.