### PR TITLE
Remove existing Bundler 1.13.0 installs on Travis (fixes #8556)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ addons:
   code_climate:
     repo_token: 9b8c58a49bdfba5582d6a766fbe198e3720158e5e65c2ae00b1667e5e1bb8769
 env: CI=yes
-before_install: 'gem install bundler -v "~> 1.11.0"'
+before_install:
+  # TODO: fix https://issues.dp.la/issues/8556
+  # Workaround modified from https://github.com/cbeer/engine_cart/issues/64
+  - if [ $TRAVIS_RUBY_VERSION != "2.1.3" ]; then gem uninstall -i "/home/travis/.rvm/gems/ruby-$TRAVIS_RUBY_VERSION@global" bundler -v 1.13.0; fi
+  - gem install bundler -v "~> 1.11.0"
 matrix:
   allow_failures:
     - rvm: 2.1.6


### PR DESCRIPTION
Dependency resolution in Bundler 1.13 breaks when using engine_cart, which we use
in Krikri to build a test application for the engine. The changes to the Travis
build are modified from the workaround specified in cbeer/engine_cart#64, but
the better long term fix would be to upgrade engine_cart to v1.0.1 (see #8557),
and to ensure Krikri works with the latest Bundler.