### PR TITLE
Add mapping for "online text" to DCMI map

### DIFF
--- a/lib/krikri/enrichments/dcmi_type_map.rb
+++ b/lib/krikri/enrichments/dcmi_type_map.rb
@@ -60,6 +60,7 @@ module Krikri::Enrichments
                     'writing' => RDF::DCMITYPE.Text,
                     'written' => RDF::DCMITYPE.Text,
                     'manuscript' => RDF::DCMITYPE.Text,
+                    'electronic text' => RDF::DCMITYPE.Text,
                     'audio' => RDF::DCMITYPE.Sound,
                     'sound' => RDF::DCMITYPE.Sound,
                     'oral history recording' => RDF::DCMITYPE.Sound,


### PR DESCRIPTION
Addresses issue #4 in this ticket https://issues.dp.la/issues/8549#note-3